### PR TITLE
Use description during NewProjectTrigger creation

### DIFF
--- a/pkg/triggers/project_trigger.go
+++ b/pkg/triggers/project_trigger.go
@@ -24,13 +24,14 @@ type ProjectTrigger struct {
 
 func NewProjectTrigger(name string, description string, isDisabled bool, project *projects.Project, action actions.ITriggerAction, filter filters.ITriggerFilter) *ProjectTrigger {
 	return &ProjectTrigger{
-		Action:     action,
-		Filter:     filter,
-		IsDisabled: isDisabled,
-		Name:       name,
-		ProjectID:  project.GetID(),
-		SpaceID:    project.SpaceID,
-		Resource:   *resources.NewResource(),
+		Action:      action,
+		Filter:      filter,
+		IsDisabled:  isDisabled,
+		Name:        name,
+		Description: description,
+		ProjectID:   project.GetID(),
+		SpaceID:     project.SpaceID,
+		Resource:    *resources.NewResource(),
 	}
 }
 

--- a/pkg/triggers/project_trigger_test.go
+++ b/pkg/triggers/project_trigger_test.go
@@ -35,7 +35,7 @@ func TestTriggerJsonSerialization(t *testing.T) {
 
 		// note that Go puts a 'Z' on the time
 		assert.Equal(t, heredoc.Doc(`
-			{"Action":{"ShouldRedeployWhenMachineHasBeenDeployedTo":true,"ActionType":"AutoDeploy"},"Filter":{"MonthlyScheduleType":"DayOfMonth","DayNumberOfMonth":"1","StartTime":"2021-12-14T09:00:00Z","Timezone":"Asia/Kuala_Lumpur","FilterType":"DaysPerMonthSchedule"},"IsDisabled":false,"Name":"triggerName","ProjectId":"Projects-123","SpaceId":""}
+			{"Action":{"ShouldRedeployWhenMachineHasBeenDeployedTo":true,"ActionType":"AutoDeploy"},"Description":"triggerDescription","Filter":{"MonthlyScheduleType":"DayOfMonth","DayNumberOfMonth":"1","StartTime":"2021-12-14T09:00:00Z","Timezone":"Asia/Kuala_Lumpur","FilterType":"DaysPerMonthSchedule"},"IsDisabled":false,"Name":"triggerName","ProjectId":"Projects-123","SpaceId":""}
 			`), output.String())
 	})
 


### PR DESCRIPTION
When creating a new project trigger, description is passed to the function but is not used to set the value, this value will now be set