### PR TITLE
feat: Add kubernetes agent

### DIFF
--- a/pkg/machines/endpoint.go
+++ b/pkg/machines/endpoint.go
@@ -15,7 +15,7 @@ type IEndpoint interface {
 // endpoint is the base definition of an endpoint and describes its
 // communication style (SSH, Kubernetes, etc.)
 type endpoint struct {
-	CommunicationStyle string `json:"CommunicationStyle,omitempty" validate:"required,oneof=AzureCloudService AzureServiceFabricCluster AzureWebApp Ftp Kubernetes None OfflineDrop Ssh TentacleActive TentaclePassive"`
+	CommunicationStyle string `json:"CommunicationStyle,omitempty" validate:"required,oneof=AzureCloudService AzureServiceFabricCluster AzureWebApp Ftp Kubernetes None OfflineDrop Ssh TentacleActive TentaclePassive KubernetesTentacle"`
 
 	resources.Resource
 }

--- a/pkg/machines/endpoint_resource.go
+++ b/pkg/machines/endpoint_resource.go
@@ -25,7 +25,7 @@ type EndpointResource struct {
 	ClusterCertificate                   string                                 `json:"ClusterCertificate,omitempty"`
 	ClusterCertificatePath               string                                 `json:"ClusterCertificatePath,omitempty"`
 	ClusterURL                           *url.URL                               `json:"ClusterUrl" validate:"required,url"`
-	CommunicationStyle                   string                                 `json:"CommunicationStyle" validate:"required,oneof=AzureCloudService AzureServiceFabricCluster Ftp Kubernetes None OfflineDrop Ssh TentacleActive TentaclePassive"`
+	CommunicationStyle                   string                                 `json:"CommunicationStyle" validate:"required,oneof=AzureCloudService AzureServiceFabricCluster Ftp Kubernetes None OfflineDrop Ssh TentacleActive TentaclePassive KubernetesTentacle"`
 	ConnectionEndpoint                   string                                 `json:"ConnectionEndpoint,omitempty"`
 	Container                            *deployments.DeploymentActionContainer `json:"Container,omitempty"`
 	ContainerOptions                     string                                 `json:"ContainerOptions,omitempty"`

--- a/pkg/machines/kubernetes_agent_details.go
+++ b/pkg/machines/kubernetes_agent_details.go
@@ -1,0 +1,9 @@
+package machines
+
+type KubernetesAgentDetails struct {
+	AgentVersion        string `json:"AgentVersion"`
+	TentacleVersion     string `json:"TentacleVersion"`
+	UpgradeStatus       string `json:"UpgradeStatus"`
+	HelmReleaseName     string `json:"HelmReleaseName"`
+	KubernetesNamespace string `json:"KubernetesNamespace"`
+}

--- a/pkg/machines/kubernetes_agent_details.go
+++ b/pkg/machines/kubernetes_agent_details.go
@@ -3,7 +3,7 @@ package machines
 type KubernetesAgentDetails struct {
 	AgentVersion        string `json:"AgentVersion"`
 	TentacleVersion     string `json:"TentacleVersion"`
-	UpgradeStatus       string `json:"UpgradeStatus"`
+	UpgradeStatus       string `json:"UpgradeStatus" validate:"oneof=NoUpgrades UpgradeAvailable UpgradeSuggested UpgradeRequired"`
 	HelmReleaseName     string `json:"HelmReleaseName"`
 	KubernetesNamespace string `json:"KubernetesNamespace"`
 }

--- a/pkg/machines/kubernetes_tentacle_endpoint.go
+++ b/pkg/machines/kubernetes_tentacle_endpoint.go
@@ -1,0 +1,76 @@
+package machines
+
+import (
+	"encoding/json"
+	"github.com/go-playground/validator/v10"
+	"net/url"
+)
+
+type KubernetesTentacleEndpoint struct {
+	TentacleEndpointConfiguration *TentacleEndpointConfiguration `json:"TentacleEndpointConfiguration" validate:"required"`
+	KubernetesAgentDetails        *KubernetesAgentDetails        `json:"KubernetesAgentDetails,omitempty"`
+	UpgradeLocked                 bool                           `json:"UpgradeLocked"`
+	DefaultNamespace              string                         `json:"DefaultNamespace,omitempty"`
+
+	endpoint `validate:"required"`
+}
+
+func NewKubernetesTentacleEndpoint(uri *url.URL, thumbprint string, upgradeLocked bool, communicationsMode string, defaultNamespace string) *KubernetesTentacleEndpoint {
+	return &KubernetesTentacleEndpoint{
+		TentacleEndpointConfiguration: &TentacleEndpointConfiguration{
+			Thumbprint:        thumbprint,
+			URI:               uri,
+			CommunicationMode: communicationsMode,
+		},
+		UpgradeLocked:    upgradeLocked,
+		DefaultNamespace: defaultNamespace,
+		endpoint:         *newEndpoint("KubernetesTentacle"),
+	}
+}
+
+func (l KubernetesTentacleEndpoint) MarshalJSON() ([]byte, error) {
+	te := struct {
+		TentacleEndpointConfiguration *TentacleEndpointConfiguration `json:"TentacleEndpointConfiguration" validate:"required"`
+		KubernetesAgentDetails        *KubernetesAgentDetails        `json:"KubernetesAgentDetails,omitempty"`
+		UpgradeLocked                 bool                           `json:"UpgradeLocked"`
+		DefaultNamespace              string                         `json:"DefaultNamespace,omitempty"`
+
+		endpoint
+	}{
+		TentacleEndpointConfiguration: l.TentacleEndpointConfiguration,
+		KubernetesAgentDetails:        l.KubernetesAgentDetails,
+		endpoint:                      l.endpoint,
+	}
+
+	return json.Marshal(te)
+}
+
+// UnmarshalJSON sets this tentacle endpoint to its representation in JSON.
+func (l *KubernetesTentacleEndpoint) UnmarshalJSON(b []byte) error {
+	var fields struct {
+		TentacleEndpointConfiguration *TentacleEndpointConfiguration `json:"TentacleEndpointConfiguration" validate:"required"`
+		KubernetesAgentDetails        *KubernetesAgentDetails        `json:"KubernetesAgentDetails,omitempty"`
+		UpgradeLocked                 bool                           `json:"UpgradeLocked"`
+		DefaultNamespace              string                         `json:"DefaultNamespace,omitempty"`
+
+		endpoint
+	}
+
+	if err := json.Unmarshal(b, &fields); err != nil {
+		return err
+	}
+
+	// validate JSON representation
+	validate := validator.New()
+	if err := validate.Struct(fields); err != nil {
+		return err
+	}
+
+	l.TentacleEndpointConfiguration = fields.TentacleEndpointConfiguration
+	l.KubernetesAgentDetails = fields.KubernetesAgentDetails
+	l.UpgradeLocked = fields.UpgradeLocked
+	l.DefaultNamespace = fields.DefaultNamespace
+	l.endpoint = fields.endpoint
+
+	return nil
+}

--- a/pkg/machines/machine.go
+++ b/pkg/machines/machine.go
@@ -199,6 +199,12 @@ func (m *machine) UnmarshalJSON(b []byte) error {
 			return err
 		}
 		m.Endpoint = listeningTentacleEndpoint
+	case "KubernetesTentacle":
+		var kubernetesTentacleEndpoint *KubernetesTentacleEndpoint
+		if err := json.Unmarshal(*endpoint, &kubernetesTentacleEndpoint); err != nil {
+			return err
+		}
+		m.Endpoint = kubernetesTentacleEndpoint
 	}
 
 	return nil

--- a/pkg/machines/tentacle_endpoint_configuration.go
+++ b/pkg/machines/tentacle_endpoint_configuration.go
@@ -1,0 +1,57 @@
+package machines
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+type TentacleEndpointConfiguration struct {
+	CertificateSignatureAlgorithm string   `json:"CertificateSignatureAlgorithm,omitempty"`
+	Thumbprint                    string   `json:"Thumbprint" validate:"required"`
+	URI                           *url.URL `json:"Uri" validate:"required,uri"`
+	CommunicationMode             string   `json:"CommunicationMode" validate:"required,oneof=Polling Listening"`
+}
+
+func (l TentacleEndpointConfiguration) MarshalJSON() ([]byte, error) {
+	te := struct {
+		CertificateSignatureAlgorithm string `json:"CertificateSignatureAlgorithm,omitempty"`
+		Thumbprint                    string `json:"Thumbprint" validate:"required"`
+		URI                           string `json:"Uri" validate:"required,uri"`
+		CommunicationMode             string `json:"CommunicationMode" validate:"required,oneof=Polling Listening"`
+	}{
+		CertificateSignatureAlgorithm: l.CertificateSignatureAlgorithm,
+		Thumbprint:                    l.Thumbprint,
+		CommunicationMode:             l.CommunicationMode,
+	}
+
+	if l.URI != nil {
+		te.URI = l.URI.String()
+	}
+
+	return json.Marshal(te)
+}
+
+func (l *TentacleEndpointConfiguration) UnmarshalJSON(b []byte) error {
+	var fields struct {
+		CertificateSignatureAlgorithm string `json:"CertificateSignatureAlgorithm,omitempty"`
+		Thumbprint                    string `json:"Thumbprint" validate:"required"`
+		URI                           string `json:"Uri" validate:"required,uri"`
+		CommunicationMode             string `json:"CommunicationMode" validate:"required,oneof=Polling Listening"`
+	}
+
+	if err := json.Unmarshal(b, &fields); err != nil {
+		return err
+	}
+
+	uri, err := url.Parse(fields.URI)
+	if err != nil {
+		return err
+	}
+
+	l.CertificateSignatureAlgorithm = fields.CertificateSignatureAlgorithm
+	l.Thumbprint = fields.Thumbprint
+	l.CommunicationMode = fields.CommunicationMode
+	l.URI = uri
+
+	return nil
+}


### PR DESCRIPTION
# Background
To fully be able to manage the Kubernetes agent in an automated environment we need to add a new deployment target endpoint

[Internal Story SC-77238](https://app.shortcut.com/octopusdeploy/story/77238/support-agent-deployment-target-in-terraform-provider)

# Results
- Added Kubernetes tentacle endpoint 