### PR TITLE
Add support for deployments previews

### DIFF
--- a/pkg/deployments/deployment_preview.go
+++ b/pkg/deployments/deployment_preview.go
@@ -1,6 +1,8 @@
 package deployments
 
-import "github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+)
 
 type MachineDeploymentPreview struct {
 	ID                string `json:"Id,omitempty"`
@@ -23,10 +25,43 @@ type DeploymentTemplateStep struct {
 	ExcludedMachines        []*resources.ReferenceDataItem `json:"ExcludedMachines,omitempty"`
 }
 
+type Control struct {
+	Type            string                     `json:"Type"`
+	Name            string                     `json:"Name"`
+	Label           string                     `json:"Label"`
+	Description     string                     `json:"Description"`
+	Required        bool                       `json:"Required"`
+	DisplaySettings *resources.DisplaySettings `json:"DisplaySettings"`
+}
+
+type Element struct {
+	Name            string   `json:"Name"`
+	Control         *Control `json:"Control"`
+	IsValueRequired bool     `json:"IsValueRequired"`
+}
+
+type Form struct {
+	Values   map[string]string `json:"Values"`
+	Elements []*Element        `json:"Elements"`
+}
+
 type DeploymentPreview struct {
 	// Changes []*ReleaseChanges // we don't use this at the moment, and it is large+expensive, so don't de-serialize for now
 	// ChangesMarkdown string  // we don't use this at the moment, and it is large+expensive, so don't de-serialize for now
-	// Form *Form // we don't use this at the moment, and it is large+expensive, so don't de-serialize for now
+	Form                          *Form                     `json:"Form,omitempty"`
 	StepsToExecute                []*DeploymentTemplateStep `json:"StepsToExecute,omitempty"`
 	UseGuidedFailureModeByDefault bool                      `json:"UseGuidedFailureModeByDefault"`
+}
+
+type DeploymentPreviewRequestBody struct {
+	EnvironmentId string `json:"EnvironmentId"`
+	TenantId      string `json:"TenantId"`
+}
+
+// For review time - Should DeploymentPreviewRequestBody be an array of pointers to an object?
+type DeploymentPreviewsBody struct {
+	DeploymentPreviews   []DeploymentPreviewRequestBody `json:"DeploymentPreviews"`
+	IncludeDisabledSteps bool                           `json:"IncludeDisabledSteps"`
+	ReleaseId            string                         `json:"ReleaseId"`
+	SpaceId              string                         `json:"SpaceId"`
 }

--- a/pkg/deployments/deployment_preview.go
+++ b/pkg/deployments/deployment_preview.go
@@ -65,3 +65,11 @@ type DeploymentPreviewsBody struct {
 	ReleaseId            string                     `json:"ReleaseId"`
 	SpaceId              string                     `json:"SpaceId"`
 }
+
+func NewEmptyDeploymentPreview() *DeploymentPreview {
+	return &DeploymentPreview{
+		Form:                          &Form{Values: map[string]string{}, Elements: []*Element{}},
+		StepsToExecute:                []*DeploymentTemplateStep{},
+		UseGuidedFailureModeByDefault: false,
+	}
+}

--- a/pkg/deployments/deployment_preview.go
+++ b/pkg/deployments/deployment_preview.go
@@ -53,15 +53,15 @@ type DeploymentPreview struct {
 	UseGuidedFailureModeByDefault bool                      `json:"UseGuidedFailureModeByDefault"`
 }
 
-type DeploymentPreviewRequestBody struct {
+type DeploymentPreviewRequest struct {
 	EnvironmentId string `json:"EnvironmentId"`
 	TenantId      string `json:"TenantId"`
 }
 
 // For review time - Should DeploymentPreviewRequestBody be an array of pointers to an object?
 type DeploymentPreviewsBody struct {
-	DeploymentPreviews   []DeploymentPreviewRequestBody `json:"DeploymentPreviews"`
-	IncludeDisabledSteps bool                           `json:"IncludeDisabledSteps"`
-	ReleaseId            string                         `json:"ReleaseId"`
-	SpaceId              string                         `json:"SpaceId"`
+	DeploymentPreviews   []DeploymentPreviewRequest `json:"DeploymentPreviews"`
+	IncludeDisabledSteps bool                       `json:"IncludeDisabledSteps"`
+	ReleaseId            string                     `json:"ReleaseId"`
+	SpaceId              string                     `json:"SpaceId"`
 }

--- a/pkg/deployments/deployment_service.go
+++ b/pkg/deployments/deployment_service.go
@@ -221,18 +221,18 @@ func GetReleaseDeploymentPreview(client newclient.Client, spaceID string, releas
 // GetReleaseDeploymentPreviews gets a preview of a release for a multiple given environments.
 // This is used by the portal to show which machines, prompted variables and other information about the deployment,
 // before proceeding with it. The CLI uses it to build the prompted variables list for a deployment to a given set of environments
-func GetReleaseDeploymentPreviews(client newclient.Client, spaceID string, releaseID string, environmentIds []string, tenantId string, includeDisabledSteps bool) ([]*DeploymentPreview, error) {
+func GetReleaseDeploymentPreviews(client newclient.Client, spaceID string, releaseID string, deploymentPreviewRequests []DeploymentPreviewRequest, includeDisabledSteps bool) ([]*DeploymentPreview, error) {
 	if client == nil {
-		return nil, internal.CreateInvalidParameterError("GetReleaseDeploymentPreview", "client")
+		return nil, internal.CreateInvalidParameterError("GetReleaseDeploymentPreviews", "client")
 	}
 	if spaceID == "" {
-		return nil, internal.CreateInvalidParameterError("GetReleaseDeploymentPreview", "spaceID")
+		return nil, internal.CreateInvalidParameterError("GetReleaseDeploymentPreviews", "spaceID")
 	}
 	if releaseID == "" {
-		return nil, internal.CreateInvalidParameterError("GetReleaseDeploymentPreview", "releaseID")
+		return nil, internal.CreateInvalidParameterError("GetReleaseDeploymentPreviews", "releaseID")
 	}
-	if len(environmentIds) == 0 {
-		return nil, internal.CreateInvalidParameterError("GetReleaseDeploymentPreviews", "environmentIDs")
+	if len(deploymentPreviewRequests) == 0 {
+		return nil, internal.CreateInvalidParameterError("GetReleaseDeploymentPreviews", "deploymentPreviewRequests")
 	}
 
 	expandedUri, err := client.URITemplateCache().Expand(uritemplates.ReleaseDeploymentPreviews, map[string]any{
@@ -243,18 +243,9 @@ func GetReleaseDeploymentPreviews(client newclient.Client, spaceID string, relea
 		return nil, err
 	}
 
-	var previews []DeploymentPreviewRequestBody
-	for _, envId := range environmentIds {
-		preview := DeploymentPreviewRequestBody{
-			EnvironmentId: envId,
-			TenantId:      tenantId,
-		}
-		previews = append(previews, preview)
-	}
-
 	// Create an instance of DeploymentPreviewsBody
 	body := DeploymentPreviewsBody{
-		DeploymentPreviews:   previews,
+		DeploymentPreviews:   deploymentPreviewRequests,
 		IncludeDisabledSteps: includeDisabledSteps,
 		ReleaseId:            releaseID,
 		SpaceId:              spaceID,

--- a/pkg/resources/display_settings.go
+++ b/pkg/resources/display_settings.go
@@ -1,4 +1,4 @@
-package variables
+package resources
 
 import (
 	"encoding/json"

--- a/pkg/variables/variable_prompt_options.go
+++ b/pkg/variables/variable_prompt_options.go
@@ -1,8 +1,10 @@
 package variables
 
+import "github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+
 type VariablePromptOptions struct {
-	Description     string           `json:"Description"`
-	DisplaySettings *DisplaySettings `json:"DisplaySettings,omitempty"`
-	IsRequired      bool             `json:"Required"`
-	Label           string           `json:"Label"`
+	Description     string                     `json:"Description"`
+	DisplaySettings *resources.DisplaySettings `json:"DisplaySettings,omitempty"`
+	IsRequired      bool                       `json:"Required"`
+	Label           string                     `json:"Label"`
 }

--- a/test/resources/display_settings_test.go
+++ b/test/resources/display_settings_test.go
@@ -3,36 +3,36 @@ package resources
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 	"testing"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
 	"github.com/kinbiko/jsonassert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDisplaySettings(t *testing.T) {
-	controlType := variables.ControlTypeSelect
+	controlType := resources.ControlTypeSelect
 	option1 := internal.GetRandomName()
 	value1 := internal.GetRandomName()
 	option2 := internal.GetRandomName()
 	value2 := internal.GetRandomName()
 
-	selectOptions := []*variables.SelectOption{
+	selectOptions := []*resources.SelectOption{
 		{Value: value1, DisplayName: option1},
 		{Value: value2, DisplayName: option2},
 	}
 
-	displaySettings := variables.NewDisplaySettings(controlType, selectOptions)
+	displaySettings := resources.NewDisplaySettings(controlType, selectOptions)
 	require.NotNil(t, displaySettings)
 	require.Equal(t, controlType, displaySettings.ControlType)
 	require.Equal(t, selectOptions, displaySettings.SelectOptions)
 }
 
 func TestDisplaySettingsAsJson(t *testing.T) {
-	controlType := variables.ControlTypeSelect
+	controlType := resources.ControlTypeSelect
 
-	displaySettings := variables.NewDisplaySettings(controlType, []*variables.SelectOption{
+	displaySettings := resources.NewDisplaySettings(controlType, []*resources.SelectOption{
 		{Value: "Value-1", DisplayName: "Option-1"},
 		{Value: "Value-2", DisplayName: "Option-2"},
 		{Value: "Value-3", DisplayName: "Option-3"},
@@ -52,7 +52,7 @@ func TestDisplaySettingsAsJson(t *testing.T) {
 }
 
 func TestSelectOptions(t *testing.T) {
-	controlType := variables.ControlTypeSelect
+	controlType := resources.ControlTypeSelect
 	option1 := internal.GetRandomName()
 	value1 := internal.GetRandomName()
 	option2 := internal.GetRandomName()
@@ -60,12 +60,12 @@ func TestSelectOptions(t *testing.T) {
 	option3 := internal.GetRandomName()
 	value3 := internal.GetRandomName()
 
-	selectOptions := []*variables.SelectOption{
+	selectOptions := []*resources.SelectOption{
 		{Value: value1, DisplayName: option1},
 		{Value: value2, DisplayName: option2},
 		{Value: value3, DisplayName: option3},
 	}
-	displaySettings := variables.NewDisplaySettings(controlType, selectOptions)
+	displaySettings := resources.NewDisplaySettings(controlType, selectOptions)
 
 	displaySettingsAsJson, err := json.Marshal(displaySettings)
 	require.NoError(t, err)
@@ -82,15 +82,15 @@ func TestDisplaySettingsFromJson(t *testing.T) {
 		"Octopus.SelectOptions": "Value-1|Option-1\nValue-2|Option-2\nValue-3|Option-3"
 	}`, controlType)
 
-	var displaySettings variables.DisplaySettings
+	var displaySettings resources.DisplaySettings
 	err := json.Unmarshal([]byte(displaySettingsAsJson), &displaySettings)
 	require.NoError(t, err)
 	require.NotNil(t, displaySettings)
 	require.NotNil(t, displaySettings.ControlType)
-	require.Equal(t, variables.ControlTypeSelect, displaySettings.ControlType)
+	require.Equal(t, resources.ControlTypeSelect, displaySettings.ControlType)
 	require.NotNil(t, displaySettings.SelectOptions)
 	require.Len(t, displaySettings.SelectOptions, 3)
-	require.Equal(t, []*variables.SelectOption{
+	require.Equal(t, []*resources.SelectOption{
 		{Value: "Value-1", DisplayName: "Option-1"},
 		{Value: "Value-2", DisplayName: "Option-2"},
 		{Value: "Value-3", DisplayName: "Option-3"},

--- a/uritemplates/links.go
+++ b/uritemplates/links.go
@@ -17,6 +17,7 @@ const (
 	LibraryVariableSets                 = "/api/{spaceId}/libraryvariablesets{/id}{?skip,contentType,take,ids,partialName}"
 	PackageUpload                       = "/api/{spaceId}/packages/raw{?replace,overwriteMode}"                                                               // POST multipart form
 	ReleaseDeploymentPreview            = "/api/{spaceId}/releases/{releaseId}/deployments/preview/{environmentId}{?includeDisabledSteps}"                    // GET
+	ReleaseDeploymentPreviews           = "/api/{spaceId}/releases/{releaseId}/deployments/previews"                                                          // POST multipart form
 	Releases                            = "/api/{spaceId}/releases{/id}{?skip,ignoreChannelRules,take,ids}"                                                   // GET
 	ReleasesByProject                   = "/api/{spaceId}/projects/{projectId}/releases{/version}{?skip,take,searchByVersion}"                                // GET
 	ReleasesByProjectAndChannel         = "/api/{spaceId}/projects/{projectId}/channels/{channelId}/releases{?skip,take,searchByVersion}"                     // GET


### PR DESCRIPTION
Adds support for fetching deployment previews from the space scoped POST endpoint. This takes an array of DeploymentPreviews (EnvironmentId and TenantId) and returns an array of deploymentPreviews.

Required for change https://github.com/OctopusDeploy/go-octopusdeploy/pull/232. This adds support for only prompting on variable within the deployment scope using the deployments previews endpoint instead of the project variable set.

This is required for a change to the cli, where we currently fetch the variable set and prompt for all variables, irrelevant of the scoping. The change to the CLI will only prompt for variables in that specific set of releases. This is handled by flattening the deployment previews, so if there are multiple environments that contain differently scoped variables they will all be prompted for and contributed. While they are all contributed due to variable scoping at deployment time the out of scope variables are not included in the manifest and therefore deployment. 

![image](https://github.com/OctopusDeploy/go-octopusdeploy/assets/101079287/08962ee2-623d-479b-9497-ccfd1ec110b3)

For this use case (showing prompted variables) tenant scoping is not allowed
![image](https://github.com/OctopusDeploy/go-octopusdeploy/assets/101079287/fe816b1b-4325-4838-8e6f-e6257a71f213)

When requesting a deployment previews for a tenant with environments out of scope those prompted variables are still returned. Tenant variables are also not able to be prompted. In the CLI consuming code this means specifying the tenant is redundant in our use case.
![image](https://github.com/OctopusDeploy/go-octopusdeploy/assets/101079287/aa4b3b96-f303-4212-b63d-0d6e7ca46eec)


