### PR TITLE
Rename DeploymentAction to DeploymentActionSlug for external feed trigger packages

### DIFF
--- a/api/octopus_deploy.json
+++ b/api/octopus_deploy.json
@@ -38987,7 +38987,8 @@
             "AutoDeploy",
             "DeployLatestRelease",
             "DeployNewRelease",
-            "RunRunbook"
+            "RunRunbook",
+            "CreateRelease"
           ],
           "type": "string",
           "readOnly": true
@@ -39021,7 +39022,8 @@
             "DaysPerMonthSchedule",
             "DaysPerWeekSchedule",
             "MachineFilter",
-            "OnceDailySchedule"
+            "OnceDailySchedule",
+            "FeedFilter"
           ],
           "type": "string",
           "readOnly": true

--- a/api/spec.json
+++ b/api/spec.json
@@ -9804,7 +9804,8 @@
         "AutoDeploy",
         "DeployLatestRelease",
         "DeployNewRelease",
-        "RunRunbook"
+        "RunRunbook",
+        "CreateRelease"
       ],
       "type": "string"
     },
@@ -9840,7 +9841,8 @@
         "DaysPerMonthSchedule",
         "CronExpressionSchedule",
         "OnceDailySchedule",
-        "ContinuousDailySchedule"
+        "ContinuousDailySchedule",
+        "FeedFilter"
       ],
       "type": "string"
     },

--- a/pkg/filters/feed_trigger_filter.go
+++ b/pkg/filters/feed_trigger_filter.go
@@ -3,12 +3,12 @@ package filters
 import "github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/packages"
 
 type FeedTriggerFilter struct {
-	Packages []packages.DeploymentActionPackage `json:"Packages,omitempty"`
+	Packages []packages.DeploymentActionSlugPackage `json:"Packages,omitempty"`
 
 	triggerFilter
 }
 
-func NewFeedTriggerFilter(packages []packages.DeploymentActionPackage) *FeedTriggerFilter {
+func NewFeedTriggerFilter(packages []packages.DeploymentActionSlugPackage) *FeedTriggerFilter {
 	return &FeedTriggerFilter{
 		Packages:      packages,
 		triggerFilter: *newTriggerFilter(FeedFilter),

--- a/pkg/packages/deployment_action_slug_package.go
+++ b/pkg/packages/deployment_action_slug_package.go
@@ -1,0 +1,6 @@
+package packages
+
+type DeploymentActionSlugPackage struct {
+	DeploymentActionSlug string `json:"DeploymentActionSlug,omitempty"`
+	PackageReference     string `json:"PackageReference,omitempty"`
+}


### PR DESCRIPTION
## Background

There was a breaking [change](https://github.com/OctopusDeploy/OctopusDeploy/pull/24178) to the Project Trigger API for external feed triggers. `DeploymentAction` is now replaced by `DeploymentActionSlug` which means that the Octopus Terraform provider also needs to be updated accordingly.