### PR TITLE
Use the new client for project triggers

### DIFF
--- a/pkg/triggers/project_trigger_service.go
+++ b/pkg/triggers/project_trigger_service.go
@@ -2,6 +2,7 @@ package triggers
 
 import (
 	"fmt"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/constants"
@@ -24,6 +25,8 @@ func NewProjectTriggerService(sling *sling.Sling, uriTemplate string) *ProjectTr
 
 // GetByID returns the project trigger that matches the input ID. If one cannot
 // be found, it returns nil and an error.
+//
+// Deprecated: use triggers.GetByID
 func (s *ProjectTriggerService) GetByID(id string) (*ProjectTrigger, error) {
 	if internal.IsEmpty(id) {
 		return nil, internal.CreateInvalidParameterError(constants.OperationGetByID, constants.ParameterID)
@@ -59,6 +62,8 @@ func (s *ProjectTriggerService) GetByProjectID(id string) ([]*ProjectTrigger, er
 
 // GetAll returns all project triggers. If none can be found or an error
 // occurs, it returns an empty collection.
+//
+// Deprecated: use triggers.GetAll
 func (s *ProjectTriggerService) GetAll() ([]*ProjectTrigger, error) {
 	path, err := services.GetPath(s)
 	if err != nil {
@@ -69,6 +74,8 @@ func (s *ProjectTriggerService) GetAll() ([]*ProjectTrigger, error) {
 }
 
 // Add creates a new project trigger.
+//
+// Deprecated: use triggers.Add
 func (s *ProjectTriggerService) Add(projectTrigger *ProjectTrigger) (*ProjectTrigger, error) {
 	if projectTrigger == nil {
 		return nil, internal.CreateInvalidParameterError(constants.OperationDelete, constants.ParameterProjectTrigger)
@@ -88,6 +95,8 @@ func (s *ProjectTriggerService) Add(projectTrigger *ProjectTrigger) (*ProjectTri
 }
 
 // Delete will delete a project trigger.
+//
+// Deprecated: use triggers.Delete
 func (s *ProjectTriggerService) Delete(projectTrigger *ProjectTrigger) error {
 	if projectTrigger == nil {
 		return internal.CreateInvalidParameterError(constants.OperationDelete, constants.ParameterProjectTrigger)
@@ -110,4 +119,36 @@ func (s *ProjectTriggerService) Update(projectTrigger *ProjectTrigger) (*Project
 	}
 
 	return resp.(*ProjectTrigger), nil
+}
+
+// ----- New --------
+
+const (
+	template = "/api/{spaceId}/projecttriggers/{id}"
+)
+
+// GetById returns the project trigger that matches the input ID. If one cannot be
+// found, it returns nil and an error.
+func GetById(client newclient.Client, spaceID string, ID string) (*ProjectTrigger, error) {
+	return newclient.GetByID[ProjectTrigger](client, template, spaceID, ID)
+}
+
+// GetAll returns all project triggers. If an error occurs, it returns nil.
+func GetAll(client newclient.Client, spaceID string) ([]*ProjectTrigger, error) {
+	return newclient.GetAll[ProjectTrigger](client, template, spaceID)
+}
+
+// Add creates a new project trigger.
+func Add(client newclient.Client, projectTrigger *ProjectTrigger) (*ProjectTrigger, error) {
+	return newclient.Add[ProjectTrigger](client, template, projectTrigger.SpaceID, projectTrigger)
+}
+
+// DeleteById deletes a specified project trigger by ID
+func DeleteById(client newclient.Client, spaceID string, ID string) error {
+	return newclient.DeleteByID(client, template, spaceID, ID)
+}
+
+// Update modifies a project trigger based on the one provided as input.
+func Update(client newclient.Client, projectTrigger *ProjectTrigger) (*ProjectTrigger, error) {
+	return newclient.Update[ProjectTrigger](client, template, projectTrigger.SpaceID, projectTrigger.ID, projectTrigger)
 }


### PR DESCRIPTION
[SC-97304]

Use the new client for project triggers to allow scoping by space ID in terraform when the resource differs from the provider