### PR TITLE
Add KubernetesAgentUpdateBehavior to MachinePolicy.MachineUpdatePolicy

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
           --health-retries 10
           --health-start-period 10s
       octopusserver:
-        image: octopusdeploy/octopusdeploy
+        image: docker.packages.octopushq.com/octopusdeploy/octopusdeploy
         env:
           ACCEPT_EULA: Y
           DB_CONNECTION_STRING: 'Server=sqlserver;Database=OctopusDeploy;User Id=sa;Password=${{ env.SA_PASSWORD }};'

--- a/pkg/machinepolicies/machine_update_policy.go
+++ b/pkg/machinepolicies/machine_update_policy.go
@@ -1,14 +1,16 @@
 package machinepolicies
 
 type MachineUpdatePolicy struct {
-	CalamariUpdateBehavior  string `json:"CalamariUpdateBehavior" validate:"required,oneof=UpdateAlways UpdateOnDeployment UpdateOnNewMachine"`
-	TentacleUpdateAccountID string `json:"TentacleUpdateAccountId,omitempty"`
-	TentacleUpdateBehavior  string `json:"TentacleUpdateBehavior" validate:"required,oneof=NeverUpdate Update"`
+	CalamariUpdateBehavior        string `json:"CalamariUpdateBehavior" validate:"required,oneof=UpdateAlways UpdateOnDeployment UpdateOnNewMachine"`
+	TentacleUpdateAccountID       string `json:"TentacleUpdateAccountId,omitempty"`
+	TentacleUpdateBehavior        string `json:"TentacleUpdateBehavior" validate:"required,oneof=NeverUpdate Update"`
+	KubernetesAgentUpdateBehavior string `json:"KubernetesAgentUpdateBehavior" validate:"required,oneof=NeverUpdate Update"`
 }
 
 func NewMachineUpdatePolicy() *MachineUpdatePolicy {
 	return &MachineUpdatePolicy{
-		CalamariUpdateBehavior: "UpdateOnDeployment",
-		TentacleUpdateBehavior: "NeverUpdate",
+		CalamariUpdateBehavior:        "UpdateOnDeployment",
+		TentacleUpdateBehavior:        "NeverUpdate",
+		KubernetesAgentUpdateBehavior: "Update",
 	}
 }

--- a/pkg/machines/machine_policy_service_test.go
+++ b/pkg/machines/machine_policy_service_test.go
@@ -36,12 +36,15 @@ func CreateTestMachinePolicy(t *testing.T, service *MachinePolicyService) *Machi
 	machineHealthCheckPolicy := NewMachineHealthCheckPolicy()
 	machineHealthCheckPolicy.HealthCheckInterval = getRandomDuration(1)
 
+	machineUpdatePolicy := NewMachineUpdatePolicy()
+
 	machinePolicy := NewMachinePolicy(name)
 	machinePolicy.ConnectionConnectTimeout = connectionConnectTimeout
 	machinePolicy.ConnectionRetrySleepInterval = connectionRetrySleepInterval
 	machinePolicy.ConnectionRetryTimeLimit = connectionRetryTimeLimit
 	machinePolicy.MachineCleanupPolicy = machineCleanupPolicy
 	machinePolicy.MachineHealthCheckPolicy = machineHealthCheckPolicy
+	machinePolicy.MachineUpdatePolicy = machineUpdatePolicy
 	machinePolicy.PollingRequestMaximumMessageProcessingTimeout = pollingRequestMaximumMessageProcessingTimeout
 	machinePolicy.PollingRequestQueueTimeout = pollingRequestQueueTimeout
 	require.NoError(t, machinePolicy.Validate())

--- a/pkg/machines/machine_update_policy.go
+++ b/pkg/machines/machine_update_policy.go
@@ -1,14 +1,16 @@
 package machines
 
 type MachineUpdatePolicy struct {
-	CalamariUpdateBehavior  string `json:"CalamariUpdateBehavior" validate:"required,oneof=UpdateAlways UpdateOnDeployment UpdateOnNewMachine"`
-	TentacleUpdateAccountID string `json:"TentacleUpdateAccountId,omitempty"`
-	TentacleUpdateBehavior  string `json:"TentacleUpdateBehavior" validate:"required,oneof=NeverUpdate Update"`
+	CalamariUpdateBehavior        string `json:"CalamariUpdateBehavior" validate:"required,oneof=UpdateAlways UpdateOnDeployment UpdateOnNewMachine"`
+	TentacleUpdateAccountID       string `json:"TentacleUpdateAccountId,omitempty"`
+	TentacleUpdateBehavior        string `json:"TentacleUpdateBehavior" validate:"required,oneof=NeverUpdate Update"`
+	KubernetesAgentUpdateBehavior string `json:"KubernetesAgentUpdateBehavior" validate:"required,oneof=NeverUpdate Update"`
 }
 
 func NewMachineUpdatePolicy() *MachineUpdatePolicy {
 	return &MachineUpdatePolicy{
-		CalamariUpdateBehavior: "UpdateOnDeployment",
-		TentacleUpdateBehavior: "NeverUpdate",
+		CalamariUpdateBehavior:        "UpdateOnDeployment",
+		TentacleUpdateBehavior:        "NeverUpdate",
+		KubernetesAgentUpdateBehavior: "Update",
 	}
 }

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       DB_CONNECTION_STRING: Server=mssql,1433;Database=Octopus;User Id=SA;Password=Password01!;ConnectRetryCount=6
       CONNSTRING: Server=mssql,1433;Database=Octopus;User Id=SA;Password=Password01!;ConnectRetryCount=6
       MASTER_KEY: 6EdU6IWsCtMEwk0kPKflQQ==
-    image: octopusdeploy/octopusdeploy:${OCTOPUS_VERSION}
+    image: docker.packages.octopushq.com/octopusdeploy/octopusdeploy:${OCTOPUS_VERSION}
     labels:
       autoheal: true
     depends_on:


### PR DESCRIPTION
Added the new `KubernetesAgentUpdateBehavior` to support the changes added in https://github.com/OctopusDeploy/OctopusDeploy/pull/24499,

Shortcut story: [sc-78687]