### PR TITLE
Add support for access token authentication

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -61,7 +61,7 @@ func TestNewClient(t *testing.T) {
 func TestGetHeadersWithApiKeySetsCorrectHeader(t *testing.T) {
 	apiKey := "API-API1234"
 	headers := getHeaders(ApiCredentials{
-		ApiKey: &apiKey,
+		ApiKey: apiKey,
 	}, "test")
 
 	require.Equal(t, headers[constants.ClientAPIKeyHTTPHeader], apiKey)
@@ -70,7 +70,7 @@ func TestGetHeadersWithApiKeySetsCorrectHeader(t *testing.T) {
 func TestGetHeadersWithAccessTokenSetsCorrectHeader(t *testing.T) {
 	accessToken := "token"
 	headers := getHeaders(ApiCredentials{
-		AccessToken: &accessToken,
+		AccessToken: accessToken,
 	}, "test")
 
 	require.Equal(t, headers["Authorization"], fmt.Sprintf("Bearer %s", accessToken))
@@ -80,51 +80,10 @@ func TestGetHeadersSetsCorrectUserAgent(t *testing.T) {
 	expectedUserAgent := api.GetUserAgentString("test")
 	accessToken := "token"
 	headers := getHeaders(ApiCredentials{
-		AccessToken: &accessToken,
+		AccessToken: accessToken,
 	}, "test")
 
 	require.Equal(t, headers["User-Agent"], expectedUserAgent)
-}
-
-func TestNewClientWithAccessToken(t *testing.T) {
-	client := &http.Client{}
-	octopusURL := os.Getenv("OCTOPUS_HOST")
-	accessToken := os.Getenv("OCTOPUS_ACCESS_TOKEN")
-	spaceID := os.Getenv("OCTOPUS_SPACE")
-
-	apiURL, err := url.Parse(octopusURL)
-	if err != nil {
-		_ = fmt.Errorf("error parsing URL for Octopus API: %v", err)
-		return
-	}
-
-	testCases := []struct {
-		name        string
-		isValid     bool
-		client      *http.Client
-		url         *url.URL
-		accessToken string
-		spaceID     string
-	}{
-		{"NilURL", false, client, nil, accessToken, spaceID},
-		{"EmptyAccessToken", false, client, apiURL, "", ""},
-		{"ValidAccessToken", true, client, apiURL, accessToken, spaceID},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			client, err := NewClientWithCredentials(tc.client, tc.url, ApiCredentials{AccessToken: &tc.accessToken}, tc.spaceID, "test")
-
-			if !tc.isValid {
-				require.Error(t, err)
-				require.Nil(t, client)
-				return
-			}
-
-			require.NoError(t, err)
-			require.NotNil(t, client)
-			assert.NotNil(t, client.Accounts)
-		})
-	}
 }
 
 func TestGetUserAgentString(t *testing.T) {

--- a/pkg/client/octopusdeploy.go
+++ b/pkg/client/octopusdeploy.go
@@ -206,7 +206,7 @@ func NewClientWithCredentials(httpClient *http.Client, apiURL *url.URL, apiCrede
 		return nil, errors.New("one of ApiKey or AccessToken must be provided")
 	}
 
-	if !internal.IsEmpty(apiCredentials.ApiKey) && !IsAPIKey(apiCredentials.AccessToken) {
+	if !internal.IsEmpty(apiCredentials.ApiKey) && !IsAPIKey(apiCredentials.ApiKey) {
 		return nil, internal.CreateInvalidParameterError("NewClient", "apiKey")
 	}
 

--- a/pkg/client/octopusdeploy.go
+++ b/pkg/client/octopusdeploy.go
@@ -1,13 +1,15 @@
 package client
 
 import (
+	"errors"
 	"fmt"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projectbranches"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projectvariables"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projectbranches"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projectvariables"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/accounts"
@@ -170,24 +172,41 @@ func IsAPIKey(apiKey string) bool {
 	return expression.MatchString(apiKey)
 }
 
+type ApiCredentials struct {
+	ApiKey      *string
+	AccessToken *string
+}
+
 // NewClient returns a new Octopus API client. If a nil client is provided, a
 // new http.Client will be used.
 func NewClient(httpClient *http.Client, apiURL *url.URL, apiKey string, spaceID string) (*Client, error) {
-	return NewClientForTool(httpClient, apiURL, apiKey, spaceID, "")
+	return NewClientWithCredentials(httpClient, apiURL, ApiCredentials{ApiKey: &apiKey}, spaceID, "")
+}
+
+// NewClientWithAccessToken returns a new Octopus API client using an access token instead of an api key. If a nil client is provided, a
+// new http.Client will be used.
+func NewClientWithAccessToken(httpClient *http.Client, apiURL *url.URL, accessToken string, spaceID string) (*Client, error) {
+	return NewClientWithCredentials(httpClient, apiURL, ApiCredentials{AccessToken: &accessToken}, spaceID, "")
 }
 
 // NewClientForTool returns a new Octopus API client with a tool reference in the useragent string.
 // If a nil client is provided, a new http.Client will be used.
 func NewClientForTool(httpClient *http.Client, apiURL *url.URL, apiKey string, spaceID string, requestingTool string) (*Client, error) {
+	return NewClientWithCredentials(httpClient, apiURL, ApiCredentials{ApiKey: &apiKey}, spaceID, "")
+}
+
+// NewClientWithCredentials returns a new Octopus API client with the specified credentials and a tool reference in the useragent string.
+// If a nil client is provided, a new http.Client will be used.
+func NewClientWithCredentials(httpClient *http.Client, apiURL *url.URL, apiCredentials ApiCredentials, spaceID string, requestingTool string) (*Client, error) {
 	if apiURL == nil {
 		return nil, internal.CreateInvalidParameterError("NewClient", "apiURL")
 	}
 
-	if internal.IsEmpty(apiKey) {
-		return nil, internal.CreateInvalidParameterError("NewClient", "apiKey")
+	if internal.IsEmpty(*apiCredentials.ApiKey) && internal.IsEmpty(*apiCredentials.AccessToken) {
+		return nil, errors.New("one of ApiKey or AccessToken must be provided")
 	}
 
-	if !IsAPIKey(apiKey) {
+	if !internal.IsEmpty(*apiCredentials.ApiKey) && !IsAPIKey(*apiCredentials.AccessToken) {
 		return nil, internal.CreateInvalidParameterError("NewClient", "apiKey")
 	}
 
@@ -199,7 +218,7 @@ func NewClientForTool(httpClient *http.Client, apiURL *url.URL, apiKey string, s
 	}
 
 	// fetch root resource and process paths
-	base, root, err := getRoot(httpClient, baseURLWithAPI, apiKey, requestingTool)
+	base, root, err := getRoot(httpClient, baseURLWithAPI, apiCredentials, requestingTool)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +227,7 @@ func NewClientForTool(httpClient *http.Client, apiURL *url.URL, apiKey string, s
 	sroot := NewRootResource()
 	if !internal.IsEmpty(spaceID) {
 		baseURLWithAPI = fmt.Sprintf("%s/%s", baseURLWithAPI, spaceID)
-		base, sroot, err = getRoot(httpClient, baseURLWithAPI, apiKey, requestingTool)
+		base, sroot, err = getRoot(httpClient, baseURLWithAPI, apiCredentials, requestingTool)
 
 		if err != nil {
 			if err == services.ErrItemNotFound {
@@ -223,13 +242,22 @@ func NewClientForTool(httpClient *http.Client, apiURL *url.URL, apiKey string, s
 		panic("failure parsing baseURL " + fatalErr.Error())
 	}
 
+	defaultHeaders := map[string]string{
+		"User-Agent": api.GetUserAgentString(requestingTool),
+	}
+
+	if !internal.IsEmpty(*apiCredentials.ApiKey) {
+		defaultHeaders[constants.ClientAPIKeyHTTPHeader] = *apiCredentials.ApiKey
+	}
+
+	if !internal.IsEmpty(*apiCredentials.AccessToken) {
+		defaultHeaders["Authorization"] = fmt.Sprintf("Bearer %s", *apiCredentials.AccessToken)
+	}
+
 	httpSession := &newclient.HttpSession{
-		HttpClient: httpClient,
-		BaseURL:    baseURLWithAPIParsed,
-		DefaultHeaders: map[string]string{
-			constants.ClientAPIKeyHTTPHeader: apiKey,
-			"User-Agent":                     api.GetUserAgentString(requestingTool),
-		},
+		HttpClient:     httpClient,
+		BaseURL:        baseURLWithAPIParsed,
+		DefaultHeaders: defaultHeaders,
 	}
 
 	rootPath := root.GetLinkPath(sroot, constants.LinkSelf)
@@ -466,14 +494,22 @@ func NewClientForTool(httpClient *http.Client, apiURL *url.URL, apiKey string, s
 	}, nil
 }
 
-func getRoot(httpClient *http.Client, baseURLWithAPI string, apiKey string, requestingTool string) (*sling.Sling, *RootResource, error) {
+func getRoot(httpClient *http.Client, baseURLWithAPI string, credentials ApiCredentials, requestingTool string) (*sling.Sling, *RootResource, error) {
 	base := sling.
 		New().
 		Client(httpClient).
 		Base(baseURLWithAPI).
-		Set(constants.ClientAPIKeyHTTPHeader, apiKey).
 		Set("User-Agent", api.GetUserAgentString(requestingTool)).
 		Set("Accept", `application/json`)
+
+	if !internal.IsEmpty(*credentials.ApiKey) {
+		base.Set(constants.ClientAPIKeyHTTPHeader, *credentials.ApiKey)
+	}
+
+	if !internal.IsEmpty(*credentials.AccessToken) {
+		base.Set("Authorization", fmt.Sprintf("Bearer %s", *credentials.AccessToken))
+	}
+
 	rootService := NewRootService(base, baseURLWithAPI)
 
 	root, err := rootService.Get()

--- a/pkg/client/octopusdeploy.go
+++ b/pkg/client/octopusdeploy.go
@@ -242,17 +242,19 @@ func NewClientWithCredentials(httpClient *http.Client, apiURL *url.URL, apiCrede
 		panic("failure parsing baseURL " + fatalErr.Error())
 	}
 
-	defaultHeaders := map[string]string{
-		"User-Agent": api.GetUserAgentString(requestingTool),
-	}
+	defaultHeaders := getHeaders(apiCredentials, requestingTool)
 
-	if !internal.IsEmpty(*apiCredentials.ApiKey) {
-		defaultHeaders[constants.ClientAPIKeyHTTPHeader] = *apiCredentials.ApiKey
-	}
+	// defaultHeaders := map[string]string{
+	// 	"User-Agent": api.GetUserAgentString(requestingTool),
+	// }
 
-	if !internal.IsEmpty(*apiCredentials.AccessToken) {
-		defaultHeaders["Authorization"] = fmt.Sprintf("Bearer %s", *apiCredentials.AccessToken)
-	}
+	// if !internal.IsEmpty(*apiCredentials.ApiKey) {
+	// 	defaultHeaders[constants.ClientAPIKeyHTTPHeader] = *apiCredentials.ApiKey
+	// }
+
+	// if !internal.IsEmpty(*apiCredentials.AccessToken) {
+	// 	defaultHeaders["Authorization"] = fmt.Sprintf("Bearer %s", *apiCredentials.AccessToken)
+	// }
 
 	httpSession := &newclient.HttpSession{
 		HttpClient:     httpClient,
@@ -499,16 +501,21 @@ func getRoot(httpClient *http.Client, baseURLWithAPI string, credentials ApiCred
 		New().
 		Client(httpClient).
 		Base(baseURLWithAPI).
-		Set("User-Agent", api.GetUserAgentString(requestingTool)).
 		Set("Accept", `application/json`)
 
-	if !internal.IsEmpty(*credentials.ApiKey) {
-		base.Set(constants.ClientAPIKeyHTTPHeader, *credentials.ApiKey)
+	headers := getHeaders(credentials, requestingTool)
+
+	for key, value := range headers {
+		base.Set(key, value)
 	}
 
-	if !internal.IsEmpty(*credentials.AccessToken) {
-		base.Set("Authorization", fmt.Sprintf("Bearer %s", *credentials.AccessToken))
-	}
+	// if !internal.IsEmpty(*credentials.ApiKey) {
+	// 	base.Set(constants.ClientAPIKeyHTTPHeader, *credentials.ApiKey)
+	// }
+
+	// if !internal.IsEmpty(*credentials.AccessToken) {
+	// 	base.Set("Authorization", fmt.Sprintf("Bearer %s", *credentials.AccessToken))
+	// }
 
 	rootService := NewRootService(base, baseURLWithAPI)
 
@@ -527,4 +534,20 @@ func (n *Client) Sling() *sling.Sling {
 
 func (n *Client) URITemplateCache() *uritemplates.URITemplateCache {
 	return n.uriTemplateCache
+}
+
+func getHeaders(apiCredentials ApiCredentials, requestingTool string) map[string]string {
+	headers := map[string]string{
+		"User-Agent": api.GetUserAgentString(requestingTool),
+	}
+
+	if !internal.IsEmpty(*apiCredentials.ApiKey) {
+		headers[constants.ClientAPIKeyHTTPHeader] = *apiCredentials.ApiKey
+	}
+
+	if !internal.IsEmpty(*apiCredentials.AccessToken) {
+		headers["Authorization"] = fmt.Sprintf("Bearer %s", *apiCredentials.AccessToken)
+	}
+
+	return headers
 }

--- a/pkg/client/octopusdeploy.go
+++ b/pkg/client/octopusdeploy.go
@@ -173,26 +173,26 @@ func IsAPIKey(apiKey string) bool {
 }
 
 type ApiCredentials struct {
-	ApiKey      *string
-	AccessToken *string
+	ApiKey      string
+	AccessToken string
 }
 
 // NewClient returns a new Octopus API client. If a nil client is provided, a
 // new http.Client will be used.
 func NewClient(httpClient *http.Client, apiURL *url.URL, apiKey string, spaceID string) (*Client, error) {
-	return NewClientWithCredentials(httpClient, apiURL, ApiCredentials{ApiKey: &apiKey}, spaceID, "")
+	return NewClientWithCredentials(httpClient, apiURL, ApiCredentials{ApiKey: apiKey}, spaceID, "")
 }
 
 // NewClientWithAccessToken returns a new Octopus API client using an access token instead of an api key. If a nil client is provided, a
 // new http.Client will be used.
 func NewClientWithAccessToken(httpClient *http.Client, apiURL *url.URL, accessToken string, spaceID string) (*Client, error) {
-	return NewClientWithCredentials(httpClient, apiURL, ApiCredentials{AccessToken: &accessToken}, spaceID, "")
+	return NewClientWithCredentials(httpClient, apiURL, ApiCredentials{AccessToken: accessToken}, spaceID, "")
 }
 
 // NewClientForTool returns a new Octopus API client with a tool reference in the useragent string.
 // If a nil client is provided, a new http.Client will be used.
 func NewClientForTool(httpClient *http.Client, apiURL *url.URL, apiKey string, spaceID string, requestingTool string) (*Client, error) {
-	return NewClientWithCredentials(httpClient, apiURL, ApiCredentials{ApiKey: &apiKey}, spaceID, "")
+	return NewClientWithCredentials(httpClient, apiURL, ApiCredentials{ApiKey: apiKey}, spaceID, "")
 }
 
 // NewClientWithCredentials returns a new Octopus API client with the specified credentials and a tool reference in the useragent string.
@@ -202,11 +202,11 @@ func NewClientWithCredentials(httpClient *http.Client, apiURL *url.URL, apiCrede
 		return nil, internal.CreateInvalidParameterError("NewClient", "apiURL")
 	}
 
-	if internal.IsEmpty(*apiCredentials.ApiKey) && internal.IsEmpty(*apiCredentials.AccessToken) {
+	if internal.IsEmpty(apiCredentials.ApiKey) && internal.IsEmpty(apiCredentials.AccessToken) {
 		return nil, errors.New("one of ApiKey or AccessToken must be provided")
 	}
 
-	if !internal.IsEmpty(*apiCredentials.ApiKey) && !IsAPIKey(*apiCredentials.AccessToken) {
+	if !internal.IsEmpty(apiCredentials.ApiKey) && !IsAPIKey(apiCredentials.AccessToken) {
 		return nil, internal.CreateInvalidParameterError("NewClient", "apiKey")
 	}
 
@@ -243,18 +243,6 @@ func NewClientWithCredentials(httpClient *http.Client, apiURL *url.URL, apiCrede
 	}
 
 	defaultHeaders := getHeaders(apiCredentials, requestingTool)
-
-	// defaultHeaders := map[string]string{
-	// 	"User-Agent": api.GetUserAgentString(requestingTool),
-	// }
-
-	// if !internal.IsEmpty(*apiCredentials.ApiKey) {
-	// 	defaultHeaders[constants.ClientAPIKeyHTTPHeader] = *apiCredentials.ApiKey
-	// }
-
-	// if !internal.IsEmpty(*apiCredentials.AccessToken) {
-	// 	defaultHeaders["Authorization"] = fmt.Sprintf("Bearer %s", *apiCredentials.AccessToken)
-	// }
 
 	httpSession := &newclient.HttpSession{
 		HttpClient:     httpClient,
@@ -509,14 +497,6 @@ func getRoot(httpClient *http.Client, baseURLWithAPI string, credentials ApiCred
 		base.Set(key, value)
 	}
 
-	// if !internal.IsEmpty(*credentials.ApiKey) {
-	// 	base.Set(constants.ClientAPIKeyHTTPHeader, *credentials.ApiKey)
-	// }
-
-	// if !internal.IsEmpty(*credentials.AccessToken) {
-	// 	base.Set("Authorization", fmt.Sprintf("Bearer %s", *credentials.AccessToken))
-	// }
-
 	rootService := NewRootService(base, baseURLWithAPI)
 
 	root, err := rootService.Get()
@@ -541,12 +521,12 @@ func getHeaders(apiCredentials ApiCredentials, requestingTool string) map[string
 		"User-Agent": api.GetUserAgentString(requestingTool),
 	}
 
-	if !internal.IsEmpty(*apiCredentials.ApiKey) {
-		headers[constants.ClientAPIKeyHTTPHeader] = *apiCredentials.ApiKey
+	if !internal.IsEmpty(apiCredentials.ApiKey) {
+		headers[constants.ClientAPIKeyHTTPHeader] = apiCredentials.ApiKey
 	}
 
-	if !internal.IsEmpty(*apiCredentials.AccessToken) {
-		headers["Authorization"] = fmt.Sprintf("Bearer %s", *apiCredentials.AccessToken)
+	if !internal.IsEmpty(apiCredentials.AccessToken) {
+		headers["Authorization"] = fmt.Sprintf("Bearer %s", apiCredentials.AccessToken)
 	}
 
 	return headers


### PR DESCRIPTION
This PR adds support for authenticating using an access token, passing it in the `Authorization` header as a bearer token. It forms part of the in-progress work to support connecting to the Octopus API using OpenID Connect and is currently only available internally. When this is released we'll plan to update the readme with instructions on using access tokens.