### PR TITLE
chore: Support process scoped variable scope matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ if err != nil {
 
 Operations like `Add`, `DeleteByID`, `GetByID`, and `Update` are supported by most services that are exposed through the client if not exposed in the package. These operations are configured at runtime since the Octopus REST API is hypermedia-driven.
 
-Numerous code samples that showcase the API and this client are available in the [examples](/examples) directory. There are also many [integration](/integration) and unit tests available to examine that demonstrate the capabilities of this API client.
+Numerous code samples that showcase the API and this client are available in the [examples](/examples) directory. There are also many [integration](/test) and unit tests available to examine that demonstrate the capabilities of this API client.
 
 ## 🤝 Contributions
 

--- a/pkg/variables/variable_service.go
+++ b/pkg/variables/variable_service.go
@@ -603,6 +603,15 @@ func MatchesScope(variableScope VariableScope, definedScope *VariableScope) (boo
 		}
 	}
 
+	for _, p1 := range definedScope.ProcessOwners {
+		for _, p2 := range variableScope.ProcessOwners {
+			if p1 == p2 {
+				matched = true
+				matchedScopes.ProcessOwners = append(matchedScopes.ProcessOwners, p1)
+			}
+		}
+	}
+
 	return matched, &matchedScopes, nil
 }
 

--- a/pkg/variables/variable_service_test.go
+++ b/pkg/variables/variable_service_test.go
@@ -88,3 +88,99 @@ func TestVariableServiceDeleteSingleWithEmptyID(t *testing.T) {
 	require.Error(t, err)
 	require.NotNil(t, variableSet)
 }
+
+func TestMatchesScopeWithEmptyVariableScope(t *testing.T) {
+	variableScope := VariableScope{
+		Environments:  nil,
+		Machines:      nil,
+		Actions:       nil,
+		Roles:         nil,
+		Channels:      nil,
+		TenantTags:    nil,
+		ProcessOwners: nil,
+	}
+	definedScope := &VariableScope{
+		Environments:  []string{"env-1"},
+		Machines:      []string{"machine-1"},
+		Actions:       []string{"action-1"},
+		Roles:         []string{"role-1"},
+		Channels:      []string{"channel-1"},
+		TenantTags:    []string{"tenant-1"},
+		ProcessOwners: []string{"process-1"},
+	}
+
+	match, matchedScope, err := MatchesScope(variableScope, definedScope)
+	require.Nil(t, err)
+	require.False(t, match)
+	require.Nil(t, matchedScope.Environments)
+	require.Nil(t, matchedScope.Machines)
+	require.Nil(t, matchedScope.Actions)
+	require.Nil(t, matchedScope.Roles)
+	require.Nil(t, matchedScope.Channels)
+	require.Nil(t, matchedScope.TenantTags)
+	require.Nil(t, matchedScope.ProcessOwners)
+}
+
+func TestMatchesScopeWithNonMatchingVariableScope(t *testing.T) {
+	variableScope := VariableScope{
+		Environments:  []string{"env-1"},
+		Machines:      []string{"machine-1"},
+		Actions:       []string{"action-1"},
+		Roles:         []string{"role-1"},
+		Channels:      []string{"channel-1"},
+		TenantTags:    []string{"tenant-1"},
+		ProcessOwners: []string{"process-1"},
+	}
+	definedScope := &VariableScope{
+		Environments:  []string{"env-2"},
+		Machines:      []string{"machine-2"},
+		Actions:       []string{"action-2"},
+		Roles:         []string{"role-2"},
+		Channels:      []string{"channel-2"},
+		TenantTags:    []string{"tenant-2"},
+		ProcessOwners: []string{"process-2"},
+	}
+
+	match, matchedScope, err := MatchesScope(variableScope, definedScope)
+	require.Nil(t, err)
+	require.False(t, match)
+	require.Nil(t, matchedScope.Environments)
+	require.Nil(t, matchedScope.Machines)
+	require.Nil(t, matchedScope.Actions)
+	require.Nil(t, matchedScope.Roles)
+	require.Nil(t, matchedScope.Channels)
+	require.Nil(t, matchedScope.TenantTags)
+	require.Nil(t, matchedScope.ProcessOwners)
+}
+
+func TestMatchesScopeWithMatchingVariableScope(t *testing.T) {
+	variableScope := VariableScope{
+		Environments:  []string{"env-1"},
+		Machines:      []string{"machine-1"},
+		Actions:       []string{"action-1"},
+		Roles:         []string{"role-1"},
+		Channels:      []string{"channel-1"},
+		TenantTags:    []string{"tenant-1"},
+		ProcessOwners: []string{"process-1"},
+	}
+	definedScope := &VariableScope{
+		Environments:  []string{"env-1"},
+		Machines:      []string{"machine-1"},
+		Actions:       []string{"action-1"},
+		Roles:         []string{"role-1"},
+		Channels:      []string{"channel-1"},
+		TenantTags:    []string{"tenant-1"},
+		ProcessOwners: []string{"process-1"},
+	}
+
+	match, matchedScope, err := MatchesScope(variableScope, definedScope)
+	require.Nil(t, err)
+	require.True(t, match)
+	require.ElementsMatch(t, matchedScope.Environments, variableScope.Environments)
+	require.ElementsMatch(t, matchedScope.Machines, variableScope.Machines)
+	require.ElementsMatch(t, matchedScope.Actions, variableScope.Actions)
+	require.ElementsMatch(t, matchedScope.Roles, variableScope.Roles)
+	require.ElementsMatch(t, matchedScope.Channels, variableScope.Channels)
+	require.ElementsMatch(t, matchedScope.TenantTags, variableScope.TenantTags)
+	require.ElementsMatch(t, matchedScope.ProcessOwners, variableScope.ProcessOwners)
+}


### PR DESCRIPTION
# Background 
[sc-66829]

To support process owners in the terraform provider we need to update the Go Client to handle matching the scope for it, everything else related process owner scope in variables was already implemented

# Result
- Updated `MatchesScope` method to match process owners
- Added some basic unit tests for `MatchesScope`
- Fixed broken link in readme 