### PR TITLE
feat: Add scoped user role support

### DIFF
--- a/octopusdeploy/constants_parameters.go
+++ b/octopusdeploy/constants_parameters.go
@@ -31,6 +31,7 @@ const (
 	ParameterReplacementCertificate string = "replacementCertificate"
 	ParameterResource               string = "resource"
 	ParameterRunbook                string = "runbook"
+	ParameterScopedUserRole         string = "scopedUserRole"
 	ParameterSecretKey              string = "secretKey"
 	ParameterSling                  string = "sling"
 	ParameterTagSet                 string = "tagSet"

--- a/octopusdeploy/scoped_user_role.go
+++ b/octopusdeploy/scoped_user_role.go
@@ -1,0 +1,18 @@
+package octopusdeploy
+
+type ScopedUserRole struct {
+	EnvironmentIDs  []string `json:"EnvironmentIds,omitempty"`
+	ProjectIDs      []string `json:"ProjectIds,omitempty"`
+	ProjectGroupIDs []string `json:"ProjectGroupIds,omitempty"`
+	TeamID          string   `json:"TeamId"`
+	TenantIDs       []string `json:"TenantIds,omitempty"`
+	SpaceID         string   `json:"SpaceId"`
+	UserRoleID      string   `json:"UserRoleId"`
+
+	resource
+}
+
+type ScopedUserRoles struct {
+	Items []*ScopedUserRole `json:"Items"`
+	PagedResults
+}

--- a/octopusdeploy/scoped_user_role_service.go
+++ b/octopusdeploy/scoped_user_role_service.go
@@ -12,3 +12,62 @@ func newScopedUserRoleService(sling *sling.Sling, uriTemplate string) *scopedUse
 
 	return scopedUserRoleService
 }
+
+func (s scopedUserRoleService) Add(scopedUserRole *ScopedUserRole) (*ScopedUserRole, error) {
+	if scopedUserRole == nil {
+		return nil, createInvalidParameterError(OperationAdd, ParameterScopedUserRole)
+	}
+
+	path, err := getAddPath(s, scopedUserRole)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := apiAdd(s.getClient(), scopedUserRole, new(ScopedUserRole), path)
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*ScopedUserRole), nil
+}
+
+// Currently no known query params, not even take and skip
+// Query params could exist, but are undocumented in the swagger
+func (s scopedUserRoleService) Get() (*ScopedUserRoles, error) {
+	path := s.BasePath
+
+	resp, err := apiGet(s.getClient(), new(ScopedUserRoles), path)
+	if err != nil {
+		return &ScopedUserRoles{}, err
+	}
+	return resp.(*ScopedUserRoles), nil
+}
+
+func (s scopedUserRoleService) GetByID(id string) (*ScopedUserRole, error) {
+	path, err := getByIDPath(s, id)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := apiGet(s.getClient(), new(ScopedUserRole), path)
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*ScopedUserRole), nil
+}
+
+func (s scopedUserRoleService) Update(scopedUserRole *ScopedUserRole) (*ScopedUserRole, error) {
+	if scopedUserRole == nil {
+		return nil, createInvalidParameterError(OperationUpdate, ParameterScopedUserRole)
+	}
+
+	path, err := getUpdatePath(s, scopedUserRole)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := apiUpdate(s.getClient(), scopedUserRole, new(ScopedUserRole), path)
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*ScopedUserRole), nil
+}

--- a/octopusdeploy/scoped_user_role_service_test.go
+++ b/octopusdeploy/scoped_user_role_service_test.go
@@ -1,0 +1,53 @@
+package octopusdeploy
+
+import (
+	"testing"
+
+	"github.com/dghubble/sling"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createScopedUserRoleService(t *testing.T) *scopedUserRoleService {
+	service := newScopedUserRoleService(nil, TestURIScopedUserRoles)
+	testNewService(t, service, TestURIScopedUserRoles, ServiceScopedUserRoleService)
+	return service
+}
+
+func TestScopedUserRoleServiceAddGetDelete(t *testing.T) {
+	scopedUserRoleService := createScopedUserRoleService(t)
+	require.NotNil(t, scopedUserRoleService)
+
+	resource, err := scopedUserRoleService.Add(nil)
+	assert.Equal(t, err, createInvalidParameterError(OperationAdd, ParameterScopedUserRole))
+	assert.Nil(t, resource)
+
+	invalidResource := &ScopedUserRole{}
+	resource, err = scopedUserRoleService.Add(invalidResource)
+	assert.Equal(t, createValidationFailureError(OperationAdd, invalidResource.Validate()), err)
+	assert.Nil(t, resource)
+}
+
+func TestScopedUserRoleServiceNew(t *testing.T) {
+	ServiceFunction := newScopedUserRoleService
+	client := &sling.Sling{}
+	uriTemplate := emptyString
+	ServiceName := ServiceScopedUserRoleService
+
+	testCases := []struct {
+		name        string
+		f           func(*sling.Sling, string) *scopedUserRoleService
+		client      *sling.Sling
+		uriTemplate string
+	}{
+		{"NilClient", ServiceFunction, nil, uriTemplate},
+		{"EmptyURITemplate", ServiceFunction, client, emptyString},
+		{"URITemplateWithWhitespace", ServiceFunction, client, whitespaceString},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			service := tc.f(tc.client, tc.uriTemplate)
+			testNewService(t, service, uriTemplate, ServiceName)
+		})
+	}
+}


### PR DESCRIPTION
This adds support for scoped user role 

Implementation is based off of the documentation available in the swagger docs.

Supported:
 - Get
 - GetById
 - Add
 - Update
 - Delete

Get appears to have limited functionality based on the swagger document and doesn't support any query parameters, so I just left it without a query struct.