### PR TITLE
feat: add new functions for getting a project not using a service

### DIFF
--- a/pkg/projects/project_service.go
+++ b/pkg/projects/project_service.go
@@ -177,6 +177,7 @@ func (s *ProjectService) GetByID(id string) (*Project, error) {
 	return resp.(*Project), nil
 }
 
+// Deprecated: Use projects.GetByName
 func (p *ProjectService) GetByName(name string) (*Project, error) {
 	if internal.IsEmpty(name) {
 		return nil, internal.CreateInvalidParameterError(constants.OperationGetByName, constants.ParameterName)
@@ -198,6 +199,7 @@ func (p *ProjectService) GetByName(name string) (*Project, error) {
 	return nil, services.ErrItemNotFound
 }
 
+// Deprecated: Use project.GetByIdentifier
 func (p *ProjectService) GetByIdentifier(identifier string) (*Project, error) {
 	project, err := p.GetByID(identifier)
 	if err != nil {

--- a/pkg/projects/project_service.go
+++ b/pkg/projects/project_service.go
@@ -601,5 +601,4 @@ func GetByIdentifier(client newclient.Client, spaceId string, identifier string)
 	}
 
 	return GetByName(client, client.GetSpaceID(), identifier)
-
 }


### PR DESCRIPTION
Refactors the following method to no longer use a `ProjectService`
- `GetByName`
- `GetByIdentifier`

[sc-83935]