### PR TITLE
fix: tolerate a null StandardChangeTemplateName from the server

### DIFF
--- a/pkg/projects/jira_service_management_extension_settings.go
+++ b/pkg/projects/jira_service_management_extension_settings.go
@@ -63,6 +63,11 @@ func (j JiraServiceManagementExtensionSettings) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON sets the Jira Service Management (JSM) extension settings to its representation in JSON.
+//
+// The server stores these values verbatim, so any of them can come back as null;
+// a project that isn't change controlled skips validation entirely and can be left
+// with a null ServiceDeskProjectName. Values of an unexpected type are ignored
+// rather than asserted, which would panic.
 func (j *JiraServiceManagementExtensionSettings) UnmarshalJSON(b []byte) error {
 	var fields struct {
 		ExtensionID extensions.ExtensionID `json:"ExtensionId"`
@@ -78,11 +83,17 @@ func (j *JiraServiceManagementExtensionSettings) UnmarshalJSON(b []byte) error {
 	for k, v := range fields.Values {
 		switch k {
 		case "JsmChangeControlled":
-			j.SetIsChangeControlled(v.(bool))
+			if value, ok := v.(bool); ok {
+				j.SetIsChangeControlled(value)
+			}
 		case "JsmConnectionId":
-			j.SetConnectionID(v.(string))
+			if value, ok := v.(string); ok {
+				j.SetConnectionID(value)
+			}
 		case "ServiceDeskProjectName":
-			j.ServiceDeskProjectName = v.(string)
+			if value, ok := v.(string); ok {
+				j.ServiceDeskProjectName = value
+			}
 		}
 	}
 

--- a/pkg/projects/jira_service_management_extension_settings_test.go
+++ b/pkg/projects/jira_service_management_extension_settings_test.go
@@ -78,3 +78,42 @@ func TestJiraServiceManagementExtensionSettingsUnmarshalJSON(t *testing.T) {
 	require.Equal(t, isChangeControlled, j.IsChangeControlled())
 	require.Equal(t, serviceDeskProjectName, j.ServiceDeskProjectName)
 }
+
+func TestJiraServiceManagementExtensionSettingsUnmarshalJSONWithNullServiceDeskProjectName(t *testing.T) {
+	connectionID := internal.GetRandomName()
+
+	inputJSON := fmt.Sprintf(`{
+		"ExtensionId": "%s",
+		"Values": {
+			"JsmConnectionId": "%s",
+			"JsmChangeControlled": false,
+			"ServiceDeskProjectName": null
+		}
+	}`, extensions.JiraServiceManagementExtensionID, connectionID)
+
+	var j projects.JiraServiceManagementExtensionSettings
+	err := json.Unmarshal([]byte(inputJSON), &j)
+	require.NoError(t, err)
+	require.Equal(t, connectionID, j.ConnectionID())
+	require.False(t, j.IsChangeControlled())
+	require.Empty(t, j.ServiceDeskProjectName)
+}
+
+func TestJiraServiceManagementExtensionSettingsUnmarshalJSONWithMissingServiceDeskProjectName(t *testing.T) {
+	connectionID := internal.GetRandomName()
+
+	inputJSON := fmt.Sprintf(`{
+		"ExtensionId": "%s",
+		"Values": {
+			"JsmConnectionId": "%s",
+			"JsmChangeControlled": false
+		}
+	}`, extensions.JiraServiceManagementExtensionID, connectionID)
+
+	var j projects.JiraServiceManagementExtensionSettings
+	err := json.Unmarshal([]byte(inputJSON), &j)
+	require.NoError(t, err)
+	require.Equal(t, connectionID, j.ConnectionID())
+	require.False(t, j.IsChangeControlled())
+	require.Empty(t, j.ServiceDeskProjectName)
+}

--- a/pkg/projects/jira_service_management_extension_settings_test.go
+++ b/pkg/projects/jira_service_management_extension_settings_test.go
@@ -68,12 +68,13 @@ func TestJiraServiceManagementExtensionSettingsUnmarshalJSON(t *testing.T) {
 			"JsmChangeControlled": %v,
 			"ServiceDeskProjectName": "%s"
 		}
-	}`, extensions.ServiceNowExtensionID, connectionID, isChangeControlled, serviceDeskProjectName)
+	}`, extensions.JiraServiceManagementExtensionID, connectionID, isChangeControlled, serviceDeskProjectName)
 
 	var j projects.JiraServiceManagementExtensionSettings
 	err := json.Unmarshal([]byte(inputJSON), &j)
 	require.NoError(t, err)
 	require.NotNil(t, j)
+	require.Equal(t, extensions.JiraServiceManagementExtensionID, j.ExtensionID())
 	require.Equal(t, connectionID, j.ConnectionID())
 	require.Equal(t, isChangeControlled, j.IsChangeControlled())
 	require.Equal(t, serviceDeskProjectName, j.ServiceDeskProjectName)

--- a/pkg/projects/servicenow_extension_settings.go
+++ b/pkg/projects/servicenow_extension_settings.go
@@ -8,8 +8,8 @@ import (
 )
 
 type ServiceNowExtensionSettings struct {
-	IsStateAutomaticallyTransitioned bool
-	StandardChangeTemplateName       string
+	IsStateAutomaticallyTransitioned bool   `json:"AutomaticStateTransition"`
+	StandardChangeTemplateName       string `json:"StandardChangeTemplateName,omitempty"`
 
 	ext.ConnectedChangeControlExtensionSettings
 }

--- a/pkg/projects/servicenow_extension_settings.go
+++ b/pkg/projects/servicenow_extension_settings.go
@@ -8,8 +8,8 @@ import (
 )
 
 type ServiceNowExtensionSettings struct {
-	IsStateAutomaticallyTransitioned bool   `json:"AutomaticStateTransition"`
-	StandardChangeTemplateName       string `json:"StandardChangeTemplateName,omitempty"`
+	IsStateAutomaticallyTransitioned bool
+	StandardChangeTemplateName       string
 
 	ext.ConnectedChangeControlExtensionSettings
 }
@@ -48,6 +48,10 @@ func (s *ServiceNowExtensionSettings) SetIsChangeControlled(isChangeControlled b
 }
 
 // MarshalJSON returns the ServiceNow extension settings as its JSON encoding.
+//
+// Every value is always written, including an empty StandardChangeTemplateName.
+// The server treats empty as "no standard change template", and the portal reads
+// the key back without guarding against it being absent.
 func (s ServiceNowExtensionSettings) MarshalJSON() ([]byte, error) {
 	extensionSettings := struct {
 		ExtensionID extensions.ExtensionID `json:"ExtensionId"`
@@ -66,6 +70,11 @@ func (s ServiceNowExtensionSettings) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON sets the ServiceNow extension settings to its representation in JSON.
+//
+// The server stores these values verbatim, so any of them can come back as null;
+// StandardChangeTemplateName in particular is optional and is null on projects that
+// don't use a standard change template. Values of an unexpected type are ignored
+// rather than asserted, which would panic.
 func (s *ServiceNowExtensionSettings) UnmarshalJSON(b []byte) error {
 	var fields struct {
 		ExtensionID extensions.ExtensionID `json:"ExtensionId"`
@@ -81,13 +90,21 @@ func (s *ServiceNowExtensionSettings) UnmarshalJSON(b []byte) error {
 	for k, v := range fields.Values {
 		switch k {
 		case "AutomaticStateTransition":
-			s.IsStateAutomaticallyTransitioned = v.(bool)
+			if value, ok := v.(bool); ok {
+				s.IsStateAutomaticallyTransitioned = value
+			}
 		case "StandardChangeTemplateName":
-			s.StandardChangeTemplateName = v.(string)
+			if value, ok := v.(string); ok {
+				s.StandardChangeTemplateName = value
+			}
 		case "ServiceNowChangeControlled":
-			s.SetIsChangeControlled(v.(bool))
+			if value, ok := v.(bool); ok {
+				s.SetIsChangeControlled(value)
+			}
 		case "ServiceNowConnectionId":
-			s.SetConnectionID(v.(string))
+			if value, ok := v.(string); ok {
+				s.SetConnectionID(value)
+			}
 		}
 	}
 

--- a/pkg/projects/servicenow_extension_settings_test.go
+++ b/pkg/projects/servicenow_extension_settings_test.go
@@ -62,6 +62,26 @@ func TestServiceNowExtensionSettingsMarshalJSON(t *testing.T) {
 	jsonassert.New(t).Assertf(expectedJson, string(serviceNowExtensionSettingsAsJSON))
 }
 
+func TestServiceNowExtensionSettingsMarshalJSONWithoutStandardChangeTemplateName(t *testing.T) {
+	connectionID := internal.GetRandomName()
+	serviceNowExtensionSettings := projects.NewServiceNowExtensionSettings(connectionID, true, "", false)
+
+	serviceNowExtensionSettingsAsJSON, err := json.Marshal(serviceNowExtensionSettings)
+	require.NoError(t, err)
+
+	expectedJson := fmt.Sprintf(`{
+		"ExtensionId": "%s",
+		"Values": {
+			"AutomaticStateTransition": false,
+			"StandardChangeTemplateName": "",
+			"ServiceNowChangeControlled": true,
+			"ServiceNowConnectionId": "%s"
+		}
+	}`, extensions.ServiceNowExtensionID, connectionID)
+
+	jsonassert.New(t).Assertf(expectedJson, string(serviceNowExtensionSettingsAsJSON))
+}
+
 func TestServiceNowExtensionSettingsUnmarshalJSON(t *testing.T) {
 	connectionID := internal.GetRandomName()
 	isChangeControlled := false
@@ -86,4 +106,45 @@ func TestServiceNowExtensionSettingsUnmarshalJSON(t *testing.T) {
 	require.Equal(t, isChangeControlled, serviceNowExtensionSettings.IsChangeControlled())
 	require.Equal(t, standardChangeTemplateName, serviceNowExtensionSettings.StandardChangeTemplateName)
 	require.Equal(t, isStateAutomaticallyTransitioned, serviceNowExtensionSettings.IsStateAutomaticallyTransitioned)
+}
+
+func TestServiceNowExtensionSettingsUnmarshalJSONWithNullStandardChangeTemplateName(t *testing.T) {
+	connectionID := internal.GetRandomName()
+
+	inputJSON := fmt.Sprintf(`{
+		"ExtensionId": "%s",
+		"Values": {
+			"AutomaticStateTransition": false,
+			"StandardChangeTemplateName": null,
+			"ServiceNowChangeControlled": true,
+			"ServiceNowConnectionId": "%s"
+		}
+	}`, extensions.ServiceNowExtensionID, connectionID)
+
+	var serviceNowExtensionSettings projects.ServiceNowExtensionSettings
+	err := json.Unmarshal([]byte(inputJSON), &serviceNowExtensionSettings)
+	require.NoError(t, err)
+	require.Equal(t, connectionID, serviceNowExtensionSettings.ConnectionID())
+	require.True(t, serviceNowExtensionSettings.IsChangeControlled())
+	require.Empty(t, serviceNowExtensionSettings.StandardChangeTemplateName)
+}
+
+func TestServiceNowExtensionSettingsUnmarshalJSONWithMissingStandardChangeTemplateName(t *testing.T) {
+	connectionID := internal.GetRandomName()
+
+	inputJSON := fmt.Sprintf(`{
+		"ExtensionId": "%s",
+		"Values": {
+			"AutomaticStateTransition": false,
+			"ServiceNowChangeControlled": true,
+			"ServiceNowConnectionId": "%s"
+		}
+	}`, extensions.ServiceNowExtensionID, connectionID)
+
+	var serviceNowExtensionSettings projects.ServiceNowExtensionSettings
+	err := json.Unmarshal([]byte(inputJSON), &serviceNowExtensionSettings)
+	require.NoError(t, err)
+	require.Equal(t, connectionID, serviceNowExtensionSettings.ConnectionID())
+	require.True(t, serviceNowExtensionSettings.IsChangeControlled())
+	require.Empty(t, serviceNowExtensionSettings.StandardChangeTemplateName)
 }


### PR DESCRIPTION
Relates to https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/pull/574

Changes direction from the original commit. The `omitempty` tags had no effect — `ServiceNowExtensionSettings` has a custom `MarshalJSON` that builds the `Values` map by hand and never reads struct tags, so the wire format was identical before and after.

Omitting the key isn't the fix either. The server stores `Values` verbatim and resolves the template with `string.IsNullOrWhiteSpace`, so an empty string already means "no standard change template". The portal reads `Values.StandardChangeTemplateName.trim()` unconditionally, so a project written without the key would break the ITSM settings page.

What actually breaks is reading a project whose value is null — `UnmarshalJSON` asserted straight to a string and panicked with `interface conversion: interface {} is nil, not string`. Values are now type-checked before assigning.

Three commits:

1. ServiceNow — revert the no-op tags, type-check the four values in `UnmarshalJSON`.
2. Jira Service Management — identical unchecked assertions, fixed the same way. A JSM project that isn't change controlled skips server-side validation, so a null `ServiceDeskProjectName` can be stored and panics on read.
3. Test fix — `TestJiraServiceManagementExtensionSettingsUnmarshalJSON` built its input with `ServiceNowExtensionID`; nothing asserted the extension ID, so it went unnoticed.

Verified against a local instance for both extensions: a project with a null value panicked before and now reads back as empty, and a create/update/re-read round-trip is accepted and stable.