### PR TITLE
Scoped User Role Improvements

### DIFF
--- a/octopusdeploy/scoped_user_role.go
+++ b/octopusdeploy/scoped_user_role.go
@@ -16,3 +16,10 @@ type ScopedUserRoles struct {
 	Items []*ScopedUserRole `json:"Items"`
 	PagedResults
 }
+
+func NewScopedUserRole(userRoleId string) *ScopedUserRole {
+	return &ScopedUserRole{
+		UserRoleID: userRoleId,
+		resource:   *newResource(),
+	}
+}

--- a/octopusdeploy/team_service.go
+++ b/octopusdeploy/team_service.go
@@ -122,16 +122,30 @@ func (s teamService) GetByPartialName(name string) ([]*Team, error) {
 }
 
 // Update modifies a team based on the one provided as input.
-func (s teamService) Update(machinePolicy *Team) (*Team, error) {
-	path, err := getUpdatePath(s, machinePolicy)
+func (s teamService) Update(team *Team) (*Team, error) {
+	path, err := getUpdatePath(s, team)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := apiUpdate(s.getClient(), machinePolicy, new(Team), path)
+	resp, err := apiUpdate(s.getClient(), team, new(Team), path)
 	if err != nil {
 		return nil, err
 	}
 
 	return resp.(*Team), nil
+}
+
+func (s teamService) GetScopedUserRolesByID(id string) (*ScopedUserRoles, error) {
+	path, err := getByIDPath(s, id)
+	if err != nil {
+		return nil, err
+	}
+	path += "/scopeduserroles"
+
+	resp, err := apiGet(s.getClient(), new(ScopedUserRoles), path)
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*ScopedUserRoles), nil
 }


### PR DESCRIPTION
Adds the constructor for new ScopeUserRole structs require for the terraform provider resource.

Adds `GetScopedUserRoles` function to the team service to allow for retrieval of the scoped user roles associated with the team.