### PR TITLE
Add space delimited CRUD operations to Workers using the new client

### DIFF
--- a/pkg/machines/worker_service.go
+++ b/pkg/machines/worker_service.go
@@ -49,6 +49,8 @@ func (s *WorkerService) Get(workersQuery WorkersQuery) (*resources.Resources[*Wo
 }
 
 // Add creates a new worker.
+//
+// Deprecated: use workers.Add
 func (s *WorkerService) Add(worker *Worker) (*Worker, error) {
 	if IsNil(worker) {
 		return nil, internal.CreateInvalidParameterError(constants.OperationAdd, constants.ParameterWorker)
@@ -69,6 +71,8 @@ func (s *WorkerService) Add(worker *Worker) (*Worker, error) {
 
 // GetAll returns all workers. If none can be found or an error occurs, it
 // returns an empty collection.
+//
+// Deprecated: use workers.GetAll
 func (s *WorkerService) GetAll() ([]*Worker, error) {
 	items := []*Worker{}
 	path, err := services.GetAllPath(s)
@@ -82,6 +86,8 @@ func (s *WorkerService) GetAll() ([]*Worker, error) {
 
 // GetByID returns the worker that matches the input ID. If one cannot be
 // found, it returns nil and an error.
+//
+// Deprecated: use workers.GetByID
 func (s *WorkerService) GetByID(id string) (*Worker, error) {
 	if internal.IsEmpty(id) {
 		return nil, internal.CreateInvalidParameterError(constants.OperationGetByID, constants.ParameterID)
@@ -172,6 +178,8 @@ func (s *WorkerService) GetByPartialName(partialName string) ([]*Worker, error) 
 }
 
 // Update modifies a worker based on the one provided as input.
+//
+// Deprecated: use workers.Update
 func (s *WorkerService) Update(worker *Worker) (*Worker, error) {
 	if worker == nil {
 		return nil, internal.CreateInvalidParameterError(constants.OperationUpdate, constants.ParameterWorker)

--- a/pkg/machines/worker_service.go
+++ b/pkg/machines/worker_service.go
@@ -67,18 +67,6 @@ func (s *WorkerService) Add(worker *Worker) (*Worker, error) {
 	return resp.(*Worker), nil
 }
 
-// TODO: validation implementation
-
-// func (s workerService) DiscoverWorker() ([]string, error) {
-// 	resp, err := api.ApiGet(s.GetClient(), new([]string), s.discoverWorkerPath)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	response := resp.(*[]string)
-// 	return *response, nil
-// }
-
 // GetAll returns all workers. If none can be found or an error occurs, it
 // returns an empty collection.
 func (s *WorkerService) GetAll() ([]*Worker, error) {

--- a/pkg/workers/worker_service.go
+++ b/pkg/workers/worker_service.go
@@ -1,0 +1,42 @@
+package workers
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/machines"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+)
+
+const template = "/api/{spaceId}/workers{/id}{?skip,take,name,ids,partialName,isDisabled,healthStatuses,commStyles,shellNames}"
+
+// Add creates a new worker.
+func Add(client newclient.Client, worker *machines.Worker) (*machines.Worker, error) {
+	return newclient.Add[machines.Worker](client, template, worker.SpaceID, worker)
+}
+
+// Get returns a collection of workers based on the criteria defined by its
+// input query parameter. If an error occurs, an empty collection is returned
+// along with the associated error.
+func Get(client newclient.Client, spaceID string, workersQuery machines.WorkersQuery) (*resources.Resources[*machines.Worker], error) {
+	return newclient.GetByQuery[machines.Worker](client, template, spaceID, workersQuery)
+}
+
+// GetAll returns all workers. If an error occurs, it returns nil.
+func GetAll(client newclient.Client, spaceID string) ([]*machines.Worker, error) {
+	return newclient.GetAll[machines.Worker](client, template, spaceID)
+}
+
+// GetByID returns the worker that matches the input ID. If one cannot be
+// found, it returns nil and an error.
+func GetByID(client newclient.Client, spaceID string, ID string) (*machines.Worker, error) {
+	return newclient.GetByID[machines.Worker](client, template, spaceID, ID)
+}
+
+// Update updates an existing machine in Octopus Deploy
+func Update(client newclient.Client, worker *machines.Worker) (*machines.Worker, error) {
+	return newclient.Update[machines.Worker](client, template, worker.SpaceID, worker.ID, worker)
+}
+
+// DeleteByID deletes the worker based on the ID provided.
+func DeleteByID(client newclient.Client, spaceID string, ID string) error {
+	return newclient.DeleteByID(client, template, spaceID, ID)
+}


### PR DESCRIPTION
## Background

The current `worker_service` is still using the 'old' client which does not utilise the `SpaceID` on the Worker resource. This means that the worker_service cannot be used in situations where the spaceId is not already set on the base client itself. An example of such a situation is when you want to create the space and worker resource in the same invocation of `terraform apply`. The spaceId cannot be known ahead of time, and hence cannot be set on the Terraform provider config in advance. The current code then creates a bug as the optional SpaceID field on the Worker suggests that the service supports space delimited operations, whereas in reality the operations fallback to the default space.


Needed for https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/pull/655

## Results

Copies the same pattern of deprecating old CRUD functions in favour of new ones using the `newClient`.