### PR TITLE
fix: generated uri can be incorrect for Project Query

### DIFF
--- a/pkg/projects/projects_query.go
+++ b/pkg/projects/projects_query.go
@@ -1,7 +1,7 @@
 package projects
 
 type ProjectsQuery struct {
-	ClonedFromProjectID string   `url:"clonedFromProjectId"`
+	ClonedFromProjectID string   `uri:"clonedFromProjectId,omitempty" url:"clonedFromProjectId,omitempty"`
 	IDs                 []string `uri:"ids,omitempty" url:"ids,omitempty"`
 	IsClone             bool     `uri:"clone,omitempty" url:"clone,omitempty"`
 	Name                string   `uri:"name,omitempty" url:"name,omitempty"`


### PR DESCRIPTION
before:
`/api/Spaces-1/projects?clonedFromProjectId=&partialName=schedule+script`

![image](https://user-images.githubusercontent.com/5336529/206335867-40cf0226-0455-4004-9106-87efe2126094.png)


after:
`api/Spaces-1/projects?partialName=schedule+script`

![image](https://user-images.githubusercontent.com/5336529/206336024-86cd0861-605d-42b0-9555-050165531748.png)
