### PR TITLE
feat: Support git resource sourcing

### DIFF
--- a/pkg/deployments/deployment_action.go
+++ b/pkg/deployments/deployment_action.go
@@ -2,6 +2,7 @@ package deployments
 
 import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/gitdependencies"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/packages"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 	"github.com/go-playground/validator/v10"
@@ -9,23 +10,24 @@ import (
 )
 
 type DeploymentAction struct {
-	ActionType                    string                        `json:"ActionType" validate:"required,notblank"`
-	CanBeUsedForProjectVersioning bool                          `json:"CanBeUsedForProjectVersioning"`
-	Channels                      []string                      `json:"Channels,omitempty"`
-	Condition                     string                        `json:"Condition,omitempty"`
-	Container                     *DeploymentActionContainer    `json:"Container,omitempty"`
-	Environments                  []string                      `json:"Environments,omitempty"`
-	ExcludedEnvironments          []string                      `json:"ExcludedEnvironments,omitempty"`
-	IsDisabled                    bool                          `json:"IsDisabled"`
-	IsRequired                    bool                          `json:"IsRequired"`
-	Name                          string                        `json:"Name" validate:"required,notblank"`
-	Notes                         string                        `json:"Notes,omitempty"`
-	Packages                      []*packages.PackageReference  `json:"Packages,omitempty"`
-	Properties                    map[string]core.PropertyValue `json:"Properties,omitempty"`
-	StepPackageVersion            string                        `json:"StepPackageVersion,omitempty"`
-	TenantTags                    []string                      `json:"TenantTags,omitempty"`
-	WorkerPool                    string                        `json:"WorkerPoolId,omitempty"`
-	WorkerPoolVariable            string                        `json:"WorkerPoolVariable,omitempty"`
+	ActionType                    string                           `json:"ActionType" validate:"required,notblank"`
+	CanBeUsedForProjectVersioning bool                             `json:"CanBeUsedForProjectVersioning"`
+	Channels                      []string                         `json:"Channels,omitempty"`
+	Condition                     string                           `json:"Condition,omitempty"`
+	Container                     *DeploymentActionContainer       `json:"Container,omitempty"`
+	Environments                  []string                         `json:"Environments,omitempty"`
+	ExcludedEnvironments          []string                         `json:"ExcludedEnvironments,omitempty"`
+	IsDisabled                    bool                             `json:"IsDisabled"`
+	IsRequired                    bool                             `json:"IsRequired"`
+	Name                          string                           `json:"Name" validate:"required,notblank"`
+	Notes                         string                           `json:"Notes,omitempty"`
+	Packages                      []*packages.PackageReference     `json:"Packages,omitempty"`
+	GitDependencies               []*gitdependencies.GitDependency `json:"GitDependencies,omitempty"`
+	Properties                    map[string]core.PropertyValue    `json:"Properties,omitempty"`
+	StepPackageVersion            string                           `json:"StepPackageVersion,omitempty"`
+	TenantTags                    []string                         `json:"TenantTags,omitempty"`
+	WorkerPool                    string                           `json:"WorkerPoolId,omitempty"`
+	WorkerPoolVariable            string                           `json:"WorkerPoolVariable,omitempty"`
 
 	resources.Resource
 }

--- a/pkg/gitdependencies/git_dependency.go
+++ b/pkg/gitdependencies/git_dependency.go
@@ -1,0 +1,11 @@
+package gitdependencies
+
+type GitDependency struct {
+	Name                         string   `json:"Name" validate:"required,notblank"`
+	RepositoryUri                string   `json:"RepositoryUri" validate:"required,notblank"`
+	DefaultBranch                string   `json:"DefaultBranch" validate:"required,notblank"`
+	GitCredentialType            string   `json:"GitCredentialType" validate:"required,notblank"`
+	FilePathFilters              []string `json:"FilePathFilters,omitempty"`
+	GitCredentialId              string   `json:"GitCredentialId,omitempty"`
+	StepPackageInputsReferenceId string   `json:"StepPackageInputsReferenceId,omitempty"`
+}


### PR DESCRIPTION
# Background
[SC-67713]
Octopus supports sourcing scripts from git repositories on some of deployment actions, but currently the go api client which is used by the cli and terraform provider doesn't support the properties required to configure git resource sourcing. 

# Solution
- Added new git dependency type
- Added new property to deployment action type to use the git dependency type
