### PR TITLE
feat: Add isDisabled field to tenant

### DIFF
--- a/pkg/tenants/tenant.go
+++ b/pkg/tenants/tenant.go
@@ -12,6 +12,7 @@ type Tenant struct {
 	ProjectEnvironments map[string][]string `json:"ProjectEnvironments,omitempty"`
 	SpaceID             string              `json:"SpaceId"`
 	TenantTags          []string            `json:"TenantTags,omitempty"`
+	IsDisabled          bool                `json:"IsDisabled"`
 
 	resources.Resource
 }
@@ -28,4 +29,8 @@ func NewTenant(name string) *Tenant {
 // Validate checks the state of the tenant and returns an error if invalid.
 func (t Tenant) Validate() error {
 	return validator.New().Struct(t)
+}
+
+func (t *Tenant) GetName() string {
+	return t.Name
 }

--- a/pkg/tenants/tenant_service.go
+++ b/pkg/tenants/tenant_service.go
@@ -282,7 +282,7 @@ func (s *TenantService) UpdateVariables(tenant *Tenant, tenantVariables *variabl
 
 // --- new ---
 
-const template = "/api/{spaceId}/tenants{/id}{?skip,projectId,name,tags,take,ids,clone,partialName,clonedFromTenantId}"
+const template = "/api/{spaceId}/tenants{/id}{?skip,projectId,name,tags,take,ids,clone,partialName,isDisabled,clonedFromTenantId}"
 
 // Get returns a collection of tenants based on the criteria defined by its
 // input query parameter.

--- a/pkg/tenants/tenants_query.go
+++ b/pkg/tenants/tenants_query.go
@@ -4,6 +4,7 @@ type TenantsQuery struct {
 	ClonedFromTenantID string   `uri:"clonedFromTenantId,omitempty" url:"clonedFromTenantId,omitempty"`
 	IDs                []string `uri:"ids,omitempty" url:"ids,omitempty"`
 	IsClone            bool     `uri:"clone,omitempty" url:"clone,omitempty"`
+	IsDisabled         bool     `uri:"isDisabled,omitempty" url:"isDisabled,omitempty"`
 	Name               string   `uri:"name,omitempty" url:"name,omitempty"`
 	PartialName        string   `uri:"partialName,omitempty" url:"partialName,omitempty"`
 	ProjectID          string   `uri:"projectId,omitempty" url:"projectId,omitempty"`

--- a/test/e2e/tenant_service_test.go
+++ b/test/e2e/tenant_service_test.go
@@ -32,6 +32,7 @@ func AssertEqualTenants(t *testing.T, expected *tenants.Tenant, actual *tenants.
 	assert.Equal(t, expected.ProjectEnvironments, actual.ProjectEnvironments)
 	assert.Equal(t, expected.SpaceID, actual.SpaceID)
 	assert.Equal(t, expected.TenantTags, actual.TenantTags)
+	assert.Equal(t, expected.IsDisabled, actual.IsDisabled)
 }
 
 func CreateTestTenant(t *testing.T, octopusClient *client.Client, project *projects.Project, environment *environments.Environment) *tenants.Tenant {
@@ -191,6 +192,7 @@ func TestTenantUpdate(t *testing.T) {
 
 	expected.Name = internal.GetRandomName()
 	expected.Description = internal.GetRandomName()
+	expected.IsDisabled = true
 
 	actual, err := octopusClient.Tenants.Update(expected)
 	assert.NoError(t, err)


### PR DESCRIPTION
Adds the `isDisabled` field to a tenant and update e2e tests to ensure field is set. [#project-disabling-tenants
](https://octopusdeploy.slack.com/archives/C07VBST79AL)