### PR TITLE
Add support for changing git resource refs when creating a release

### DIFF
--- a/pkg/releases/create_release_v1.go
+++ b/pkg/releases/create_release_v1.go
@@ -20,6 +20,7 @@ type CreateReleaseCommandV1 struct {
 	ReleaseVersion        string   `json:"releaseVersion,omitempty"`
 	ChannelIDOrName       string   `json:"channelName,omitempty"`
 	Packages              []string `json:"packages,omitempty"`
+	GitResources          []string `json:"gitResources,omitempty"`
 	ReleaseNotes          string   `json:"releaseNotes,omitempty"`
 	IgnoreIfAlreadyExists bool     `json:"ignoreIfAlreadyExists"`
 	IgnoreChannelRules    bool     `json:"ignoreChannelRules"`


### PR DESCRIPTION
Adds SDK support for changing the git refs for Git resources when creating a release

Shortcut story: [sc-69100]

Now the feature toggle is at 100% rollout, this can be merged