### PR TITLE
Update to only include the initial commit branch if one is specified

### DIFF
--- a/pkg/projects/convert_to_vcs.go
+++ b/pkg/projects/convert_to_vcs.go
@@ -1,15 +1,26 @@
 package projects
 
+import "golang.org/x/exp/slices"
+
 type ConvertToVcs struct {
 	CommitMessage           string                 `json:"CommitMessage"`
 	VersionControlSettings  GitPersistenceSettings `json:"VersionControlSettings"`
-	InitialCommitBranchName string                 `json:"InitialCommitBranchName"`
+	InitialCommitBranchName string                 `json:"InitialCommitBranchName,omitempty"`
 }
 
+// NewConvertToVcs returns the new structure to send to Octopus to convert a project to VCS. initialCommitBranchName
+// will default to "octopus-vcs-conversion" if not explicitly specified and the default branch is listed in the protected
+// branch patterns.
 func NewConvertToVcs(commitMessage string, initialCommitBranchName string, gitPersistenceSettings GitPersistenceSettings) *ConvertToVcs {
-	return &ConvertToVcs{
+	c := &ConvertToVcs{
 		CommitMessage:           commitMessage,
 		VersionControlSettings:  gitPersistenceSettings,
 		InitialCommitBranchName: initialCommitBranchName,
 	}
+
+	if slices.Contains(gitPersistenceSettings.ProtectedBranchNamePatterns(), gitPersistenceSettings.DefaultBranch()) && len(initialCommitBranchName) < 1 {
+		c.InitialCommitBranchName = "octopus-vcs-conversion"
+	}
+
+	return c
 }

--- a/pkg/projects/project_service.go
+++ b/pkg/projects/project_service.go
@@ -64,8 +64,10 @@ func (s *ProjectService) Add(project *Project) (*Project, error) {
 	return resp.(*Project), nil
 }
 
-// ConvertToVcs converts an input project to use a version-control system (VCS) for its persistence.
-func (s *ProjectService) ConvertToVcs(project *Project, commitMessage string, initalCommitBranch string, gitPersistenceSettings GitPersistenceSettings) (*Project, error) {
+// ConvertToVcs converts an input project to use a version-control system (VCS) for its persistence. initialCommitBranch is ignored unless
+// the default branch in the gitPersistenceSettings appears in the protected branch patterns, and will default to "octopus-vcs-conversion"
+// if not explicitly specified.
+func (s *ProjectService) ConvertToVcs(project *Project, commitMessage string, initialCommitBranch string, gitPersistenceSettings GitPersistenceSettings) (*Project, error) {
 	if project == nil {
 		return nil, internal.CreateInvalidParameterError("ConvertToVcs", "project")
 	}
@@ -82,7 +84,7 @@ func (s *ProjectService) ConvertToVcs(project *Project, commitMessage string, in
 		return nil, fmt.Errorf("the state of the input project is not valid; cannot resolve ConvertToVcs link")
 	}
 
-	convertToVcs := NewConvertToVcs(commitMessage, initalCommitBranch, gitPersistenceSettings)
+	convertToVcs := NewConvertToVcs(commitMessage, initialCommitBranch, gitPersistenceSettings)
 	_, err := services.ApiAddWithResponseStatus(s.GetClient(), convertToVcs, new(ConvertToVcsResponse), project.Links["ConvertToVcs"], http.StatusOK)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes the serialization to only pass the initial commit branch if one is needed/specified.

One is needed if the default branch is protected. In this case, if one isn't provided a default will be used.

Relates to OctopusDeployLabs/terraform-provider-octopusdeploy#477