### PR TITLE
fix: virtual path support 

### DIFF
--- a/pkg/client/octopusdeploy.go
+++ b/pkg/client/octopusdeploy.go
@@ -7,9 +7,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projectbranches"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projectvariables"
-
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/accounts"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actions"
@@ -44,8 +41,10 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/octopusservernodes"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/packages"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/permissions"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projectbranches"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projectgroups"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projectvariables"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/proxies"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/releases"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/reporting"
@@ -214,15 +213,22 @@ func NewClientWithCredentials(httpClient *http.Client, apiURL *url.URL, apiCrede
 		return nil, internal.CreateInvalidParameterError("NewClient", "apiCredentials")
 	}
 
-	baseURLWithAPI := strings.TrimRight(apiURL.String(), "/")
-	//baseURLWithAPI = fmt.Sprintf("%s/api", baseURLWithAPI)
+	var baseURL string
+	if apiURL.Path == "" {
+		baseURL = strings.TrimRight(apiURL.String(), "/")
+	} else {
+		baseURL = apiURL.String()
+		if !strings.HasSuffix(baseURL, "/") {
+			baseURL = fmt.Sprintf("%s/", apiURL)
+		}
+	}
 
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
 
 	// fetch root resource and process paths
-	base, root, err := getRoot(httpClient, baseURLWithAPI, apiCredentials, requestingTool)
+	base, root, err := getRoot(httpClient, baseURL, apiCredentials, requestingTool)
 	if err != nil {
 		return nil, err
 	}
@@ -230,8 +236,8 @@ func NewClientWithCredentials(httpClient *http.Client, apiURL *url.URL, apiCrede
 	// Root with specified Space ID, if it's defined
 	sroot := NewRootResource()
 	if !internal.IsEmpty(spaceID) {
-		baseURLWithAPI = fmt.Sprintf("%s/%s", baseURLWithAPI, spaceID)
-		base, sroot, err = getRoot(httpClient, baseURLWithAPI, apiCredentials, requestingTool)
+		baseURL = fmt.Sprintf("%s/%s", baseURL, spaceID)
+		base, sroot, err = getRoot(httpClient, baseURL, apiCredentials, requestingTool)
 
 		if err != nil {
 			if err == services.ErrItemNotFound {
@@ -241,7 +247,7 @@ func NewClientWithCredentials(httpClient *http.Client, apiURL *url.URL, apiCrede
 		}
 	}
 
-	baseURLWithAPIParsed, fatalErr := url.Parse(baseURLWithAPI)
+	baseURLWithAPIParsed, fatalErr := url.Parse(baseURL)
 	if fatalErr != nil { // should never fail because baseURLWithAPI is entirely constructed out of things that are known to be parseable
 		panic("failure parsing baseURL " + fatalErr.Error())
 	}
@@ -500,11 +506,14 @@ func NewClientWithCredentials(httpClient *http.Client, apiURL *url.URL, apiCrede
 	}, nil
 }
 
-func getRoot(httpClient *http.Client, baseUrl string, credentials ICredential, requestingTool string) (*sling.Sling, *RootResource, error) {
+func getRoot(httpClient *http.Client, baseURL string, credentials ICredential, requestingTool string) (*sling.Sling, *RootResource, error) {
+	apiUrl := strings.TrimRight(baseURL, "/")
+	apiUrl = fmt.Sprintf("%s/api", apiUrl)
+
 	base := sling.
 		New().
 		Client(httpClient).
-		Base(baseUrl).
+		Base(apiUrl).
 		Set("Accept", `application/json`)
 
 	headers := getHeaders(credentials, requestingTool)
@@ -513,11 +522,7 @@ func getRoot(httpClient *http.Client, baseUrl string, credentials ICredential, r
 		base.Set(key, value)
 	}
 
-	if !strings.HasSuffix(baseUrl, "/api") {
-		baseUrl = fmt.Sprintf("%s/api", baseUrl)
-	}
-
-	rootService := NewRootService(base, baseUrl)
+	rootService := NewRootService(base, apiUrl)
 
 	root, err := rootService.Get()
 	return base, root, err

--- a/pkg/client/octopusdeploy.go
+++ b/pkg/client/octopusdeploy.go
@@ -215,7 +215,7 @@ func NewClientWithCredentials(httpClient *http.Client, apiURL *url.URL, apiCrede
 	}
 
 	baseURLWithAPI := strings.TrimRight(apiURL.String(), "/")
-	baseURLWithAPI = fmt.Sprintf("%s/api", baseURLWithAPI)
+	//baseURLWithAPI = fmt.Sprintf("%s/api", baseURLWithAPI)
 
 	if httpClient == nil {
 		httpClient = &http.Client{}
@@ -500,11 +500,11 @@ func NewClientWithCredentials(httpClient *http.Client, apiURL *url.URL, apiCrede
 	}, nil
 }
 
-func getRoot(httpClient *http.Client, baseURLWithAPI string, credentials ICredential, requestingTool string) (*sling.Sling, *RootResource, error) {
+func getRoot(httpClient *http.Client, baseUrl string, credentials ICredential, requestingTool string) (*sling.Sling, *RootResource, error) {
 	base := sling.
 		New().
 		Client(httpClient).
-		Base(baseURLWithAPI).
+		Base(baseUrl).
 		Set("Accept", `application/json`)
 
 	headers := getHeaders(credentials, requestingTool)
@@ -513,7 +513,11 @@ func getRoot(httpClient *http.Client, baseURLWithAPI string, credentials ICreden
 		base.Set(key, value)
 	}
 
-	rootService := NewRootService(base, baseURLWithAPI)
+	if !strings.HasSuffix(baseUrl, "/api") {
+		baseUrl = fmt.Sprintf("%s/api", baseUrl)
+	}
+
+	rootService := NewRootService(base, baseUrl)
 
 	root, err := rootService.Get()
 	return base, root, err

--- a/pkg/newclient/httpsession.go
+++ b/pkg/newclient/httpsession.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 // HttpSession is a layer over http.Client, and provides the following additional functionality:
@@ -40,6 +41,10 @@ func (h *HttpSession) DoRawRequest(req *http.Request) (*http.Response, error) {
 	}
 
 	if h.BaseURL != nil {
+		// a HTTP URL with a path needs to retain that path during ResolveReference by removing any leading / from the request URL
+		if h.BaseURL.Path != "" && strings.HasSuffix(h.BaseURL.Path, "/") {
+			req.URL, _ = url.Parse(strings.TrimLeft(req.URL.String(), "/"))
+		}
 		req.URL = h.BaseURL.ResolveReference(req.URL)
 	}
 


### PR DESCRIPTION
[sc-70983]

```
❯ octopus login --server https://ben-octo.australiaeast.cloudapp.azure.com/octopus --api-key API-apikey
Testing login to Octopus Server: https://ben-octo.australiaeast.cloudapp.azure.com/octopus
Configuring CLI to use API key for Octopus Server: https://ben-octo.australiaeast.cloudapp.azure.com/octopus
Login successful, happy deployments!

❯ octopus space list
NAME     DESCRIPTION  TASK QUEUE
Default               Running

❯ octopus login --server http://localhost:8065 --api-key API-apikey
Testing login to Octopus Server: http://localhost:8065
Configuring CLI to use API key for Octopus Server: http://localhost:8065
Login successful, happy deployments!

❯ octopus space list
NAME      DESCRIPTION  TASK QUEUE
Default                Running
tag sets               Running

```