### PR TITLE
Fix OCI Registry feed update

### DIFF
--- a/pkg/feeds/feed_utilities.go
+++ b/pkg/feeds/feed_utilities.go
@@ -188,6 +188,9 @@ func ToFeedResource(feed IFeed) (*FeedResource, error) {
 		feedResource.AccessKey = s3Feed.AccessKey
 		feedResource.SecretKey = s3Feed.SecretKey
 		feedResource.UseMachineCredentials = s3Feed.UseMachineCredentials
+	case FeedTypeOCIRegistry:
+		mavenFeed := feed.(*OCIRegistryFeed)
+		feedResource.FeedURI = mavenFeed.FeedURI
 	case FeedTypeOctopusProject:
 		// nothing to copy
 	}

--- a/pkg/feeds/feed_utilities.go
+++ b/pkg/feeds/feed_utilities.go
@@ -189,8 +189,8 @@ func ToFeedResource(feed IFeed) (*FeedResource, error) {
 		feedResource.SecretKey = s3Feed.SecretKey
 		feedResource.UseMachineCredentials = s3Feed.UseMachineCredentials
 	case FeedTypeOCIRegistry:
-		mavenFeed := feed.(*OCIRegistryFeed)
-		feedResource.FeedURI = mavenFeed.FeedURI
+		ociFeed := feed.(*OCIRegistryFeed)
+		feedResource.FeedURI = ociFeed.FeedURI
 	case FeedTypeOctopusProject:
 		// nothing to copy
 	}

--- a/pkg/feeds/feed_utilities_test.go
+++ b/pkg/feeds/feed_utilities_test.go
@@ -588,3 +588,28 @@ func TestOCIRegistry(t *testing.T) {
 		t.Fatalf("Username does not match")
 	}
 }
+
+func TestOCIRegistryToResource(t *testing.T) {
+	feed := OCIRegistryFeed{
+		FeedURI: "oci://registry-2.docker.io",
+		feed:    *newFeed("Test Registry 2", FeedTypeOCIRegistry),
+	}
+
+	feedResource, err := ToFeedResource(&feed)
+
+	if err != nil {
+		t.Fatalf("Error should not have been returned. %s", err)
+	}
+
+	if feedResource.FeedType != FeedTypeOCIRegistry {
+		t.Fatalf("FeedType does not match")
+	}
+
+	if feedResource.Name != "Test Registry 2" {
+		t.Fatalf("Name does not match")
+	}
+
+	if feedResource.FeedURI != "oci://registry-2.docker.io" {
+		t.Fatalf("FeedURI does not match")
+	}
+}


### PR DESCRIPTION
Add mapping from feed to resource for OCI Registry feed

Updating OCI Registry feed were failing with error below, because of missing mapping from feed object to API Resource for this particular feed type.

```
Error: unable to update OCI Registry feed

   with octopusdeploy_oci_registry_feed.registry_42,
   on main.tf line 25, in resource "octopusdeploy_oci_registry_feed" "registry_42":
   25: resource "octopusdeploy_oci_registry_feed" "registry_42" {│
 Octopus API error: There was a problem with your request. [The FeedUri field is required. The Feed URL must be a valid URI]
```