### PR TITLE
fix: Add feed name to search functionality

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,7 +23,7 @@ jobs:
           SA_PASSWORD: ${{ env.SA_PASSWORD }}
           MSSQL_PID: Developer
         options: >-
-          --health-cmd "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P \"$SA_PASSWORD\" -Q \"SELECT 1\" || exit 1"
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$SA_PASSWORD\" -Q \"SELECT 1\" || exit 1"
           --health-interval 10s
           --health-timeout 3s
           --health-retries 10

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,10 +20,10 @@ jobs:
         image: mcr.microsoft.com/mssql/server:2019-latest
         env:
           ACCEPT_EULA: Y
-          SA_PASSWORD: SomeTest01!PassThingy
+          SA_PASSWORD: ${{ env.SA_PASSWORD }}
           MSSQL_PID: Developer
         options: >-
-          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$SA_PASSWORD\" -Q \"SELECT 1\" || exit 1"
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P \"$SA_PASSWORD\" -Q \"SELECT 1\" || exit 1"
           --health-interval 10s
           --health-timeout 3s
           --health-retries 10

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,7 +20,7 @@ jobs:
         image: mcr.microsoft.com/mssql/server:2019-latest
         env:
           ACCEPT_EULA: Y
-          SA_PASSWORD: ${{ env.SA_PASSWORD }}
+          SA_PASSWORD: SomeTest01!PassThingy
           MSSQL_PID: Developer
         options: >-
           --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$SA_PASSWORD\" -Q \"SELECT 1\" || exit 1"

--- a/pkg/feeds/feeds_query.go
+++ b/pkg/feeds/feeds_query.go
@@ -1,6 +1,7 @@
 package feeds
 
 type FeedsQuery struct {
+	Name        string   `uri:"name,omitempty" url:"name,omitempty"`
 	FeedType    string   `uri:"feedType,omitempty" url:"feedType,omitempty"`
 	IDs         []string `uri:"ids,omitempty" url:"ids,omitempty"`
 	PartialName string   `uri:"partialName,omitempty" url:"partialName,omitempty"`


### PR DESCRIPTION
This change adds the Name field to feeds search to support the feeds datasource searching in terraform.

```
data "octopusdeploy_feeds" "foo" {
  name      = "foo"
  feed_type = "Docker"
  skip      = 0
  take      = 1
}

data "octopusdeploy_feeds" "bar" {
  name = "bar"
  feed_type = "Docker"
  skip      = 0
  take      = 1
}

resource "terraform_data" "feeds" {
  input = {
    foo = data.octopusdeploy_feeds.foo.feeds[0].id, # Feeds-1
    bar = data.octopusdeploy_feeds.bar.feeds[0].id, # also Feeds-1
  }
}

output "feeds_out" {
  value = resource.terraform_data.feeds
}
```

> 
>  ~ feeds_outy = {
>         id               = "17c8e400-62a6-3c69-c884-5beb7e1c5457"
>       ~ input            = {
>           ~ foo = "Feeds-1689" -> "Feeds-1688"
>             # (1 unchanged attribute hidden)
>         }
>       ~ output           = {
>           - bar = "Feeds-1689"
>           - foo = "Feeds-1689"
>         } -> (known after apply)
>         # (1 unchanged attribute hidden)
>     }

Fixes https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/653