### PR TITLE
Add basic tenant client

### DIFF
--- a/octopusdeploy/octopusdeploy.go
+++ b/octopusdeploy/octopusdeploy.go
@@ -28,6 +28,7 @@ type Client struct {
 	LibraryVariableSet *LibraryVariableSetService
 	Interruption       *InterruptionsService
 	TagSet             *TagSetService
+	Tenant             *TenantService
 	Space              *SpaceService
 	Channel            *ChannelService
 }
@@ -54,6 +55,7 @@ func NewClient(httpClient *http.Client, octopusURL, octopusAPIKey string) *Clien
 		LibraryVariableSet: NewLibraryVariableSetService(base.New()),
 		Interruption:       NewInterruptionService(base.New()),
 		TagSet:             NewTagSetService(base.New()),
+		Tenant:             NewTenantService(base.New()),
 		Space:              NewSpaceService(base.New()),
 		Channel:            NewChannelService(base.New()),
 	}
@@ -79,6 +81,7 @@ func ForSpace(httpClient *http.Client, octopusURL, octopusAPIKey string, space *
 		Lifecycle:          NewLifecycleService(base.New()),
 		LibraryVariableSet: NewLibraryVariableSetService(base.New()),
 		TagSet:             NewTagSetService(base.New()),
+		Tenant:             NewTenantService(base.New()),
 		Channel:            NewChannelService(base.New()),
 	}
 }

--- a/octopusdeploy/tenant.go
+++ b/octopusdeploy/tenant.go
@@ -1,0 +1,124 @@
+package octopusdeploy
+
+import (
+	"fmt"
+	"github.com/dghubble/sling"
+	"time"
+)
+
+type TenantService struct {
+	sling *sling.Sling
+}
+
+func NewTenantService(sling *sling.Sling) *TenantService {
+	return &TenantService{
+		sling: sling,
+	}
+}
+
+type Tenants struct {
+	Items []Tenant `json:"Items"`
+	PagedResults
+}
+
+type Tenant struct {
+	ID                  string              `json:"Id"`
+	Name                string              `json:"Name"`
+	TenantTags          []string            `json:"TenantTags"`
+	ProjectEnvironments map[string][]string `json:"ProjectEnvironments"`
+	SpaceID             string              `json:"SpaceId"`
+	ClonedFromTenantID  string              `json:"ClonedFromTenantId"`
+	Description         string              `json:"Description"`
+	LastModifiedOn      time.Time           `json:"LastModifiedOn"`
+	LastModifiedBy      string              `json:"LastModifiedBy"`
+	Links               map[string]string   `json:"Links"`
+}
+
+func NewTenant(name, description string) *Tenant {
+	return &Tenant{
+		Name:        name,
+		Description: description,
+	}
+}
+
+func ValidateTenantValues(tenant *Tenant) error {
+	return ValidateMultipleProperties([]error{
+		ValidateRequiredPropertyValue("Name", tenant.Name),
+	})
+}
+
+func (s *TenantService) Get(tenantId string) (*Tenant, error) {
+	path := fmt.Sprintf("tenants/%s", tenantId)
+	resp, err := apiGet(s.sling, new(Tenant), path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*Tenant), nil
+}
+
+func (s *TenantService) GetAll() ([]Tenant, error) {
+	var t []Tenant
+
+	path := "tenants"
+
+	loadNextPage := true
+	for loadNextPage {
+		resp, err := apiGet(s.sling, new(Tenants), path)
+
+		if err != nil {
+			return nil, err
+		}
+
+		r := resp.(*Tenants)
+
+		t = append(t, r.Items...)
+
+		path, loadNextPage = LoadNextPage(r.PagedResults)
+	}
+
+	return t, nil
+}
+
+func (s *TenantService) Add(tenant *Tenant) (*Tenant, error) {
+	err := ValidateTenantValues(tenant)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := apiAdd(s.sling, tenant, new(Tenant), "tenants")
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*Tenant), nil
+}
+
+func (s *TenantService) Delete(tenantId string) error {
+	path := fmt.Sprintf("tenants/%s", tenantId)
+	err := apiDelete(s.sling, path)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *TenantService) Update(tenant *Tenant) (*Tenant, error) {
+	err := ValidateTenantValues(tenant)
+	if err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("tenants/%s", tenant.ID)
+	resp, err := apiUpdate(s.sling, tenant, new(Tenant), path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*Tenant), nil
+}


### PR DESCRIPTION
I have followed the pattern from projects.go.

There is however one things i'm slightly currious about: How should tenant variables be handled? It seems to be one big blob that Octopus expects, however the blob is independent in the Octopus api from the tenant resource. 

What i would suggest doing:
Make the variables "sub-resource" be a part of the tenant resource itself, and then we will need to do partial updates to make everything consistent in Terraform? That of-cause means that things in this client library could still be independent. 

This closes #23.