### PR TITLE
feat: Build information service

### DIFF
--- a/internal/utilities.go
+++ b/internal/utilities.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/constants"
 	"github.com/dghubble/sling"
@@ -31,6 +32,11 @@ func GetRandomName() string {
 func GetRandomThumbprint() string {
 	thumbprint := strings.ToUpper(strings.ReplaceAll(fmt.Sprintf("%s%s", uuid.New(), uuid.New()), "-", ""))
 	return thumbprint[0:40]
+}
+
+func GetRandomVersion() string {
+	now := time.Now()
+	return fmt.Sprintf("%d.%d.%d.%d", now.Year(), now.Month(), now.Day(), now.Hour()*10000+now.Minute()*100+now.Second())
 }
 
 func IsEmpty(s string) bool {

--- a/pkg/buildinformation/build_information.go
+++ b/pkg/buildinformation/build_information.go
@@ -1,11 +1,10 @@
 package buildinformation
 
 import (
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/issuetrackers"
 	"time"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
-
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/issuetrackers"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 )
 
@@ -32,5 +31,39 @@ type BuildInformation struct {
 func NewBuildInformation() *BuildInformation {
 	return &BuildInformation{
 		Resource: *resources.NewResource(),
+	}
+}
+
+type Commit struct {
+	Id      string `json:"Id,omitempty"`
+	Comment string `json:"Comment,omitempty"`
+}
+
+type OctopusBuildInformation struct {
+	BuildEnvironment string `json:"BuildEnvironment,omitempty"`
+	BuildNumber      string `json:"BuildNumber,omitempty"`
+	BuildUrl         string `json:"BuildUrl,omitempty"`
+	Branch           string `json:"Branch,omitempty"`
+	VcsType          string `json:"VcsType,omitempty"`
+	VcsRoot          string `json:"VcsRoot,omitempty"`
+	VcsCommitNumber  string `json:"VcsCommitNumber,omitempty"`
+
+	Commits []*Commit `json:"Commits"`
+}
+
+type CreateBuildInformationCommand struct {
+	SpaceId                 string                   `json:"SpaceId,omitempty"`
+	PackageId               string                   `json:"PackageId,omitempty"`
+	Version                 string                   `json:"Version,omitempty"`
+	OctopusBuildInformation *OctopusBuildInformation `json:"OctopusBuildInformation,omitempty"`
+	OverwriteMode           OverwriteMode            `json:"OverwriteMode,omitempty"`
+}
+
+func NewCreateBuildInformationCommand(spaceId string, packageId string, version string, buildInformation OctopusBuildInformation) *CreateBuildInformationCommand {
+	return &CreateBuildInformationCommand{
+		SpaceId:                 spaceId,
+		PackageId:               packageId,
+		Version:                 version,
+		OctopusBuildInformation: &buildInformation,
 	}
 }

--- a/pkg/buildinformation/build_information_query.go
+++ b/pkg/buildinformation/build_information_query.go
@@ -1,10 +1,11 @@
 package buildinformation
 
 type BuildInformationQuery struct {
-	Filter        string `uri:"filter,omitempty" url:"filter,omitempty"`
-	Latest        string `uri:"latest,omitempty" url:"latest,omitempty"`
-	OverwriteMode string `uri:"overwriteMode,omitempty" url:"overwriteMode,omitempty"`
-	PackageID     string `uri:"packageId,omitempty" url:"packageId,omitempty"`
-	Skip          int    `uri:"skip,omitempty" url:"skip,omitempty"`
-	Take          int    `uri:"take,omitempty" url:"take,omitempty"`
+	Filter           string `uri:"filter,omitempty" url:"filter,omitempty"`
+	Latest           string `uri:"latest,omitempty" url:"latest,omitempty"`
+	OverwriteMode    string `uri:"overwriteMode,omitempty" url:"overwriteMode,omitempty"`
+	PackageID        string `uri:"packageId,omitempty" url:"packageId,omitempty"`
+	IncludeWorkItems bool   `uri:"includeWorkItems,omitempty" url:"includeWorkItems,omitempty"`
+	Skip             int    `uri:"skip,omitempty" url:"skip,omitempty"`
+	Take             int    `uri:"take,omitempty" url:"take,omitempty"`
 }

--- a/pkg/buildinformation/build_information_service.go
+++ b/pkg/buildinformation/build_information_service.go
@@ -1,9 +1,11 @@
 package buildinformation
 
 import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/constants"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/services"
-
 	"github.com/dghubble/sling"
 )
 
@@ -20,4 +22,62 @@ func NewBuildInformationService(sling *sling.Sling, uriTemplate string, bulkPath
 			Service: services.NewService(constants.ServiceBuildInformationService, sling, uriTemplate),
 		},
 	}
+}
+
+const (
+	template     = "/api/{spaceId}/build-information{/id}{?packageId,filter,latest,skip,take,overwriteMode}"
+	bulkTemplate = "/api/{spaceId}/build-information/bulk{?ids}"
+)
+
+// Add creates a new build information package
+func Add(client newclient.Client, command *CreateBuildInformationCommand) (*BuildInformation, error) {
+	if IsNil(command) {
+		return nil, internal.CreateInvalidParameterError("CreateBuildInformation", "command")
+	}
+
+	resp, err := newclient.Add[BuildInformation](client, template, command.SpaceId, command)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// Get returns a collection of build information based on the criteria defined by its
+// input query parameters. If an error occurs, an empty collection is returned along
+// with the associated error
+func Get(client newclient.Client, spaceId string, buildInformationQuery BuildInformationQuery) (*resources.Resources[*BuildInformation], error) {
+	return newclient.GetByQuery[BuildInformation](client, template, spaceId, buildInformationQuery)
+}
+
+// GetAll returns all build information. If none can be found or an error occurs, it
+// returns an empty collection.
+func GetAll(client newclient.Client, spaceId string) ([]*BuildInformation, error) {
+	return newclient.GetAll[BuildInformation](client, template, spaceId)
+}
+
+// GetById returns the build information that matches the input ID. If one cannot be
+// found, it return nil and an error
+func GetById(client newclient.Client, spaceId string, id string) (*BuildInformation, error) {
+	if internal.IsEmpty(id) {
+		return nil, internal.CreateInvalidParameterError(constants.OperationGetByID, constants.ParameterID)
+	}
+
+	return newclient.GetByID[BuildInformation](client, template, spaceId, id)
+}
+
+// DeleteById deletes the build information based on the ID provided as input.
+func DeleteByID(client newclient.Client, spaceId string, id string) error {
+	return newclient.DeleteByID(client, template, spaceId, id)
+}
+
+// DeleteByIds deletes all build information based on the IDs provided as input.
+func DeleteByIDs(client newclient.Client, spaceId string, ids []string) error {
+	templateParams := map[string]any{"spaceId": spaceId, "ids": ids}
+	expandedUri, err := client.URITemplateCache().Expand(bulkTemplate, templateParams)
+	if err != nil {
+		return err
+	}
+
+	return newclient.Delete(client.HttpSession(), expandedUri)
 }

--- a/pkg/buildinformation/is_nil.go
+++ b/pkg/buildinformation/is_nil.go
@@ -1,0 +1,10 @@
+package buildinformation
+
+func IsNil(i interface{}) bool {
+	switch v := i.(type) {
+	case *CreateBuildInformationCommand:
+		return v == nil
+	default:
+		return v == nil
+	}
+}

--- a/pkg/buildinformation/overwrite_mode.go
+++ b/pkg/buildinformation/overwrite_mode.go
@@ -1,0 +1,9 @@
+package buildinformation
+
+type OverwriteMode string
+
+const (
+	OverwriteModeFailIfExists      = OverwriteMode("FailIfExists")
+	OverwriteModeIgnoreIfExists    = OverwriteMode("IgnoreIfExists")
+	OverwriteModeOverwriteExisting = OverwriteMode("OverwriteExisting")
+)

--- a/test/e2e/build_information_test.go
+++ b/test/e2e/build_information_test.go
@@ -1,0 +1,95 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/buildinformation"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/spaces"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func CreateTestSpaceWithCurrentUserAsSpaceManager(t *testing.T, client *client.Client) *spaces.Space {
+	space := CreateTestSpace(t, client)
+
+	me, err := client.Users.GetMe()
+	require.NoError(t, err)
+	require.NotNil(t, me)
+
+	space.SpaceManagersTeamMembers = append(space.SpaceManagersTeamMembers, me.GetID())
+	space, err = spaces.Update(client, space)
+	require.NoError(t, err)
+	require.Contains(t, space.SpaceManagersTeamMembers, me.GetID())
+
+	return space
+}
+
+func CreateTestBuildInformation(t *testing.T, client *client.Client, space *spaces.Space, packageId string, version string) *buildinformation.BuildInformation {
+	buildInfo := &buildinformation.OctopusBuildInformation{
+		BuildEnvironment: "GitHub",
+		BuildNumber:      "1",
+		BuildUrl:         "https://github.com/user/repo/actions/run/1",
+		Branch:           "main",
+		VcsType:          "Git",
+		VcsRoot:          "https://github.com/user/repo",
+		VcsCommitNumber:  strings.ReplaceAll(uuid.New().String(), "-", ""),
+		Commits: []*buildinformation.Commit{
+			{
+				Id:      strings.ReplaceAll(uuid.New().String(), "-", ""),
+				Comment: "This is the comment",
+			},
+		},
+	}
+
+	createBuildInformationCommand := buildinformation.NewCreateBuildInformationCommand(space.GetID(), packageId, version, *buildInfo)
+
+	createdBuildInformation, err := buildinformation.Add(client, createBuildInformationCommand)
+	require.NoError(t, err)
+	require.NotNil(t, createdBuildInformation)
+
+	return createdBuildInformation
+}
+
+func IsEqualBuildInformation(t *testing.T, expected *buildinformation.BuildInformation, actual *buildinformation.BuildInformation) {
+	// IResource
+	assert.Equal(t, expected.GetID(), actual.GetID())
+	assert.True(t, internal.IsLinksEqual(expected.GetLinks(), actual.GetLinks()))
+
+	// build information
+	assert.Equal(t, expected.PackageID, actual.PackageID)
+	assert.Equal(t, expected.Version, actual.Version)
+	assert.Equal(t, expected.BuildEnvironment, actual.BuildEnvironment)
+	assert.Equal(t, expected.BuildNumber, actual.BuildNumber)
+	assert.Equal(t, expected.BuildURL, actual.BuildURL)
+	assert.Equal(t, expected.Branch, actual.Branch)
+	assert.Equal(t, expected.VcsType, actual.VcsType)
+	assert.Equal(t, expected.VcsRoot, actual.VcsRoot)
+	assert.Equal(t, expected.VcsCommitNumber, actual.VcsCommitNumber)
+	assert.Equal(t, expected.VcsCommitURL, actual.VcsCommitURL)
+	assert.ElementsMatch(t, expected.Commits, actual.Commits)
+}
+
+func TestBuildInformationCreate(t *testing.T) {
+	client := getOctopusClient()
+	require.NotNil(t, client)
+
+	space := CreateTestSpaceWithCurrentUserAsSpaceManager(t, client)
+	require.NotNil(t, space)
+
+	packageId := "TestPackage"
+	version := internal.GetRandomVersion()
+
+	createdBuildInfo := CreateTestBuildInformation(t, client, space, packageId, version)
+	require.NotNil(t, createdBuildInfo)
+
+	buildInfo, err := buildinformation.GetById(client, space.GetID(), createdBuildInfo.ID)
+	require.NoError(t, err)
+	require.NotNil(t, buildInfo)
+	IsEqualBuildInformation(t, createdBuildInfo, buildInfo)
+
+	t.Cleanup(func() { DeleteTestSpace(t, client, space) })
+}

--- a/test/resources/build_information_test.go
+++ b/test/resources/build_information_test.go
@@ -1,0 +1,104 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/buildinformation"
+	"github.com/kinbiko/jsonassert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildInformationCommand(t *testing.T) {
+	var spaceId string
+	var packageId string
+	var version string
+	var buildInformation buildinformation.OctopusBuildInformation
+
+	buildInfo := buildinformation.NewCreateBuildInformationCommand(spaceId, packageId, version, buildInformation)
+	require.NotNil(t, buildInfo)
+	require.Equal(t, packageId, buildInfo.PackageId)
+	require.Equal(t, version, buildInfo.Version)
+}
+
+func TestCreateBuildInformationCommandMarshalJSON(t *testing.T) {
+	spaceId := "Spaces-1"
+	packageId := "ThePackage"
+	version := "1.0.0"
+	buildInformation := &buildinformation.OctopusBuildInformation{
+		BuildEnvironment: "GitHub",
+		BuildNumber:      "1",
+		BuildUrl:         "https://github.com/user/repo/actions/run/1",
+		Branch:           "main",
+		VcsType:          "Git",
+		VcsRoot:          "https://github.com/user/repo",
+		VcsCommitNumber:  "abc123",
+		Commits: []*buildinformation.Commit{
+			{
+				Id:      "abc123",
+				Comment: "The comment",
+			},
+		},
+	}
+
+	buildInformationAsJSON, err := json.Marshal(buildInformation)
+	require.NoError(t, err)
+	require.NotNil(t, buildInformation)
+
+	expectedJson := fmt.Sprintf(`{
+		"SpaceId": "%s",
+		"PackageId": "%s",
+		"Version": "%s",
+		"OctopusBuildInformation": %s
+	}`, spaceId, packageId, version, buildInformationAsJSON)
+
+	createBuildInformationCommand := buildinformation.NewCreateBuildInformationCommand(spaceId, packageId, version, *buildInformation)
+	commandAsJSON, err := json.Marshal(createBuildInformationCommand)
+	require.NoError(t, err)
+	require.NotNil(t, commandAsJSON)
+	jsonassert.New(t).Assertf(string(commandAsJSON), expectedJson)
+}
+
+func TestCreateBuildInformationCommandUnmarshalJSON(t *testing.T) {
+	spaceId := "Spaces-1"
+	packageId := "ThePackage"
+	version := "1.0.0"
+	buildInformation := &buildinformation.OctopusBuildInformation{
+		BuildEnvironment: "GitHub",
+		BuildNumber:      "1",
+		BuildUrl:         "https://github.com/user/repo/actions/run/1",
+		Branch:           "main",
+		VcsType:          "Git",
+		VcsRoot:          "https://github.com/user/repo",
+		VcsCommitNumber:  "abc123",
+		Commits: []*buildinformation.Commit{
+			{
+				Id:      "abc123",
+				Comment: "The comment",
+			},
+		},
+	}
+
+	buildInformationAsJSON, err := json.Marshal(buildInformation)
+	require.NoError(t, err)
+	require.NotNil(t, buildInformation)
+
+	inputJSON := fmt.Sprintf(`{
+		"SpaceId": "%s",
+		"PackageId": "%s",
+		"Version": "%s",
+		"OctopusBuildInformation": %s
+	}`, spaceId, packageId, version, buildInformationAsJSON)
+
+	var createBuildInformationCommand buildinformation.CreateBuildInformationCommand
+	err = json.Unmarshal([]byte(inputJSON), &createBuildInformationCommand)
+	require.NoError(t, err)
+	require.NotNil(t, createBuildInformationCommand)
+	require.Equal(t, spaceId, createBuildInformationCommand.SpaceId)
+	require.Equal(t, packageId, createBuildInformationCommand.PackageId)
+	require.Equal(t, version, createBuildInformationCommand.Version)
+	require.Equal(t, buildInformation.BuildEnvironment, createBuildInformationCommand.OctopusBuildInformation.BuildEnvironment)
+	require.Len(t, createBuildInformationCommand.OctopusBuildInformation.Commits, 1)
+	require.Equal(t, "abc123", createBuildInformationCommand.OctopusBuildInformation.Commits[0].Id)
+}


### PR DESCRIPTION
This PR completes the build information service implementing the following methods:
- `Add`
- `Get`
- `GetAll`
- `GetById`
- `DeleteById`
- `DeleteByIds` (aka Bulk Delete)

[sc-83928]