### PR TITLE
Use the standard method for generating a get ID URL

### DIFF
--- a/pkg/triggers/project_trigger_service.go
+++ b/pkg/triggers/project_trigger_service.go
@@ -29,7 +29,12 @@ func (s *ProjectTriggerService) GetByID(id string) (*ProjectTrigger, error) {
 		return nil, internal.CreateInvalidParameterError(constants.OperationGetByID, constants.ParameterID)
 	}
 
-	path := fmt.Sprintf("/api/projecttriggers/%s", id)
+	path, err := services.GetByIDPath(s, id)
+
+	if err != nil {
+		return nil, err
+	}
+
 	resp, err := api.ApiGet(s.GetClient(), new(ProjectTrigger), path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The call to get a project trigger does not include the space ID, leading to resources not being found. 

For example, this is the error from the terraform provider:

```
Error: Octopus API error: Resource is not found or it doesn't exist in the current space context. Please contact your administrator for more information. []  
  with octopusdeploy_project_scheduled_trigger.projecttrigger_octopub___all___yaml_deploy_to_development__apac_, 
  on projecttrigger_octopub___all___yaml_deploy_to_development__apac_.tf line 1, in resource "octopusdeploy_project_scheduled_trigger" "projecttrigger_octopub___all___yaml_deploy_to_development__apac_": 
   1: resource "octopusdeploy_project_scheduled_trigger" "projecttrigger_octopub___all___yaml_deploy_to_development__apac_" { 
```

This PR uses the standard method to generate a URL for getting resources.