### PR TITLE
Update APIKey struct

### DIFF
--- a/pkg/users/api_key.go
+++ b/pkg/users/api_key.go
@@ -6,7 +6,7 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 )
 
-// CreateAPIKey represents an API key when returned from creating a new API key (POST)
+// CreateAPIKey represents an API key when creating a new API key (POST)
 type CreateAPIKey struct {
 	APIKey  string     `json:"ApiKey,omitempty"`
 	Created *time.Time `json:"Created,omitempty"`

--- a/pkg/users/api_key.go
+++ b/pkg/users/api_key.go
@@ -6,8 +6,8 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 )
 
-// APIKey represents an API key.
-type APIKey struct {
+// CreateAPIKey represents an API key when returned from creating a new API key (POST)
+type CreateAPIKey struct {
 	APIKey  string     `json:"ApiKey,omitempty"`
 	Created *time.Time `json:"Created,omitempty"`
 	Purpose string     `json:"Purpose,omitempty"`
@@ -17,9 +17,26 @@ type APIKey struct {
 	resources.Resource
 }
 
+// APIKey represents an API key returned from a GET request
+type APIKey struct {
+	APIKey  *APIKeyStruct `json:"ApiKey,omitempty"`
+	Created *time.Time    `json:"Created,omitempty"`
+	Purpose string        `json:"Purpose,omitempty"`
+	UserID  string        `json:"UserId,omitempty"`
+	Expires *time.Time    `json:"Expires,omitempty"`
+
+	resources.Resource
+}
+
+type APIKeyStruct struct {
+	HasValue bool   `json:"HasValue"`
+	NewValue string `json:"NewValue,omitempty"`
+	Hint     string `json:"Hint"`
+}
+
 // NewAPIKey initializes an API key with a purpose.
-func NewAPIKey(purpose string, userID string) *APIKey {
-	return &APIKey{
+func NewAPIKey(purpose string, userID string) *CreateAPIKey {
+	return &CreateAPIKey{
 		Purpose:  purpose,
 		UserID:   userID,
 		Resource: *resources.NewResource(),

--- a/pkg/users/api_key_service.go
+++ b/pkg/users/api_key_service.go
@@ -82,7 +82,7 @@ func (s *ApiKeyService) GetByID(userID string, apiKeyID string) (*APIKey, error)
 // Create generates a new API key for the specified user ID. The API key
 // returned in the result must be saved by the caller, as it cannot be
 // retrieved subsequently from the Octopus server.
-func (s *ApiKeyService) Create(apiKey *APIKey) (*APIKey, error) {
+func (s *ApiKeyService) Create(apiKey *CreateAPIKey) (*CreateAPIKey, error) {
 	if err := services.ValidateInternalState(s); err != nil {
 		return nil, err
 	}
@@ -94,10 +94,10 @@ func (s *ApiKeyService) Create(apiKey *APIKey) (*APIKey, error) {
 	path := internal.TrimTemplate(s.GetPath())
 	path = fmt.Sprintf("%s/%s/apikeys", path, apiKey.UserID)
 
-	resp, err := services.ApiPost(s.GetClient(), apiKey, new(APIKey), path)
+	resp, err := services.ApiPost(s.GetClient(), apiKey, new(CreateAPIKey), path)
 	if err != nil {
 		return nil, err
 	}
 
-	return resp.(*APIKey), nil
+	return resp.(*CreateAPIKey), nil
 }

--- a/test/e2e/api_keys_test.go
+++ b/test/e2e/api_keys_test.go
@@ -26,7 +26,7 @@ func CreateTestAPIKey(t *testing.T, client *client.Client, user *users.User) *us
 	apiKey := users.NewAPIKey(internal.GetRandomName(), user.ID)
 	require.NotNil(t, apiKey)
 
-	expiry := time.Now().Add(time.Hour).UTC()
+	expiry := time.Now().Add(time.Hour).Round(time.Millisecond)
 	apiKey.Expires = &expiry
 
 	createdAPIKey, err := client.APIKeys.Create(apiKey)

--- a/test/e2e/api_keys_test.go
+++ b/test/e2e/api_keys_test.go
@@ -26,7 +26,7 @@ func CreateTestAPIKey(t *testing.T, client *client.Client, user *users.User) *us
 	apiKey := users.NewAPIKey(internal.GetRandomName(), user.ID)
 	require.NotNil(t, apiKey)
 
-	expiry := time.Now().Add(time.Hour)
+	expiry := time.Now().Add(time.Hour).UTC()
 	apiKey.Expires = &expiry
 
 	createdAPIKey, err := client.APIKeys.Create(apiKey)

--- a/test/e2e/api_keys_test.go
+++ b/test/e2e/api_keys_test.go
@@ -52,7 +52,7 @@ func TestAPIKeysCreate(t *testing.T) {
 	require.NotNil(t, apiKeys)
 	require.NoError(t, err)
 
-	CleanupTestUser(t, client, user)
+	t.Cleanup(func() { CleanupTestUser(t, client, user) })
 }
 
 func TestAPIKeysGetByID(t *testing.T) {
@@ -72,7 +72,7 @@ func TestAPIKeysGetByID(t *testing.T) {
 		assert.NotNil(t, key)
 	}
 
-	CleanupTestUser(t, client, user)
+	t.Cleanup(func() { CleanupTestUser(t, client, user) })
 }
 
 func TestAPIKeysGetByUserID(t *testing.T) {
@@ -92,5 +92,5 @@ func TestAPIKeysGetByUserID(t *testing.T) {
 		assert.NotNil(t, apiKey.ID)
 	}
 
-	CleanupTestUser(t, client, user)
+	t.Cleanup(func() { CleanupTestUser(t, client, user) })
 }


### PR DESCRIPTION
[sc-43458]
Fixes https://github.com/OctopusDeploy/Issues/issues/8434

Created different types for the POST response and GET response as the "APIKey" field is different
- Post response:
<img width="1094" alt="Screenshot 2023-10-30 at 1 10 52 pm" src="https://github.com/OctopusDeploy/go-octopusdeploy/assets/82346985/165cdbfd-ed55-4997-8c12-f16a438d01d5">

- GET response:
<img width="1084" alt="apikeys-get-response" src="https://github.com/OctopusDeploy/go-octopusdeploy/assets/82346985/a45977a5-d74d-4aca-8b1f-0bad0b76b8ad">

