### PR TITLE
Isaac/makr polling messageprocessing timeout optional

### DIFF
--- a/api/octopus_deploy.json
+++ b/api/octopus_deploy.json
@@ -33297,6 +33297,9 @@
         "Name": {
           "type": "string"
         },
+        "PollingRequestMaximumMessageProcessingTimeout": {
+          "type": "string"
+        },
         "PollingRequestQueueTimeout": {
           "type": "string"
         },

--- a/api/spec.json
+++ b/api/spec.json
@@ -4964,6 +4964,10 @@
         "Name": {
           "type": "string"
         },
+        "PollingRequestMaximumMessageProcessingTimeout": {
+          "format": "date-span",
+          "type": "string"
+        },
         "PollingRequestQueueTimeout": {
           "format": "date-span",
           "type": "string"

--- a/pkg/machinepolicies/machine_policy.go
+++ b/pkg/machinepolicies/machine_policy.go
@@ -10,55 +10,58 @@ import (
 )
 
 type MachinePolicy struct {
-	ConnectionConnectTimeout     time.Duration              `json:"ConnectionConnectTimeout" validate:"required,min=10s"`
-	ConnectionRetryCountLimit    int32                      `json:"ConnectionRetryCountLimit" validate:"required,gte=2"`
-	ConnectionRetrySleepInterval time.Duration              `json:"ConnectionRetrySleepInterval" validate:"required"`
-	ConnectionRetryTimeLimit     time.Duration              `json:"ConnectionRetryTimeLimit" validate:"required,min=10s"`
-	Description                  string                     `json:"Description,omitempty"`
-	IsDefault                    bool                       `json:"IsDefault"`
-	MachineCleanupPolicy         *MachineCleanupPolicy      `json:"MachineCleanupPolicy"`
-	MachineConnectivityPolicy    *MachineConnectivityPolicy `json:"MachineConnectivityPolicy"`
-	MachineHealthCheckPolicy     *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
-	MachineUpdatePolicy          *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
-	Name                         string                     `json:"Name" validate:"required,notblank"`
-	PollingRequestQueueTimeout   time.Duration              `json:"PollingRequestQueueTimeout" validate:"required"`
-	SpaceID                      string                     `json:"SpaceId,omitempty"`
+	ConnectionConnectTimeout                      time.Duration              `json:"ConnectionConnectTimeout" validate:"required,min=10s"`
+	ConnectionRetryCountLimit                     int32                      `json:"ConnectionRetryCountLimit" validate:"required,gte=2"`
+	ConnectionRetrySleepInterval                  time.Duration              `json:"ConnectionRetrySleepInterval" validate:"required"`
+	ConnectionRetryTimeLimit                      time.Duration              `json:"ConnectionRetryTimeLimit" validate:"required,min=10s"`
+	Description                                   string                     `json:"Description,omitempty"`
+	IsDefault                                     bool                       `json:"IsDefault"`
+	MachineCleanupPolicy                          *MachineCleanupPolicy      `json:"MachineCleanupPolicy"`
+	MachineConnectivityPolicy                     *MachineConnectivityPolicy `json:"MachineConnectivityPolicy"`
+	MachineHealthCheckPolicy                      *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
+	MachineUpdatePolicy                           *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
+	Name                                          string                     `json:"Name" validate:"required,notblank"`
+	PollingRequestMaximumMessageProcessingTimeout time.Duration              `json:"PollingRequestMaximumMessageProcessingTimeout" validate:"required"`
+	PollingRequestQueueTimeout                    time.Duration              `json:"PollingRequestQueueTimeout" validate:"required"`
+	SpaceID                                       string                     `json:"SpaceId,omitempty"`
 
 	resources.Resource
 }
 
 func NewMachinePolicy(name string) *MachinePolicy {
 	return &MachinePolicy{
-		ConnectionConnectTimeout:     time.Minute,
-		ConnectionRetryCountLimit:    5,
-		ConnectionRetrySleepInterval: time.Second,
-		ConnectionRetryTimeLimit:     5 * time.Minute,
-		MachineCleanupPolicy:         NewMachineCleanupPolicy(),
-		MachineConnectivityPolicy:    NewMachineConnectivityPolicy(),
-		MachineHealthCheckPolicy:     NewMachineHealthCheckPolicy(),
-		MachineUpdatePolicy:          NewMachineUpdatePolicy(),
-		Name:                         name,
-		PollingRequestQueueTimeout:   2 * time.Minute,
-		Resource:                     *resources.NewResource(),
+		ConnectionConnectTimeout:                      time.Minute,
+		ConnectionRetryCountLimit:                     5,
+		ConnectionRetrySleepInterval:                  time.Second,
+		ConnectionRetryTimeLimit:                      5 * time.Minute,
+		MachineCleanupPolicy:                          NewMachineCleanupPolicy(),
+		MachineConnectivityPolicy:                     NewMachineConnectivityPolicy(),
+		MachineHealthCheckPolicy:                      NewMachineHealthCheckPolicy(),
+		MachineUpdatePolicy:                           NewMachineUpdatePolicy(),
+		Name:                                          name,
+		PollingRequestMaximumMessageProcessingTimeout: 10 * time.Minute,
+		PollingRequestQueueTimeout:                    2 * time.Minute,
+		Resource:                                      *resources.NewResource(),
 	}
 }
 
 // MarshalJSON returns a machine policy as its JSON encoding.
 func (m *MachinePolicy) MarshalJSON() ([]byte, error) {
 	machinePolicy := struct {
-		ConnectionConnectTimeout     string                     `json:"ConnectionConnectTimeout" validate:"required"`
-		ConnectionRetryCountLimit    int32                      `json:"ConnectionRetryCountLimit" validate:"required"`
-		ConnectionRetrySleepInterval string                     `json:"ConnectionRetrySleepInterval" validate:"required"`
-		ConnectionRetryTimeLimit     string                     `json:"ConnectionRetryTimeLimit" validate:"required"`
-		Description                  string                     `json:"Description,omitempty"`
-		IsDefault                    bool                       `json:"IsDefault"`
-		MachineCleanupPolicy         *MachineCleanupPolicy      `json:"MachineCleanupPolicy"`
-		MachineConnectivityPolicy    *MachineConnectivityPolicy `json:"MachineConnectivityPolicy"`
-		MachineHealthCheckPolicy     *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
-		MachineUpdatePolicy          *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
-		Name                         string                     `json:"Name" validate:"required,notblank"`
-		PollingRequestQueueTimeout   string                     `json:"PollingRequestQueueTimeout" validate:"required"`
-		SpaceID                      string                     `json:"SpaceId,omitempty"`
+		ConnectionConnectTimeout                      string                     `json:"ConnectionConnectTimeout" validate:"required"`
+		ConnectionRetryCountLimit                     int32                      `json:"ConnectionRetryCountLimit" validate:"required"`
+		ConnectionRetrySleepInterval                  string                     `json:"ConnectionRetrySleepInterval" validate:"required"`
+		ConnectionRetryTimeLimit                      string                     `json:"ConnectionRetryTimeLimit" validate:"required"`
+		Description                                   string                     `json:"Description,omitempty"`
+		IsDefault                                     bool                       `json:"IsDefault"`
+		MachineCleanupPolicy                          *MachineCleanupPolicy      `json:"MachineCleanupPolicy"`
+		MachineConnectivityPolicy                     *MachineConnectivityPolicy `json:"MachineConnectivityPolicy"`
+		MachineHealthCheckPolicy                      *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
+		MachineUpdatePolicy                           *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
+		Name                                          string                     `json:"Name" validate:"required,notblank"`
+		PollingRequestMaximumMessageProcessingTimeout string                     `json:"PollingRequestMaximumMessageProcessingTimeout" validate:"required"`
+		PollingRequestQueueTimeout                    string                     `json:"PollingRequestQueueTimeout" validate:"required"`
+		SpaceID                                       string                     `json:"SpaceId,omitempty"`
 		resources.Resource
 	}{
 		ConnectionConnectTimeout:     ToTimeSpan(m.ConnectionConnectTimeout),
@@ -72,9 +75,10 @@ func (m *MachinePolicy) MarshalJSON() ([]byte, error) {
 		MachineHealthCheckPolicy:     m.MachineHealthCheckPolicy,
 		MachineUpdatePolicy:          m.MachineUpdatePolicy,
 		Name:                         m.Name,
-		PollingRequestQueueTimeout:   ToTimeSpan(m.PollingRequestQueueTimeout),
-		SpaceID:                      m.SpaceID,
-		Resource:                     m.Resource,
+		PollingRequestMaximumMessageProcessingTimeout: ToTimeSpan(m.PollingRequestMaximumMessageProcessingTimeout),
+		PollingRequestQueueTimeout:                    ToTimeSpan(m.PollingRequestQueueTimeout),
+		SpaceID:                                       m.SpaceID,
+		Resource:                                      m.Resource,
 	}
 
 	return json.Marshal(machinePolicy)
@@ -83,19 +87,20 @@ func (m *MachinePolicy) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON sets this Kubernetes endpoint to its representation in JSON.
 func (m *MachinePolicy) UnmarshalJSON(data []byte) error {
 	var fields struct {
-		ConnectionConnectTimeout     string                     `json:"ConnectionConnectTimeout" validate:"required"`
-		ConnectionRetryCountLimit    int32                      `json:"ConnectionRetryCountLimit" validate:"required"`
-		ConnectionRetrySleepInterval string                     `json:"ConnectionRetrySleepInterval" validate:"required"`
-		ConnectionRetryTimeLimit     string                     `json:"ConnectionRetryTimeLimit" validate:"required"`
-		Description                  string                     `json:"Description,omitempty"`
-		IsDefault                    bool                       `json:"IsDefault"`
-		MachineCleanupPolicy         *MachineCleanupPolicy      `json:"MachineCleanupPolicy"`
-		MachineConnectivityPolicy    *MachineConnectivityPolicy `json:"MachineConnectivityPolicy"`
-		MachineHealthCheckPolicy     *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
-		MachineUpdatePolicy          *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
-		Name                         string                     `json:"Name"`
-		PollingRequestQueueTimeout   string                     `json:"PollingRequestQueueTimeout" validate:"required"`
-		SpaceID                      string                     `json:"SpaceId,omitempty"`
+		ConnectionConnectTimeout                      string                     `json:"ConnectionConnectTimeout" validate:"required"`
+		ConnectionRetryCountLimit                     int32                      `json:"ConnectionRetryCountLimit" validate:"required"`
+		ConnectionRetrySleepInterval                  string                     `json:"ConnectionRetrySleepInterval" validate:"required"`
+		ConnectionRetryTimeLimit                      string                     `json:"ConnectionRetryTimeLimit" validate:"required"`
+		Description                                   string                     `json:"Description,omitempty"`
+		IsDefault                                     bool                       `json:"IsDefault"`
+		MachineCleanupPolicy                          *MachineCleanupPolicy      `json:"MachineCleanupPolicy"`
+		MachineConnectivityPolicy                     *MachineConnectivityPolicy `json:"MachineConnectivityPolicy"`
+		MachineHealthCheckPolicy                      *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
+		MachineUpdatePolicy                           *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
+		Name                                          string                     `json:"Name"`
+		PollingRequestMaximumMessageProcessingTimeout string                     `json:"PollingRequestMaximumMessageProcessingTimeout" validate:"required"`
+		PollingRequestQueueTimeout                    string                     `json:"PollingRequestQueueTimeout" validate:"required"`
+		SpaceID                                       string                     `json:"SpaceId,omitempty"`
 		resources.Resource
 	}
 	err := json.Unmarshal(data, &fields)
@@ -124,6 +129,10 @@ func (m *MachinePolicy) UnmarshalJSON(data []byte) error {
 
 	if len(fields.ConnectionRetryTimeLimit) > 0 {
 		m.ConnectionRetryTimeLimit = FromTimeSpan(fields.ConnectionRetryTimeLimit)
+	}
+
+	if len(fields.PollingRequestMaximumMessageProcessingTimeout) > 0 {
+		m.PollingRequestMaximumMessageProcessingTimeout = FromTimeSpan(fields.PollingRequestMaximumMessageProcessingTimeout)
 	}
 
 	if len(fields.PollingRequestQueueTimeout) > 0 {

--- a/pkg/machinepolicies/machine_policy.go
+++ b/pkg/machinepolicies/machine_policy.go
@@ -21,7 +21,7 @@ type MachinePolicy struct {
 	MachineHealthCheckPolicy                      *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
 	MachineUpdatePolicy                           *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
 	Name                                          string                     `json:"Name" validate:"required,notblank"`
-	PollingRequestMaximumMessageProcessingTimeout time.Duration              `json:"PollingRequestMaximumMessageProcessingTimeout" validate:"required"`
+	PollingRequestMaximumMessageProcessingTimeout time.Duration              `json:"PollingRequestMaximumMessageProcessingTimeout,omitempty"`
 	PollingRequestQueueTimeout                    time.Duration              `json:"PollingRequestQueueTimeout" validate:"required"`
 	SpaceID                                       string                     `json:"SpaceId,omitempty"`
 
@@ -59,7 +59,7 @@ func (m *MachinePolicy) MarshalJSON() ([]byte, error) {
 		MachineHealthCheckPolicy                      *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
 		MachineUpdatePolicy                           *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
 		Name                                          string                     `json:"Name" validate:"required,notblank"`
-		PollingRequestMaximumMessageProcessingTimeout string                     `json:"PollingRequestMaximumMessageProcessingTimeout" validate:"required"`
+		PollingRequestMaximumMessageProcessingTimeout string                     `json:"PollingRequestMaximumMessageProcessingTimeout,omitempty"`
 		PollingRequestQueueTimeout                    string                     `json:"PollingRequestQueueTimeout" validate:"required"`
 		SpaceID                                       string                     `json:"SpaceId,omitempty"`
 		resources.Resource
@@ -98,7 +98,7 @@ func (m *MachinePolicy) UnmarshalJSON(data []byte) error {
 		MachineHealthCheckPolicy                      *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
 		MachineUpdatePolicy                           *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
 		Name                                          string                     `json:"Name"`
-		PollingRequestMaximumMessageProcessingTimeout string                     `json:"PollingRequestMaximumMessageProcessingTimeout" validate:"required"`
+		PollingRequestMaximumMessageProcessingTimeout string                     `json:"PollingRequestMaximumMessageProcessingTimeout,omitempty"`
 		PollingRequestQueueTimeout                    string                     `json:"PollingRequestQueueTimeout" validate:"required"`
 		SpaceID                                       string                     `json:"SpaceId,omitempty"`
 		resources.Resource

--- a/pkg/machines/machine_policy.go
+++ b/pkg/machines/machine_policy.go
@@ -10,55 +10,58 @@ import (
 )
 
 type MachinePolicy struct {
-	ConnectionConnectTimeout     time.Duration              `json:"ConnectionConnectTimeout" validate:"required,min=10s"`
-	ConnectionRetryCountLimit    int32                      `json:"ConnectionRetryCountLimit" validate:"required,gte=2"`
-	ConnectionRetrySleepInterval time.Duration              `json:"ConnectionRetrySleepInterval" validate:"required"`
-	ConnectionRetryTimeLimit     time.Duration              `json:"ConnectionRetryTimeLimit" validate:"required,min=10s"`
-	Description                  string                     `json:"Description,omitempty"`
-	IsDefault                    bool                       `json:"IsDefault"`
-	MachineCleanupPolicy         *MachineCleanupPolicy      `json:"MachineCleanupPolicy"`
-	MachineConnectivityPolicy    *MachineConnectivityPolicy `json:"MachineConnectivityPolicy"`
-	MachineHealthCheckPolicy     *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
-	MachineUpdatePolicy          *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
-	Name                         string                     `json:"Name" validate:"required,notblank"`
-	PollingRequestQueueTimeout   time.Duration              `json:"PollingRequestQueueTimeout" validate:"required"`
-	SpaceID                      string                     `json:"SpaceId,omitempty"`
+	ConnectionConnectTimeout                      time.Duration              `json:"ConnectionConnectTimeout" validate:"required,min=10s"`
+	ConnectionRetryCountLimit                     int32                      `json:"ConnectionRetryCountLimit" validate:"required,gte=2"`
+	ConnectionRetrySleepInterval                  time.Duration              `json:"ConnectionRetrySleepInterval" validate:"required"`
+	ConnectionRetryTimeLimit                      time.Duration              `json:"ConnectionRetryTimeLimit" validate:"required,min=10s"`
+	Description                                   string                     `json:"Description,omitempty"`
+	IsDefault                                     bool                       `json:"IsDefault"`
+	MachineCleanupPolicy                          *MachineCleanupPolicy      `json:"MachineCleanupPolicy"`
+	MachineConnectivityPolicy                     *MachineConnectivityPolicy `json:"MachineConnectivityPolicy"`
+	MachineHealthCheckPolicy                      *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
+	MachineUpdatePolicy                           *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
+	Name                                          string                     `json:"Name" validate:"required,notblank"`
+	PollingRequestMaximumMessageProcessingTimeout time.Duration              `json:"PollingRequestMaximumMessageProcessingTimeout" validate:"required"`
+	PollingRequestQueueTimeout                    time.Duration              `json:"PollingRequestQueueTimeout" validate:"required"`
+	SpaceID                                       string                     `json:"SpaceId,omitempty"`
 
 	resources.Resource
 }
 
 func NewMachinePolicy(name string) *MachinePolicy {
 	return &MachinePolicy{
-		ConnectionConnectTimeout:     time.Minute,
-		ConnectionRetryCountLimit:    5,
-		ConnectionRetrySleepInterval: time.Second,
-		ConnectionRetryTimeLimit:     5 * time.Minute,
-		MachineCleanupPolicy:         NewMachineCleanupPolicy(),
-		MachineConnectivityPolicy:    NewMachineConnectivityPolicy(),
-		MachineHealthCheckPolicy:     NewMachineHealthCheckPolicy(),
-		MachineUpdatePolicy:          NewMachineUpdatePolicy(),
-		Name:                         name,
-		PollingRequestQueueTimeout:   2 * time.Minute,
-		Resource:                     *resources.NewResource(),
+		ConnectionConnectTimeout:                      time.Minute,
+		ConnectionRetryCountLimit:                     5,
+		ConnectionRetrySleepInterval:                  time.Second,
+		ConnectionRetryTimeLimit:                      5 * time.Minute,
+		MachineCleanupPolicy:                          NewMachineCleanupPolicy(),
+		MachineConnectivityPolicy:                     NewMachineConnectivityPolicy(),
+		MachineHealthCheckPolicy:                      NewMachineHealthCheckPolicy(),
+		MachineUpdatePolicy:                           NewMachineUpdatePolicy(),
+		Name:                                          name,
+		PollingRequestMaximumMessageProcessingTimeout: 10 * time.Minute,
+		PollingRequestQueueTimeout:                    2 * time.Minute,
+		Resource:                                      *resources.NewResource(),
 	}
 }
 
 // MarshalJSON returns a machine policy as its JSON encoding.
 func (m *MachinePolicy) MarshalJSON() ([]byte, error) {
 	machinePolicy := struct {
-		ConnectionConnectTimeout     string                     `json:"ConnectionConnectTimeout" validate:"required"`
-		ConnectionRetryCountLimit    int32                      `json:"ConnectionRetryCountLimit" validate:"required"`
-		ConnectionRetrySleepInterval string                     `json:"ConnectionRetrySleepInterval" validate:"required"`
-		ConnectionRetryTimeLimit     string                     `json:"ConnectionRetryTimeLimit" validate:"required"`
-		Description                  string                     `json:"Description,omitempty"`
-		IsDefault                    bool                       `json:"IsDefault"`
-		MachineCleanupPolicy         *MachineCleanupPolicy      `json:"MachineCleanupPolicy"`
-		MachineConnectivityPolicy    *MachineConnectivityPolicy `json:"MachineConnectivityPolicy"`
-		MachineHealthCheckPolicy     *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
-		MachineUpdatePolicy          *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
-		Name                         string                     `json:"Name" validate:"required,notblank"`
-		PollingRequestQueueTimeout   string                     `json:"PollingRequestQueueTimeout" validate:"required"`
-		SpaceID                      string                     `json:"SpaceId,omitempty"`
+		ConnectionConnectTimeout                      string                     `json:"ConnectionConnectTimeout" validate:"required"`
+		ConnectionRetryCountLimit                     int32                      `json:"ConnectionRetryCountLimit" validate:"required"`
+		ConnectionRetrySleepInterval                  string                     `json:"ConnectionRetrySleepInterval" validate:"required"`
+		ConnectionRetryTimeLimit                      string                     `json:"ConnectionRetryTimeLimit" validate:"required"`
+		Description                                   string                     `json:"Description,omitempty"`
+		IsDefault                                     bool                       `json:"IsDefault"`
+		MachineCleanupPolicy                          *MachineCleanupPolicy      `json:"MachineCleanupPolicy"`
+		MachineConnectivityPolicy                     *MachineConnectivityPolicy `json:"MachineConnectivityPolicy"`
+		MachineHealthCheckPolicy                      *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
+		MachineUpdatePolicy                           *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
+		Name                                          string                     `json:"Name" validate:"required,notblank"`
+		PollingRequestMaximumMessageProcessingTimeout string                     `json:"PollingRequestMaximumMessageProcessingTimeout" validate:"required"`
+		PollingRequestQueueTimeout                    string                     `json:"PollingRequestQueueTimeout" validate:"required"`
+		SpaceID                                       string                     `json:"SpaceId,omitempty"`
 		resources.Resource
 	}{
 		ConnectionConnectTimeout:     ToTimeSpan(m.ConnectionConnectTimeout),
@@ -72,9 +75,10 @@ func (m *MachinePolicy) MarshalJSON() ([]byte, error) {
 		MachineHealthCheckPolicy:     m.MachineHealthCheckPolicy,
 		MachineUpdatePolicy:          m.MachineUpdatePolicy,
 		Name:                         m.Name,
-		PollingRequestQueueTimeout:   ToTimeSpan(m.PollingRequestQueueTimeout),
-		SpaceID:                      m.SpaceID,
-		Resource:                     m.Resource,
+		PollingRequestMaximumMessageProcessingTimeout: ToTimeSpan(m.PollingRequestMaximumMessageProcessingTimeout),
+		PollingRequestQueueTimeout:                    ToTimeSpan(m.PollingRequestQueueTimeout),
+		SpaceID:                                       m.SpaceID,
+		Resource:                                      m.Resource,
 	}
 
 	return json.Marshal(machinePolicy)
@@ -83,19 +87,20 @@ func (m *MachinePolicy) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON sets this Kubernetes endpoint to its representation in JSON.
 func (m *MachinePolicy) UnmarshalJSON(data []byte) error {
 	var fields struct {
-		ConnectionConnectTimeout     string                     `json:"ConnectionConnectTimeout" validate:"required"`
-		ConnectionRetryCountLimit    int32                      `json:"ConnectionRetryCountLimit" validate:"required"`
-		ConnectionRetrySleepInterval string                     `json:"ConnectionRetrySleepInterval" validate:"required"`
-		ConnectionRetryTimeLimit     string                     `json:"ConnectionRetryTimeLimit" validate:"required"`
-		Description                  string                     `json:"Description,omitempty"`
-		IsDefault                    bool                       `json:"IsDefault"`
-		MachineCleanupPolicy         *MachineCleanupPolicy      `json:"MachineCleanupPolicy"`
-		MachineConnectivityPolicy    *MachineConnectivityPolicy `json:"MachineConnectivityPolicy"`
-		MachineHealthCheckPolicy     *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
-		MachineUpdatePolicy          *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
-		Name                         string                     `json:"Name"`
-		PollingRequestQueueTimeout   string                     `json:"PollingRequestQueueTimeout" validate:"required"`
-		SpaceID                      string                     `json:"SpaceId,omitempty"`
+		ConnectionConnectTimeout                      string                     `json:"ConnectionConnectTimeout" validate:"required"`
+		ConnectionRetryCountLimit                     int32                      `json:"ConnectionRetryCountLimit" validate:"required"`
+		ConnectionRetrySleepInterval                  string                     `json:"ConnectionRetrySleepInterval" validate:"required"`
+		ConnectionRetryTimeLimit                      string                     `json:"ConnectionRetryTimeLimit" validate:"required"`
+		Description                                   string                     `json:"Description,omitempty"`
+		IsDefault                                     bool                       `json:"IsDefault"`
+		MachineCleanupPolicy                          *MachineCleanupPolicy      `json:"MachineCleanupPolicy"`
+		MachineConnectivityPolicy                     *MachineConnectivityPolicy `json:"MachineConnectivityPolicy"`
+		MachineHealthCheckPolicy                      *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
+		MachineUpdatePolicy                           *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
+		Name                                          string                     `json:"Name"`
+		PollingRequestMaximumMessageProcessingTimeout string                     `json:"PollingRequestMaximumMessageProcessingTimeout" validate:"required"`
+		PollingRequestQueueTimeout                    string                     `json:"PollingRequestQueueTimeout" validate:"required"`
+		SpaceID                                       string                     `json:"SpaceId,omitempty"`
 		resources.Resource
 	}
 	err := json.Unmarshal(data, &fields)
@@ -124,6 +129,10 @@ func (m *MachinePolicy) UnmarshalJSON(data []byte) error {
 
 	if len(fields.ConnectionRetryTimeLimit) > 0 {
 		m.ConnectionRetryTimeLimit = FromTimeSpan(fields.ConnectionRetryTimeLimit)
+	}
+
+	if len(fields.PollingRequestMaximumMessageProcessingTimeout) > 0 {
+		m.PollingRequestMaximumMessageProcessingTimeout = FromTimeSpan(fields.PollingRequestMaximumMessageProcessingTimeout)
 	}
 
 	if len(fields.PollingRequestQueueTimeout) > 0 {

--- a/pkg/machines/machine_policy.go
+++ b/pkg/machines/machine_policy.go
@@ -21,7 +21,7 @@ type MachinePolicy struct {
 	MachineHealthCheckPolicy                      *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
 	MachineUpdatePolicy                           *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
 	Name                                          string                     `json:"Name" validate:"required,notblank"`
-	PollingRequestMaximumMessageProcessingTimeout time.Duration              `json:"PollingRequestMaximumMessageProcessingTimeout" validate:"required"`
+	PollingRequestMaximumMessageProcessingTimeout time.Duration              `json:"PollingRequestMaximumMessageProcessingTimeout,omitempty"`
 	PollingRequestQueueTimeout                    time.Duration              `json:"PollingRequestQueueTimeout" validate:"required"`
 	SpaceID                                       string                     `json:"SpaceId,omitempty"`
 
@@ -59,7 +59,7 @@ func (m *MachinePolicy) MarshalJSON() ([]byte, error) {
 		MachineHealthCheckPolicy                      *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
 		MachineUpdatePolicy                           *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
 		Name                                          string                     `json:"Name" validate:"required,notblank"`
-		PollingRequestMaximumMessageProcessingTimeout string                     `json:"PollingRequestMaximumMessageProcessingTimeout" validate:"required"`
+		PollingRequestMaximumMessageProcessingTimeout string                     `json:"PollingRequestMaximumMessageProcessingTimeout,omitempty"`
 		PollingRequestQueueTimeout                    string                     `json:"PollingRequestQueueTimeout" validate:"required"`
 		SpaceID                                       string                     `json:"SpaceId,omitempty"`
 		resources.Resource
@@ -98,7 +98,7 @@ func (m *MachinePolicy) UnmarshalJSON(data []byte) error {
 		MachineHealthCheckPolicy                      *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
 		MachineUpdatePolicy                           *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
 		Name                                          string                     `json:"Name"`
-		PollingRequestMaximumMessageProcessingTimeout string                     `json:"PollingRequestMaximumMessageProcessingTimeout" validate:"required"`
+		PollingRequestMaximumMessageProcessingTimeout string                     `json:"PollingRequestMaximumMessageProcessingTimeout,omitempty"`
 		PollingRequestQueueTimeout                    string                     `json:"PollingRequestQueueTimeout" validate:"required"`
 		SpaceID                                       string                     `json:"SpaceId,omitempty"`
 		resources.Resource

--- a/pkg/machines/machine_policy_service_test.go
+++ b/pkg/machines/machine_policy_service_test.go
@@ -27,6 +27,7 @@ func CreateTestMachinePolicy(t *testing.T, service *MachinePolicyService) *Machi
 	connectionConnectTimeout := getRandomDuration(10)
 	connectionRetrySleepInterval := getRandomDuration(1)
 	connectionRetryTimeLimit := getRandomDuration(10)
+	pollingRequestMaximumMessageProcessingTimeout := getRandomDuration(20)
 	pollingRequestQueueTimeout := getRandomDuration(10)
 
 	machineCleanupPolicy := NewMachineCleanupPolicy()
@@ -41,6 +42,7 @@ func CreateTestMachinePolicy(t *testing.T, service *MachinePolicyService) *Machi
 	machinePolicy.ConnectionRetryTimeLimit = connectionRetryTimeLimit
 	machinePolicy.MachineCleanupPolicy = machineCleanupPolicy
 	machinePolicy.MachineHealthCheckPolicy = machineHealthCheckPolicy
+	machinePolicy.PollingRequestMaximumMessageProcessingTimeout = pollingRequestMaximumMessageProcessingTimeout
 	machinePolicy.PollingRequestQueueTimeout = pollingRequestQueueTimeout
 	require.NoError(t, machinePolicy.Validate())
 
@@ -96,6 +98,7 @@ func IsEqualMachinePolicies(t *testing.T, expected *MachinePolicy, actual *Machi
 	assert.Equal(t, expected.MachineHealthCheckPolicy, actual.MachineHealthCheckPolicy)
 	assert.Equal(t, expected.MachineUpdatePolicy, actual.MachineUpdatePolicy)
 	assert.Equal(t, expected.Name, actual.Name)
+	assert.Equal(t, expected.PollingRequestMaximumMessageProcessingTimeout, actual.PollingRequestMaximumMessageProcessingTimeout)
 	assert.Equal(t, expected.PollingRequestQueueTimeout, actual.PollingRequestQueueTimeout)
 	assert.Equal(t, expected.SpaceID, actual.SpaceID)
 }


### PR DESCRIPTION
https://github.com/OctopusDeploy/OctopusDeploy/pull/22899/files Removed support for the PollingRequestMaximumMessageProcessingTimeout. This makes the property optional for backwards compatibility in the  terraform provider.