### PR TITLE
fix: Make project AllowIgnoreChannelRules property optional

### DIFF
--- a/pkg/projects/project.go
+++ b/pkg/projects/project.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Project struct {
-	AllowIgnoreChannelRules         bool                                      `json:"AllowIgnoreChannelRules"`
+	AllowIgnoreChannelRules         bool                                      `json:"AllowIgnoreChannelRules,omitempty"`
 	AutoCreateRelease               bool                                      `json:"AutoCreateRelease"`
 	AutoDeployReleaseOverrides      []AutoDeployReleaseOverride               `json:"AutoDeployReleaseOverrides,omitempty"`
 	ClonedFromProjectID             string                                    `json:"ClonedFromProjectId,omitempty"`
@@ -72,7 +72,7 @@ func NewProject(name string, lifecycleID string, projectGroupID string) *Project
 // UnmarshalJSON sets this project to its representation in JSON.
 func (p *Project) UnmarshalJSON(data []byte) error {
 	var fields struct {
-		AllowIgnoreChannelRules         bool                                      `json:"AllowIgnoreChannelRules"`
+		AllowIgnoreChannelRules         bool                                      `json:"AllowIgnoreChannelRules,omitempty"`
 		AutoCreateRelease               bool                                      `json:"AutoCreateRelease"`
 		AutoDeployReleaseOverrides      []AutoDeployReleaseOverride               `json:"AutoDeployReleaseOverrides,omitempty"`
 		ClonedFromProjectID             string                                    `json:"ClonedFromProjectId,omitempty"`

--- a/pkg/projects/project_test.go
+++ b/pkg/projects/project_test.go
@@ -22,7 +22,6 @@ func TestProjectExtensionSettingsAsJSON(t *testing.T) {
 	standardChangeTemplateName := internal.GetRandomName()
 
 	expectedJSON := fmt.Sprintf(`{
-		"AllowIgnoreChannelRules": false,
 		"AutoCreateRelease": false,
  		"DefaultToSkipIfAlreadyInstalled": false,
 		"ExtensionSettings": [

--- a/test/resources/project_test.go
+++ b/test/resources/project_test.go
@@ -40,8 +40,7 @@ func TestProjectMarshalJSON(t *testing.T) {
 		"IsDisabled": false,
 		"DiscreteChannelRelease": false,
 		"IsVersionControlled": false,
-		"ProjectConnectivityPolicy":{"AllowDeploymentsToNoTargets":false,"ExcludeUnhealthyTargets":false},
-		"AllowIgnoreChannelRules": false
+		"ProjectConnectivityPolicy":{"AllowDeploymentsToNoTargets":false,"ExcludeUnhealthyTargets":false}
 	}`, lifecycleID, name, projectGroupID)
 
 	project := projects.NewProject(name, lifecycleID, projectGroupID)
@@ -69,8 +68,7 @@ func TestProjectMarshalJSON(t *testing.T) {
 		"DefaultToSkipIfAlreadyInstalled": false,
 		"IsDisabled": false,
 		"DiscreteChannelRelease": false,
-		"IsVersionControlled": false,
-		"AllowIgnoreChannelRules": false
+		"IsVersionControlled": false
 	}`, lifecycleID, name, connectivityPolicyAsJSON, projectGroupID)
 
 	jsonassert.New(t).Assertf(string(projectAsJSON), expectedJson)


### PR DESCRIPTION
Support for setting the `AllowIgnoreChannelRules` property was added in https://github.com/OctopusDeploy/go-octopusdeploy/pull/253, and was set to a default of false if not supplied. This doesn't match up with how it's treated in Octopus Server when creating/modifying projects, where the property is optional.

This PR fixes that up to match other client libraries by omitting the property if not supplied.