### PR TITLE
fix: updated persistence settings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/kinbiko/jsonassert v1.1.1
 	github.com/stretchr/testify v1.8.1
+	golang.org/x/exp v0.0.0-20221217163422-3c43f8badb15
 	golang.org/x/text v0.5.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.4.0 h1:UVQgzMY87xqpKNgb+kDsll2Igd33HszWHFLmpaRMq/8=
 golang.org/x/crypto v0.4.0/go.mod h1:3quD/ATkf6oY+rnes5c3ExXTbLc8mueNue5/DoinL80=
+golang.org/x/exp v0.0.0-20221217163422-3c43f8badb15 h1:5oN1Pz/eDhCpbMbLstvIPa0b/BEQo6g6nwV3pLjfM6w=
+golang.org/x/exp v0.0.0-20221217163422-3c43f8badb15/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/projects/project_service.go
+++ b/pkg/projects/project_service.go
@@ -2,7 +2,6 @@ package projects
 
 import (
 	"fmt"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"net/http"
 	"net/url"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/channels"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/constants"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/releases"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/services"
@@ -285,11 +285,6 @@ func (s *ProjectService) GetReleases(project *Project) ([]*releases.Release, err
 func (s *ProjectService) Update(project *Project) (*Project, error) {
 	if project == nil {
 		return nil, internal.CreateInvalidParameterError(constants.OperationUpdate, constants.ParameterProject)
-	}
-
-	if project.PersistenceSettings != nil && project.PersistenceSettings.Type() == PersistenceSettingsTypeVersionControlled {
-		defaultBranch := project.PersistenceSettings.(GitPersistenceSettings).DefaultBranch()
-		return s.UpdateWithGitRef(project, defaultBranch)
 	}
 
 	path, err := services.GetUpdatePath(s, project)

--- a/test/e2e/project_service_test.go
+++ b/test/e2e/project_service_test.go
@@ -130,7 +130,7 @@ func TestProjectAddWithPersistenceSettings(t *testing.T) {
 	url, err := url.Parse("https://example.com/")
 	require.NoError(t, err)
 
-	project.PersistenceSettings = projects.NewGitPersistenceSettings(basePath, credentials, defaultBranch, false, protectedBranchNamePatterns, url)
+	project.PersistenceSettings = projects.NewGitPersistenceSettings(basePath, credentials, defaultBranch, protectedBranchNamePatterns, url)
 
 	createdProject, err := client.Projects.Add(project)
 	require.NoError(t, err)

--- a/test/resources/project_test.go
+++ b/test/resources/project_test.go
@@ -112,7 +112,7 @@ func TestProjectUnmarshalJSON(t *testing.T) {
 	url, err := url.Parse("https://example.com/")
 	require.NoError(t, err)
 
-	gitPersistenceSettings := projects.NewGitPersistenceSettings(basePath, credentials, defaultBranch, true, protectedBranchNamePatterns, url)
+	gitPersistenceSettings := projects.NewGitPersistenceSettings(basePath, credentials, defaultBranch, protectedBranchNamePatterns, url)
 	gitPersistenceSettingsAsJSON, err := json.Marshal(gitPersistenceSettings)
 	require.NoError(t, err)
 	require.NotNil(t, gitPersistenceSettingsAsJSON)
@@ -132,5 +132,4 @@ func TestProjectUnmarshalJSON(t *testing.T) {
 	require.Equal(t, projectGroupID, project.ProjectGroupID)
 	require.Equal(t, gitPersistenceSettings.Type(), project.PersistenceSettings.Type())
 	require.Equal(t, gitPersistenceSettings.Credential().Type(), project.PersistenceSettings.(projects.GitPersistenceSettings).Credential().Type())
-	require.Equal(t, gitPersistenceSettings.ProtectedDefaultBranch(), true)
 }


### PR DESCRIPTION
The Git-related persistence settings contain unnecessary information that may be inferred dynamically. This PR changes the state and behaviour of the struct that encompasses this information. The information necessary for the Octopus REST API is inferred dynamically (i.e. at run-time).