### PR TITLE
Add GitResources to DeploymentProcessTemplate

### DIFF
--- a/pkg/deployments/deployment_process_template.go
+++ b/pkg/deployments/deployment_process_template.go
@@ -6,12 +6,13 @@ import (
 )
 
 type DeploymentProcessTemplate struct {
-	DeploymentProcessId            string                            `json:"DeploymentProcessId,omitempty"`
-	LastReleaseVersion             string                            `json:"LastReleaseVersion,omitempty"`
-	NextVersionIncrement           string                            `json:"NextVersionIncrement,omitempty"`
-	VersioningPackageStepName      *string                           `json:"VersioningPackageStepName,omitempty"`
-	VersioningPackageReferenceName *string                           `json:"VersioningPackageReferenceName,omitempty"`
-	Packages                       []releases.ReleaseTemplatePackage `json:"Packages,omitempty"`
+	DeploymentProcessId            string                                `json:"DeploymentProcessId,omitempty"`
+	LastReleaseVersion             string                                `json:"LastReleaseVersion,omitempty"`
+	NextVersionIncrement           string                                `json:"NextVersionIncrement,omitempty"`
+	VersioningPackageStepName      *string                               `json:"VersioningPackageStepName,omitempty"`
+	VersioningPackageReferenceName *string                               `json:"VersioningPackageReferenceName,omitempty"`
+	Packages                       []releases.ReleaseTemplatePackage     `json:"Packages,omitempty"`
+	GitResources                   []releases.ReleaseTemplateGitResource `json:"GitResources,omitempty"`
 
 	resources.Resource
 }

--- a/pkg/releases/release_template_git_resource.go
+++ b/pkg/releases/release_template_git_resource.go
@@ -1,0 +1,17 @@
+﻿package releases
+
+type ReleaseTemplateGitResource struct {
+	ActionName                     string                      `json:"ActionName,omitempty"`
+	RepositoryUri                  string                      `json:"RepositoryUri,omitempty"`
+	DefaultBranch                  string                      `json:"DefaultBranch,omitempty"`
+	IsResolvable                   bool                        `json:"IsResolvable"`
+	Name                           string                      `json:"Name,omitempty"`
+	FilePathFilters                []string                    `json:"FilePathFilters,omitempty"`
+	GitCredentialId                string                      `json:"NuGetPackageId,omitempty"`
+	GitResourceSelectedLastRelease ReleaseTemplateGitReference `json:"GitResourceSelectedLastRelease,omitempty"`
+}
+
+type ReleaseTemplateGitReference struct {
+	GitRef    string `json:"GitRef,omitempty"`
+	GitCommit string `json:"GitCommit,omitempty"`
+}

--- a/pkg/releases/release_template_git_resource.go
+++ b/pkg/releases/release_template_git_resource.go
@@ -1,17 +1,14 @@
 ﻿package releases
 
-type ReleaseTemplateGitResource struct {
-	ActionName                     string                      `json:"ActionName,omitempty"`
-	RepositoryUri                  string                      `json:"RepositoryUri,omitempty"`
-	DefaultBranch                  string                      `json:"DefaultBranch,omitempty"`
-	IsResolvable                   bool                        `json:"IsResolvable"`
-	Name                           string                      `json:"Name,omitempty"`
-	FilePathFilters                []string                    `json:"FilePathFilters,omitempty"`
-	GitCredentialId                string                      `json:"NuGetPackageId,omitempty"`
-	GitResourceSelectedLastRelease ReleaseTemplateGitReference `json:"GitResourceSelectedLastRelease,omitempty"`
-}
+import "github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actions"
 
-type ReleaseTemplateGitReference struct {
-	GitRef    string `json:"GitRef,omitempty"`
-	GitCommit string `json:"GitCommit,omitempty"`
+type ReleaseTemplateGitResource struct {
+	ActionName                     string                          `json:"ActionName,omitempty"`
+	RepositoryUri                  string                          `json:"RepositoryUri,omitempty"`
+	DefaultBranch                  string                          `json:"DefaultBranch,omitempty"`
+	IsResolvable                   bool                            `json:"IsResolvable"`
+	Name                           string                          `json:"Name,omitempty"`
+	FilePathFilters                []string                        `json:"FilePathFilters,omitempty"`
+	GitCredentialId                string                          `json:"NuGetPackageId,omitempty"`
+	GitResourceSelectedLastRelease actions.VersionControlReference `json:"GitResourceSelectedLastRelease,omitempty"`
 }


### PR DESCRIPTION
Adds the `GitResources` field to the `DeploymentProcessTemplate` struct.

This is a list of `ReleaseTemplateGitResources`, representing any git resources associated with the deployment process actions