### PR TITLE
Update to goreleaser v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           go-version: '>=1.18.0'
       - uses: goreleaser/goreleaser-action@v3
         with:
-          args: release --rm-dist
+          args: release --clean
           version: latest         
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
v2 of goreleaser has been released in https://github.com/goreleaser/goreleaser/pull/4806 and is now used in https://github.com/goreleaser/goreleaser-action. This caused an issue where we were now passing an invalid argument `--rm-dist` which was deprecated and replaced with `--clean`. 

This PR changes it to pass `--clean` instead and sets v2 in the config.