### PR TITLE
fix: requestingtool not plumbed through to useragent in client creation

### DIFF
--- a/pkg/client/octopusdeploy.go
+++ b/pkg/client/octopusdeploy.go
@@ -199,7 +199,7 @@ func NewClientForTool(httpClient *http.Client, apiURL *url.URL, apiKey string, s
 	if err != nil {
 		return nil, err
 	}
-	return NewClientWithCredentials(httpClient, apiURL, apiKeyCredential, spaceID, "")
+	return NewClientWithCredentials(httpClient, apiURL, apiKeyCredential, spaceID, requestingTool)
 }
 
 // NewClientWithCredentials returns a new Octopus API client with the specified credentials and a tool reference in the useragent string.


### PR DESCRIPTION
The Go Client has a factory method called `NewClientForTool` which used to instantiate the client with a default useragent string that includes the provided `requestingTool` value, so that we can disambiguate between client consumers in our logs. The plumbing of the `requestingTool` parameter here got broken accidentally during a refactor.

This PR restores that plumbing.