### PR TITLE
Add some additional fields and update functions for runbooks

### DIFF
--- a/pkg/runbooks/runbook.go
+++ b/pkg/runbooks/runbook.go
@@ -19,6 +19,7 @@ type Runbook struct {
 	RunRetentionPolicy         *RunbookRetentionPeriod     `json:"RunRetentionPolicy,omitempty"`
 	RunbookProcessID           string                      `json:"RunbookProcessId,omitempty"`
 	SpaceID                    string                      `json:"SpaceId,omitempty"`
+	ForcePackageDownload       bool                        `json:"ForcePackageDownload"`
 
 	resources.Resource
 }

--- a/pkg/runbooks/runbook_process_service.go
+++ b/pkg/runbooks/runbook_process_service.go
@@ -37,3 +37,22 @@ func (s *RunbookProcessService) GetByID(id string) (*RunbookProcess, error) {
 
 	return resp.(*RunbookProcess), nil
 }
+
+// Update modifies a runbook process based on the one provided as input.
+func (s *RunbookProcessService) Update(runbook *RunbookProcess) (*RunbookProcess, error) {
+	if runbook == nil {
+		return nil, internal.CreateInvalidParameterError(constants.OperationUpdate, constants.ParameterRunbook)
+	}
+
+	path, err := services.GetUpdatePath(s, runbook)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := services.ApiUpdate(s.GetClient(), runbook, new(RunbookProcess), path)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*RunbookProcess), nil
+}


### PR DESCRIPTION
To support https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/pull/511 this PR adds an update method to the runbook process service and exposes the `ForcePackageDownload` field on a runbook.