### PR TITLE
fix: feeds service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/kinbiko/jsonassert v1.1.1
 	github.com/stretchr/testify v1.8.1
-	golang.org/x/text v0.4.0
+	golang.org/x/text v0.5.0
 )
 
 require (
@@ -22,6 +22,6 @@ require (
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/crypto v0.3.0 // indirect
-	golang.org/x/sys v0.2.0 // indirect
+	golang.org/x/sys v0.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -57,13 +57,13 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
-golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
+golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
-golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
-golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+golang.org/x/text v0.5.0 h1:OLmvp0KP+FVG99Ct/qFiL/Fhk4zp4QQnZ7b2U+5piUM=
+golang.org/x/text v0.5.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/feeds/feed_service.go
+++ b/pkg/feeds/feed_service.go
@@ -37,17 +37,12 @@ func (s *FeedService) Add(feed IFeed) (IFeed, error) {
 		return nil, internal.CreateInvalidParameterError(constants.OperationAdd, constants.ParameterFeed)
 	}
 
-	feedResource, err := ToFeedResource(feed)
+	response, err := services.ApiAdd(s.GetClient(), feed, feed, s.BasePath)
 	if err != nil {
 		return nil, err
 	}
 
-	response, err := services.ApiAdd(s.GetClient(), feedResource, new(FeedResource), s.BasePath)
-	if err != nil {
-		return nil, err
-	}
-
-	return ToFeed(response.(*FeedResource))
+	return response.(IFeed), nil
 }
 
 // Get returns a collection of feeds based on the criteria defined by its
@@ -195,12 +190,7 @@ func (s *FeedService) Update(feed IFeed) (IFeed, error) {
 		return nil, err
 	}
 
-	feedResource, err := ToFeedResource(feed)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := services.ApiUpdate(s.GetClient(), feedResource, new(FeedResource), path)
+	resp, err := services.ApiUpdate(s.GetClient(), feed, feed, path)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/feed_service_test.go
+++ b/test/e2e/feed_service_test.go
@@ -172,22 +172,25 @@ func TestFeedServiceCRUD(t *testing.T) {
 	client := getOctopusClient()
 	require.NotNil(t, client)
 
-	expected := CreateTestGitHubRepositoryFeed(t, client)
-	require.NotNil(t, expected)
-	defer DeleteTestFeed(t, client, expected)
+	gitHubRepositoryFeed := CreateTestGitHubRepositoryFeed(t, client).(*feeds.GitHubRepositoryFeed)
+	require.NotNil(t, gitHubRepositoryFeed)
+	defer DeleteTestFeed(t, client, gitHubRepositoryFeed)
 
-	actual, err := client.Feeds.GetByID(expected.GetID())
+	actual, err := client.Feeds.GetByID(gitHubRepositoryFeed.GetID())
 	require.NoError(t, err)
-	AssertEqualFeeds(t, expected, actual)
+	AssertEqualFeeds(t, gitHubRepositoryFeed, actual)
 
 	name := internal.GetRandomName()
-	expected.SetName(name)
+	gitHubRepositoryFeed.SetName(name)
 
-	actual, err = client.Feeds.Update(expected)
+	actual, err = client.Feeds.Update(gitHubRepositoryFeed)
 	require.NoError(t, err)
-	AssertEqualFeeds(t, expected, actual)
+	AssertEqualFeeds(t, gitHubRepositoryFeed, actual)
 
-	expected = CreateTestHelmFeed(t, client)
+	gitHubRepositoryFeed = actual.(*feeds.GitHubRepositoryFeed)
+	require.NotNil(t, gitHubRepositoryFeed)
+
+	expected := CreateTestHelmFeed(t, client)
 	require.NotNil(t, expected)
 	defer DeleteTestFeed(t, client, expected)
 


### PR DESCRIPTION
Relates to [Updating a helm feed crashes #447](https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/447)