### PR TITLE
fix: Marshal default namespace and upgrade locked

### DIFF
--- a/pkg/machines/kubernetes_tentacle_endpoint.go
+++ b/pkg/machines/kubernetes_tentacle_endpoint.go
@@ -39,6 +39,8 @@ func (l KubernetesTentacleEndpoint) MarshalJSON() ([]byte, error) {
 	}{
 		TentacleEndpointConfiguration: l.TentacleEndpointConfiguration,
 		KubernetesAgentDetails:        l.KubernetesAgentDetails,
+		UpgradeLocked:                 l.UpgradeLocked,
+		DefaultNamespace:              l.DefaultNamespace,
 		endpoint:                      l.endpoint,
 	}
 


### PR DESCRIPTION
In my previous PR I forgot to include `UpgradeLocked` and `DefaultNamespace` in the `MarshalJSON` method which meant that these properties were lost when been sent to the server