### PR TITLE
fix: feed update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
-	github.com/dghubble/sling v1.4.0
+	github.com/dghubble/sling v1.4.1
 	github.com/go-playground/assert/v2 v2.2.0
 	github.com/go-playground/validator/v10 v10.11.1
 	github.com/google/go-querystring v1.1.0
@@ -21,7 +21,7 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/crypto v0.3.0 // indirect
+	golang.org/x/crypto v0.4.0 // indirect
 	golang.org/x/sys v0.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dghubble/sling v1.4.0 h1:/n8MRosVTthvMbwlNZgLx579OGVjUOy3GNEv5BIqAWY=
-github.com/dghubble/sling v1.4.0/go.mod h1:0r40aNsU9EdDUVBNhfCstAtFgutjgJGYbO1oNzkMoM8=
+github.com/dghubble/sling v1.4.1 h1:AxjTubpVyozMvbBCtXcsWEyGGgUZutC5YGrfxPNVOcQ=
+github.com/dghubble/sling v1.4.1/go.mod h1:QoMB1KL3GAo+7HsD8Itd6S+6tW91who8BGZzuLvpOyc=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
@@ -50,8 +50,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.3.0 h1:a06MkbcxBrEFc0w0QIZWXrH/9cCX6KJyWbBOIwAn+7A=
-golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
+golang.org/x/crypto v0.4.0 h1:UVQgzMY87xqpKNgb+kDsll2Igd33HszWHFLmpaRMq/8=
+golang.org/x/crypto v0.4.0/go.mod h1:3quD/ATkf6oY+rnes5c3ExXTbLc8mueNue5/DoinL80=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/deployments/deployment_process_test.go
+++ b/pkg/deployments/deployment_process_test.go
@@ -1,0 +1,78 @@
+package deployments_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
+	"github.com/kinbiko/jsonassert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeploymentProcessAsJSON(t *testing.T) {
+	lastSnapshotID := internal.GetRandomName()
+	projectID := internal.GetRandomName()
+	spaceID := internal.GetRandomName()
+
+	rand.Seed(time.Now().UnixNano())
+	version := rand.Intn(2)
+
+	expectedJSON := fmt.Sprintf(`{
+		"LastSnapshotId": "%s",
+		"ProjectId": "%s",
+		"SpaceId": "%s",
+		"Version": %v
+	}`,
+		lastSnapshotID,
+		projectID,
+		spaceID,
+		version,
+	)
+
+	var deploymentProcess deployments.DeploymentProcess
+	err := json.Unmarshal([]byte(expectedJSON), &deploymentProcess)
+	require.NoError(t, err)
+	require.NotNil(t, deploymentProcess)
+
+	// TODO: add checks
+
+	actualJSON, err := json.Marshal(deploymentProcess)
+	require.NoError(t, err)
+	require.NotNil(t, actualJSON)
+
+	jsonassert.New(t).Assertf(expectedJSON, string(actualJSON))
+
+	stepName := internal.GetRandomName()
+
+	expectedJSON = fmt.Sprintf(`{
+		"LastSnapshotId": "%s",
+		"ProjectId": "%s",
+		"SpaceId": "%s",
+		"Steps": [
+			{
+				"Name": "%s"
+			}
+		],
+		"Version": %v
+	}`,
+		lastSnapshotID,
+		projectID,
+		spaceID,
+		stepName,
+		version,
+	)
+
+	err = json.Unmarshal([]byte(expectedJSON), &deploymentProcess)
+	require.NoError(t, err)
+	require.NotNil(t, deploymentProcess)
+
+	actualJSON, err = json.Marshal(deploymentProcess)
+	require.NoError(t, err)
+	require.NotNil(t, actualJSON)
+
+	jsonassert.New(t).Assertf(expectedJSON, string(actualJSON))
+}

--- a/pkg/feeds/feed_service.go
+++ b/pkg/feeds/feed_service.go
@@ -94,7 +94,7 @@ func (s *FeedService) GetByID(id string) (IFeed, error) {
 		return nil, err
 	}
 
-	return resp.(IFeed), nil
+	return ToFeed(resp.(*FeedResource))
 }
 
 // GetBuiltInFeedStatistics returns statistics for the built-in feeds.


### PR DESCRIPTION
This PR updates the behaviour of the feeds service. Previously, feeds were serialised using the `FeedResource`. This made the API client more difficult to use; users had to know that they needed to perform a type assertion on the outbound feed before using it. This change pushes that (necessary) plumbing back into the function.

The test, `TestDeploymentProcessAsJSON` is included in this PR because of a check that was invalid whilst testing out the Terraform provider.