### PR TITLE
Revert "Show more useful error message on 500 errors"

### DIFF
--- a/octopusdeploy/octopusdeploy.go
+++ b/octopusdeploy/octopusdeploy.go
@@ -101,10 +101,6 @@ func APIErrorChecker(urlPath string, resp *http.Response, wantedResponseCode int
 		return fmt.Errorf("octopus deploy api returned an error on endpoint %s - %s", urlPath, octopusDeployError.Errors)
 	}
 
-	if octopusDeployError.ErrorMessage != "" {
-		return fmt.Errorf("octopus deploy api returned an error on endpoint %s - %s", urlPath, octopusDeployError.ErrorMessage)
-	}
-
 	if slingError != nil {
 		return fmt.Errorf("cannot get endpoint %s from server. failure from http client %v", urlPath, slingError)
 	}


### PR DESCRIPTION
This caused all the tests to fail in the terraform-provider. Need to revisit this after looking into the tests and updating them.
Reverts OctopusDeploy/go-octopusdeploy#20