### PR TITLE
Add slug to DeploymentAction model

### DIFF
--- a/api/octopus_deploy.json
+++ b/api/octopus_deploy.json
@@ -31225,6 +31225,10 @@
           },
           "readOnly": true
         },
+        "Slug": {
+          "type": "string",
+          "readOnly": true
+        },
         "TenantTags": {
           "type": "array",
           "items": {

--- a/api/spec.json
+++ b/api/spec.json
@@ -2390,6 +2390,10 @@
           },
           "readOnly": true
         },
+        "Slug": {
+          "type": "string",
+          "readOnly": true
+        },
         "TenantTags": {
           "uniqueItems": true,
           "type": "array",

--- a/pkg/deployments/deployment_action.go
+++ b/pkg/deployments/deployment_action.go
@@ -11,6 +11,7 @@ import (
 
 type DeploymentAction struct {
 	ActionType                    string                           `json:"ActionType" validate:"required,notblank"`
+	Slug                          string                           `json:"Slug,omitempty"`
 	CanBeUsedForProjectVersioning bool                             `json:"CanBeUsedForProjectVersioning"`
 	Channels                      []string                         `json:"Channels,omitempty"`
 	Condition                     string                           `json:"Condition,omitempty"`


### PR DESCRIPTION
The `slug` field is [needed](https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/pull/634#discussion_r1588772057) by the Terraform provider as a computed field such that it can be referenced by Terraform resources that depend on it, e.g. External feed triggers.