### PR TITLE
chore: removed redundant setting of user-agent

### DIFF
--- a/pkg/client/octopusdeploy.go
+++ b/pkg/client/octopusdeploy.go
@@ -209,8 +209,13 @@ func NewClientForTool(httpClient *http.Client, apiURL *url.URL, apiKey string, s
 
 	if !internal.IsEmpty(spaceID) {
 		baseURLWithAPI = fmt.Sprintf("%s/%s", baseURLWithAPI, spaceID)
-		base = sling.New().Client(httpClient).Base(baseURLWithAPI).Set(constants.ClientAPIKeyHTTPHeader, apiKey)
-		base.Set("User-Agent", api.GetUserAgentString(requestingTool))
+		base = sling.
+			New().
+			Client(httpClient).
+			Base(baseURLWithAPI).
+			Set(constants.ClientAPIKeyHTTPHeader, apiKey).
+			Set("Accept", `application/json`).
+			Set("User-Agent", api.GetUserAgentString(requestingTool))
 		rootService = NewRootService(base, baseURLWithAPI)
 		sroot, err = rootService.Get()
 

--- a/pkg/client/octopusdeploy.go
+++ b/pkg/client/octopusdeploy.go
@@ -195,29 +195,16 @@ func NewClientForTool(httpClient *http.Client, apiURL *url.URL, apiKey string, s
 	}
 
 	// fetch root resource and process paths
-	base := sling.New().Client(httpClient).Base(baseURLWithAPI).Set(constants.ClientAPIKeyHTTPHeader, apiKey)
-	base.Set("User-Agent", api.GetUserAgentString(requestingTool))
-	rootService := NewRootService(base, baseURLWithAPI)
-
-	root, err := rootService.Get()
+	base, root, err := getRoot(httpClient, baseURLWithAPI, apiKey, requestingTool)
 	if err != nil {
 		return nil, err
 	}
 
 	// Root with specified Space ID, if it's defined
 	sroot := NewRootResource()
-
 	if !internal.IsEmpty(spaceID) {
 		baseURLWithAPI = fmt.Sprintf("%s/%s", baseURLWithAPI, spaceID)
-		base = sling.
-			New().
-			Client(httpClient).
-			Base(baseURLWithAPI).
-			Set(constants.ClientAPIKeyHTTPHeader, apiKey).
-			Set("Accept", `application/json`).
-			Set("User-Agent", api.GetUserAgentString(requestingTool))
-		rootService = NewRootService(base, baseURLWithAPI)
-		sroot, err = rootService.Get()
+		base, sroot, err = getRoot(httpClient, baseURLWithAPI, apiKey, requestingTool)
 
 		if err != nil {
 			if err == services.ErrItemNotFound {
@@ -471,6 +458,20 @@ func NewClientForTool(httpClient *http.Client, apiURL *url.URL, apiKey string, s
 
 		uriTemplateCache: uritemplates.NewUriTemplateCache(),
 	}, nil
+}
+
+func getRoot(httpClient *http.Client, baseURLWithAPI string, apiKey string, requestingTool string) (*sling.Sling, *RootResource, error) {
+	base := sling.
+		New().
+		Client(httpClient).
+		Base(baseURLWithAPI).
+		Set(constants.ClientAPIKeyHTTPHeader, apiKey).
+		Set("User-Agent", api.GetUserAgentString(requestingTool)).
+		Set("Accept", `application/json`)
+	rootService := NewRootService(base, baseURLWithAPI)
+
+	root, err := rootService.Get()
+	return base, root, err
 }
 
 // confirm to newclient.Client interface for compatibility

--- a/pkg/newclient/httpsession.go
+++ b/pkg/newclient/httpsession.go
@@ -122,7 +122,7 @@ func DoRequest[TResponse any](httpSession *HttpSession, method string, path stri
 		return nil, err
 	}
 
-	// erroPayload is never nil because we allocated it just above
+	// errorPayload is never nil because we allocated it just above
 	if errorPayload.StatusCode != 0 {
 		return nil, errorPayload
 	}

--- a/pkg/services/api/api.go
+++ b/pkg/services/api/api.go
@@ -33,8 +33,6 @@ func ApiGet(sling *sling.Sling, inputStruct interface{}, path string) (interface
 		return nil, internal.CreateClientInitializationError(constants.OperationAPIGet)
 	}
 
-	client.Set("User-Agent", UserAgentString)
-
 	octopusDeployError := new(core.APIError)
 	resp, err := client.Receive(inputStruct, &octopusDeployError)
 	// if err != nil {

--- a/pkg/services/service.go
+++ b/pkg/services/service.go
@@ -274,8 +274,6 @@ func ApiAdd(sling *sling.Sling, inputStruct interface{}, resource interface{}, p
 		return nil, internal.CreateClientInitializationError(constants.OperationAPIAdd)
 	}
 
-	client.Set("Accept", `application/json`)
-
 	request := client.BodyJSON(inputStruct)
 	if request == nil {
 		return nil, internal.CreateClientInitializationError(constants.OperationAPIAdd)

--- a/pkg/services/service.go
+++ b/pkg/services/service.go
@@ -275,7 +275,6 @@ func ApiAdd(sling *sling.Sling, inputStruct interface{}, resource interface{}, p
 	}
 
 	client.Set("Accept", `application/json`)
-	client.Set("User-Agent", api.UserAgentString)
 
 	request := client.BodyJSON(inputStruct)
 	if request == nil {
@@ -317,8 +316,6 @@ func ApiAddWithResponseStatus(sling *sling.Sling, inputStruct interface{}, resou
 		return nil, internal.CreateClientInitializationError(constants.OperationApiAddWithResponseStatus)
 	}
 
-	client.Set("User-Agent", api.UserAgentString)
-
 	request := client.BodyJSON(inputStruct)
 	if request == nil {
 		return nil, internal.CreateClientInitializationError(constants.OperationApiAddWithResponseStatus)
@@ -353,8 +350,6 @@ func ApiPost(sling *sling.Sling, inputStruct interface{}, resource interface{}, 
 	if client == nil {
 		return nil, internal.CreateClientInitializationError(constants.OperationAPIPost)
 	}
-
-	client.Set("User-Agent", api.UserAgentString)
 
 	request := client.BodyJSON(inputStruct)
 	if request == nil {
@@ -399,7 +394,10 @@ func ApiPostNew[TResponse any](httpClient *http.Client, absoluteUrl *url.URL, ap
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	req.Header.Set("User-Agent", api.UserAgentString)
+	if req.Header.Get("User-Agent") == "" {
+		req.Header.Set("User-Agent", api.UserAgentString)
+	}
+
 	req.Header.Set(constants.ClientAPIKeyHTTPHeader, apiKey)
 	return doRequestReturningJson[TResponse](httpClient, req)
 }
@@ -470,8 +468,6 @@ func ApiUpdate(sling *sling.Sling, inputStruct interface{}, resource interface{}
 		return nil, internal.CreateClientInitializationError(constants.OperationAPIUpdate)
 	}
 
-	client.Set("User-Agent", api.UserAgentString)
-
 	request := client.BodyJSON(inputStruct)
 	if request == nil {
 		return nil, internal.CreateClientInitializationError(constants.OperationAPIUpdate)
@@ -506,8 +502,6 @@ func ApiDelete(sling *sling.Sling, path string) error {
 	if client == nil {
 		return internal.CreateClientInitializationError(constants.OperationAPIDelete)
 	}
-
-	client.Set("User-Agent", api.UserAgentString)
 
 	octopusDeployError := new(core.APIError)
 	resp, err := client.Receive(nil, &octopusDeployError)


### PR DESCRIPTION
[sc-31593]

The user-agent string generated at the creation of the client was being overwritten with the default value on each http request.