### PR TITLE
Add support for new tenant variables endpoints with environment scoping

### DIFF
--- a/pkg/configuration/feature_toggle_configuration.go
+++ b/pkg/configuration/feature_toggle_configuration.go
@@ -3,18 +3,12 @@ package configuration
 import "github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 
 type FeatureToggleConfigurationQuery struct {
-	Name string `json:"Name,omitempty"`
-
-	resources.Resource
-}
-
-type FeatureToggleConfigurationResponse struct {
-	FeatureToggles []ConfiguredFeatureToggle `json:"FeatureToggles"`
-
-	resources.Resource
+	Name string `uri:"Name,omitempty" url:"Name,omitempty"`
 }
 
 type ConfiguredFeatureToggle struct {
 	Name      string `json:"Name"`
 	IsEnabled bool   `json:"IsEnabled"`
+
+	resources.Resource
 }

--- a/pkg/configuration/feature_toggle_configuration.go
+++ b/pkg/configuration/feature_toggle_configuration.go
@@ -1,14 +1,14 @@
 package configuration
 
-import "github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
-
 type FeatureToggleConfigurationQuery struct {
 	Name string `uri:"Name,omitempty" url:"Name,omitempty"`
+}
+
+type FeatureToggleConfigurationResponse struct {
+	FeatureToggles []ConfiguredFeatureToggle `json:"FeatureToggles"`
 }
 
 type ConfiguredFeatureToggle struct {
 	Name      string `json:"Name"`
 	IsEnabled bool   `json:"IsEnabled"`
-
-	resources.Resource
 }

--- a/pkg/configuration/feature_toggle_configuration.go
+++ b/pkg/configuration/feature_toggle_configuration.go
@@ -1,0 +1,20 @@
+package configuration
+
+import "github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+
+type FeatureToggleConfigurationQuery struct {
+	Name string `json:"Name,omitempty"`
+
+	resources.Resource
+}
+
+type FeatureToggleConfigurationResponse struct {
+	FeatureToggles []ConfiguredFeatureToggle `json:"FeatureToggles"`
+
+	resources.Resource
+}
+
+type ConfiguredFeatureToggle struct {
+	Name      string `json:"Name"`
+	IsEnabled bool   `json:"IsEnabled"`
+}

--- a/pkg/configuration/feature_toggle_configuration_service.go
+++ b/pkg/configuration/feature_toggle_configuration_service.go
@@ -2,22 +2,13 @@ package configuration
 
 import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 )
 
 type FeatureToggleConfigurationService struct{}
 
-const template = "/api/configuration/feature-toggles"
+const template = "/api/configuration/feature-toggles{?Name}"
 
-func Get(client newclient.Client, request *FeatureToggleConfigurationQuery) (*FeatureToggleConfigurationResponse, error) {
-	path, err := client.URITemplateCache().Intern(template)
-
-	if err != nil {
-		return nil, err
-	}
-
-	test, err := newclient.GetByRequest[FeatureToggleConfigurationResponse](client.HttpSession(), path.String(), request)
-
-	test.ModifiedBy = path.String()
-
-	return test, err
+func Get(client newclient.Client, query *FeatureToggleConfigurationQuery) (*resources.Resources[*ConfiguredFeatureToggle], error) {
+	return newclient.GetByQueryWithoutSpace[ConfiguredFeatureToggle](client, template, query)
 }

--- a/pkg/configuration/feature_toggle_configuration_service.go
+++ b/pkg/configuration/feature_toggle_configuration_service.go
@@ -2,13 +2,12 @@ package configuration
 
 import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 )
 
 type FeatureToggleConfigurationService struct{}
 
 const template = "/api/configuration/feature-toggles{?Name}"
 
-func Get(client newclient.Client, query *FeatureToggleConfigurationQuery) (*resources.Resources[*ConfiguredFeatureToggle], error) {
-	return newclient.GetByQueryWithoutSpace[ConfiguredFeatureToggle](client, template, query)
+func Get(client newclient.Client, query *FeatureToggleConfigurationQuery) (*FeatureToggleConfigurationResponse, error) {
+	return newclient.GetByQueryWithoutSpace[FeatureToggleConfigurationResponse](client, template, query)
 }

--- a/pkg/configuration/feature_toggle_configuration_service.go
+++ b/pkg/configuration/feature_toggle_configuration_service.go
@@ -1,0 +1,23 @@
+package configuration
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+)
+
+type FeatureToggleConfigurationService struct{}
+
+const template = "/api/configuration/feature-toggles"
+
+func Get(client newclient.Client, request *FeatureToggleConfigurationQuery) (*FeatureToggleConfigurationResponse, error) {
+	path, err := client.URITemplateCache().Intern(template)
+
+	if err != nil {
+		return nil, err
+	}
+
+	test, err := newclient.GetByRequest[FeatureToggleConfigurationResponse](client.HttpSession(), path.String(), request)
+
+	test.ModifiedBy = path.String()
+
+	return test, err
+}

--- a/pkg/newclient/crud.go
+++ b/pkg/newclient/crud.go
@@ -105,6 +105,27 @@ func GetByQuery[TResource any](client Client, template string, spaceID string, q
 	return res, nil
 }
 
+// GetByQueryWithoutSpace returns a resource based on the criteria defined by
+// its input query parameter.
+func GetByQueryWithoutSpace[TResource any](client Client, template string, query any) (*resources.Resources[*TResource], error) {
+	values, _ := uritemplates.Struct2map(query)
+	if values == nil {
+		values = map[string]any{}
+	}
+
+	path, err := client.URITemplateCache().Expand(template, values)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := Get[resources.Resources[*TResource]](client.HttpSession(), path)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
 // GetByID returns the resource that matches the input ID.
 func GetByID[TResource any](client Client, template string, spaceID string, ID string) (*TResource, error) {
 	if ID == "" {

--- a/pkg/newclient/crud.go
+++ b/pkg/newclient/crud.go
@@ -107,7 +107,7 @@ func GetByQuery[TResource any](client Client, template string, spaceID string, q
 
 // GetByQueryWithoutSpace returns a resource based on the criteria defined by
 // its input query parameter.
-func GetByQueryWithoutSpace[TResource any](client Client, template string, query any) (*resources.Resources[*TResource], error) {
+func GetByQueryWithoutSpace[TResource any](client Client, template string, query any) (*TResource, error) {
 	values, _ := uritemplates.Struct2map(query)
 	if values == nil {
 		values = map[string]any{}
@@ -118,7 +118,7 @@ func GetByQueryWithoutSpace[TResource any](client Client, template string, query
 		return nil, err
 	}
 
-	res, err := Get[resources.Resources[*TResource]](client.HttpSession(), path)
+	res, err := Get[TResource](client.HttpSession(), path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/newclient/httpsession.go
+++ b/pkg/newclient/httpsession.go
@@ -167,10 +167,6 @@ func Get[TResponse any](httpSession *HttpSession, url string) (*TResponse, error
 	return DoRequest[TResponse](httpSession, http.MethodGet, url, nil)
 }
 
-func GetByRequest[TResponse any](httpSession *HttpSession, url string, body any) (*TResponse, error) {
-	return DoRequest[TResponse](httpSession, http.MethodGet, url, body)
-}
-
 func Post[TResponse any](httpSession *HttpSession, url string, body any) (*TResponse, error) {
 	return DoRequest[TResponse](httpSession, http.MethodPost, url, body)
 }

--- a/pkg/newclient/httpsession.go
+++ b/pkg/newclient/httpsession.go
@@ -167,6 +167,10 @@ func Get[TResponse any](httpSession *HttpSession, url string) (*TResponse, error
 	return DoRequest[TResponse](httpSession, http.MethodGet, url, nil)
 }
 
+func GetByRequest[TResponse any](httpSession *HttpSession, url string, body any) (*TResponse, error) {
+	return DoRequest[TResponse](httpSession, http.MethodGet, url, body)
+}
+
 func Post[TResponse any](httpSession *HttpSession, url string, body any) (*TResponse, error) {
 	return DoRequest[TResponse](httpSession, http.MethodPost, url, body)
 }

--- a/pkg/tenants/tenant_service.go
+++ b/pkg/tenants/tenant_service.go
@@ -329,11 +329,11 @@ func GetCommonVariables(client newclient.Client, spaceID string, tenantID string
 }
 
 // UpdateProjectVariables modifies tenant project variables based on the ones provided as input.
-func UpdateProjectVariables(client newclient.Client, spaceID string, ID string, projectVariables *variables.ModifyTenantProjectVariablesCommand) (*variables.TenantProjectVariablesResource, error) {
-	return newclient.Update[variables.TenantProjectVariablesResource](client, tenantProjectVariableTemplate, spaceID, ID, projectVariables)
+func UpdateProjectVariables(client newclient.Client, spaceID string, tenantID string, projectVariables *variables.ModifyTenantProjectVariablesCommand) (*variables.TenantProjectVariablesResource, error) {
+	return newclient.Update[variables.TenantProjectVariablesResource](client, tenantProjectVariableTemplate, spaceID, tenantID, projectVariables)
 }
 
 // UpdateCommonVariables modifies tenant common variables based on the ones provided as input.
-func UpdateCommonVariables(client newclient.Client, spaceID string, ID string, commonVariables *variables.ModifyTenantCommonVariablesCommand) (*variables.TenantCommonVariablesResource, error) {
-	return newclient.Update[variables.TenantCommonVariablesResource](client, tenantCommonVariableTemplate, spaceID, ID, commonVariables)
+func UpdateCommonVariables(client newclient.Client, spaceID string, tenantID string, commonVariables *variables.ModifyTenantCommonVariablesCommand) (*variables.TenantCommonVariablesResource, error) {
+	return newclient.Update[variables.TenantCommonVariablesResource](client, tenantCommonVariableTemplate, spaceID, tenantID, commonVariables)
 }

--- a/pkg/tenants/tenant_service.go
+++ b/pkg/tenants/tenant_service.go
@@ -314,3 +314,41 @@ func DeleteByID(client newclient.Client, spaceID string, ID string) error {
 func GetAll(client newclient.Client, spaceID string) ([]*Tenant, error) {
 	return newclient.GetAll[Tenant](client, template, spaceID)
 }
+
+// GetProjectVariables returns all tenant project variables. If an error occurs, it returns nil.
+func GetProjectVariables(client newclient.Client, tenant *Tenant) (*variables.TenantProjectVariablesResource, error) {
+	body := variables.GetTenantProjectVariablesQuery{
+		TenantID: tenant.ID,
+		SpaceID:  tenant.SpaceID,
+	}
+	return newclient.GetByRequest[variables.TenantProjectVariablesResource](client.HttpSession(), tenant.Links["ProjectVariables"], body)
+}
+
+// GetCommonVariables returns all tenant common variables. If an error occurs, it returns nil.
+func GetCommonVariables(client newclient.Client, tenant *Tenant) (*variables.TenantCommonVariablesResource, error) {
+	body := variables.GetTenantCommonVariablesQuery{
+		TenantID: tenant.ID,
+		SpaceID:  tenant.SpaceID,
+	}
+	return newclient.GetByRequest[variables.TenantCommonVariablesResource](client.HttpSession(), tenant.Links["CommonVariables"], body)
+}
+
+// UpdateProjectVariables modifies tenant project variables based on the ones provided as input.
+func UpdateProjectVariables(client newclient.Client, tenant *Tenant, projectVariables *variables.TenantProjectVariablesResource) (*variables.TenantProjectVariablesResource, error) {
+	return newclient.Update[variables.TenantProjectVariablesResource](client, tenant.Links["ProjectVariables"], tenant.SpaceID, tenant.ID, projectVariables)
+}
+
+// UpdateCommonVariables modifies tenant common variables based on the ones provided as input.
+func UpdateCommonVariables(client newclient.Client, tenant *Tenant, commonVariables *variables.TenantCommonVariablesResource) (*variables.TenantCommonVariablesResource, error) {
+	return newclient.Update[variables.TenantCommonVariablesResource](client, tenant.Links["CommonVariables"], tenant.SpaceID, tenant.ID, commonVariables)
+}
+
+// AddProjectVariables creates new tenant project variables.
+func AddProjectVariables(client newclient.Client, tenant *Tenant, projectVariables *variables.TenantProjectVariablesResource) (*variables.TenantProjectVariablesResource, error) {
+	return newclient.Add[variables.TenantProjectVariablesResource](client, tenant.Links["ProjectVariables"], tenant.SpaceID, projectVariables)
+}
+
+// AddCommonVariables creates new tenant common variables.
+func AddCommonVariables(client newclient.Client, tenant *Tenant, commonVariables *variables.TenantCommonVariablesResource) (*variables.TenantCommonVariablesResource, error) {
+	return newclient.Add[variables.TenantCommonVariablesResource](client, tenant.Links["CommonVariables"], tenant.SpaceID, commonVariables)
+}

--- a/pkg/tenants/tenant_service.go
+++ b/pkg/tenants/tenant_service.go
@@ -319,13 +319,13 @@ const tenantProjectVariableTemplate = "/api/{spaceId}/tenants/{id}/projectvariab
 const tenantCommonVariableTemplate = "/api/{spaceId}/tenants/{id}/commonvariables"
 
 // GetProjectVariables returns all tenant project variables. If an error occurs, it returns nil.
-func GetProjectVariables(client newclient.Client, spaceID string, ID string) (*variables.TenantProjectVariablesResource, error) {
-	return newclient.GetByID[variables.TenantProjectVariablesResource](client, tenantProjectVariableTemplate, spaceID, ID)
+func GetProjectVariables(client newclient.Client, spaceID string, tenantID string) (*variables.TenantProjectVariablesResource, error) {
+	return newclient.GetByID[variables.TenantProjectVariablesResource](client, tenantProjectVariableTemplate, spaceID, tenantID)
 }
 
 // GetCommonVariables returns all tenant common variables. If an error occurs, it returns nil.
-func GetCommonVariables(client newclient.Client, spaceID string, ID string) (*variables.TenantCommonVariablesResource, error) {
-	return newclient.GetByID[variables.TenantCommonVariablesResource](client, tenantCommonVariableTemplate, spaceID, ID)
+func GetCommonVariables(client newclient.Client, spaceID string, tenantID string) (*variables.TenantCommonVariablesResource, error) {
+	return newclient.GetByID[variables.TenantCommonVariablesResource](client, tenantCommonVariableTemplate, spaceID, tenantID)
 }
 
 // UpdateProjectVariables modifies tenant project variables based on the ones provided as input.

--- a/pkg/tenants/tenant_service.go
+++ b/pkg/tenants/tenant_service.go
@@ -334,21 +334,21 @@ func GetCommonVariables(client newclient.Client, tenant *Tenant) (*variables.Ten
 }
 
 // UpdateProjectVariables modifies tenant project variables based on the ones provided as input.
-func UpdateProjectVariables(client newclient.Client, tenant *Tenant, projectVariables *variables.TenantProjectVariablesResource) (*variables.TenantProjectVariablesResource, error) {
+func UpdateProjectVariables(client newclient.Client, tenant *Tenant, projectVariables *variables.ModifyTenantProjectVariablesCommand) (*variables.TenantProjectVariablesResource, error) {
 	return newclient.Update[variables.TenantProjectVariablesResource](client, tenant.Links["ProjectVariables"], tenant.SpaceID, tenant.ID, projectVariables)
 }
 
 // UpdateCommonVariables modifies tenant common variables based on the ones provided as input.
-func UpdateCommonVariables(client newclient.Client, tenant *Tenant, commonVariables *variables.TenantCommonVariablesResource) (*variables.TenantCommonVariablesResource, error) {
+func UpdateCommonVariables(client newclient.Client, tenant *Tenant, commonVariables *variables.ModifyTenantCommonVariablesCommand) (*variables.TenantCommonVariablesResource, error) {
 	return newclient.Update[variables.TenantCommonVariablesResource](client, tenant.Links["CommonVariables"], tenant.SpaceID, tenant.ID, commonVariables)
 }
 
 // AddProjectVariables creates new tenant project variables.
-func AddProjectVariables(client newclient.Client, tenant *Tenant, projectVariables *variables.TenantProjectVariablesResource) (*variables.TenantProjectVariablesResource, error) {
+func AddProjectVariables(client newclient.Client, tenant *Tenant, projectVariables *variables.ModifyTenantProjectVariablesCommand) (*variables.TenantProjectVariablesResource, error) {
 	return newclient.Add[variables.TenantProjectVariablesResource](client, tenant.Links["ProjectVariables"], tenant.SpaceID, projectVariables)
 }
 
 // AddCommonVariables creates new tenant common variables.
-func AddCommonVariables(client newclient.Client, tenant *Tenant, commonVariables *variables.TenantCommonVariablesResource) (*variables.TenantCommonVariablesResource, error) {
+func AddCommonVariables(client newclient.Client, tenant *Tenant, commonVariables *variables.ModifyTenantCommonVariablesCommand) (*variables.TenantCommonVariablesResource, error) {
 	return newclient.Add[variables.TenantCommonVariablesResource](client, tenant.Links["CommonVariables"], tenant.SpaceID, commonVariables)
 }

--- a/pkg/tenants/tenant_service.go
+++ b/pkg/tenants/tenant_service.go
@@ -337,13 +337,3 @@ func UpdateProjectVariables(client newclient.Client, spaceID string, ID string, 
 func UpdateCommonVariables(client newclient.Client, spaceID string, ID string, commonVariables *variables.ModifyTenantCommonVariablesCommand) (*variables.TenantCommonVariablesResource, error) {
 	return newclient.Update[variables.TenantCommonVariablesResource](client, tenantCommonVariableTemplate, spaceID, ID, commonVariables)
 }
-
-// AddProjectVariables creates new tenant project variables.
-func AddProjectVariables(client newclient.Client, spaceID string, projectVariables *variables.ModifyTenantProjectVariablesCommand) (*variables.TenantProjectVariablesResource, error) {
-	return newclient.Add[variables.TenantProjectVariablesResource](client, tenantProjectVariableTemplate, spaceID, projectVariables)
-}
-
-// AddCommonVariables creates new tenant common variables.
-func AddCommonVariables(client newclient.Client, spaceID string, commonVariables *variables.ModifyTenantCommonVariablesCommand) (*variables.TenantCommonVariablesResource, error) {
-	return newclient.Add[variables.TenantCommonVariablesResource](client, tenantCommonVariableTemplate, spaceID, commonVariables)
-}

--- a/pkg/tenants/tenant_service.go
+++ b/pkg/tenants/tenant_service.go
@@ -319,21 +319,21 @@ const tenantProjectVariableTemplate = "/api/{spaceId}/tenants/{id}/projectvariab
 const tenantCommonVariableTemplate = "/api/{spaceId}/tenants/{id}/commonvariables"
 
 // GetProjectVariables returns all tenant project variables. If an error occurs, it returns nil.
-func GetProjectVariables(client newclient.Client, spaceID string, tenantID string) (*variables.TenantProjectVariablesResource, error) {
-	return newclient.GetByID[variables.TenantProjectVariablesResource](client, tenantProjectVariableTemplate, spaceID, tenantID)
+func GetProjectVariables(client newclient.Client, spaceID string, tenantID string) (*variables.TenantProjectVariablesResponse, error) {
+	return newclient.GetByID[variables.TenantProjectVariablesResponse](client, tenantProjectVariableTemplate, spaceID, tenantID)
 }
 
 // GetCommonVariables returns all tenant common variables. If an error occurs, it returns nil.
-func GetCommonVariables(client newclient.Client, spaceID string, tenantID string) (*variables.TenantCommonVariablesResource, error) {
-	return newclient.GetByID[variables.TenantCommonVariablesResource](client, tenantCommonVariableTemplate, spaceID, tenantID)
+func GetCommonVariables(client newclient.Client, spaceID string, tenantID string) (*variables.TenantCommonVariablesResponse, error) {
+	return newclient.GetByID[variables.TenantCommonVariablesResponse](client, tenantCommonVariableTemplate, spaceID, tenantID)
 }
 
 // UpdateProjectVariables modifies tenant project variables based on the ones provided as input.
-func UpdateProjectVariables(client newclient.Client, spaceID string, tenantID string, projectVariables *variables.ModifyTenantProjectVariablesCommand) (*variables.TenantProjectVariablesResource, error) {
-	return newclient.Update[variables.TenantProjectVariablesResource](client, tenantProjectVariableTemplate, spaceID, tenantID, projectVariables)
+func UpdateProjectVariables(client newclient.Client, spaceID string, tenantID string, projectVariables *variables.ModifyTenantProjectVariablesCommand) (*variables.TenantProjectVariablesResponse, error) {
+	return newclient.Update[variables.TenantProjectVariablesResponse](client, tenantProjectVariableTemplate, spaceID, tenantID, projectVariables)
 }
 
 // UpdateCommonVariables modifies tenant common variables based on the ones provided as input.
-func UpdateCommonVariables(client newclient.Client, spaceID string, tenantID string, commonVariables *variables.ModifyTenantCommonVariablesCommand) (*variables.TenantCommonVariablesResource, error) {
-	return newclient.Update[variables.TenantCommonVariablesResource](client, tenantCommonVariableTemplate, spaceID, tenantID, commonVariables)
+func UpdateCommonVariables(client newclient.Client, spaceID string, tenantID string, commonVariables *variables.ModifyTenantCommonVariablesCommand) (*variables.TenantCommonVariablesResponse, error) {
+	return newclient.Update[variables.TenantCommonVariablesResponse](client, tenantCommonVariableTemplate, spaceID, tenantID, commonVariables)
 }

--- a/pkg/tenants/tenant_service.go
+++ b/pkg/tenants/tenant_service.go
@@ -315,40 +315,35 @@ func GetAll(client newclient.Client, spaceID string) ([]*Tenant, error) {
 	return newclient.GetAll[Tenant](client, template, spaceID)
 }
 
+const tenantProjectVariableTemplate = "/api/{spaceId}/tenants/{id}/projectvariables"
+const tenantCommonVariableTemplate = "/api/{spaceId}/tenants/{id}/commonvariables"
+
 // GetProjectVariables returns all tenant project variables. If an error occurs, it returns nil.
-func GetProjectVariables(client newclient.Client, tenant *Tenant) (*variables.TenantProjectVariablesResource, error) {
-	body := variables.GetTenantProjectVariablesQuery{
-		TenantID: tenant.ID,
-		SpaceID:  tenant.SpaceID,
-	}
-	return newclient.GetByRequest[variables.TenantProjectVariablesResource](client.HttpSession(), tenant.Links["ProjectVariables"], body)
+func GetProjectVariables(client newclient.Client, spaceID string, ID string) (*variables.TenantProjectVariablesResource, error) {
+	return newclient.GetByID[variables.TenantProjectVariablesResource](client, tenantProjectVariableTemplate, spaceID, ID)
 }
 
 // GetCommonVariables returns all tenant common variables. If an error occurs, it returns nil.
-func GetCommonVariables(client newclient.Client, tenant *Tenant) (*variables.TenantCommonVariablesResource, error) {
-	body := variables.GetTenantCommonVariablesQuery{
-		TenantID: tenant.ID,
-		SpaceID:  tenant.SpaceID,
-	}
-	return newclient.GetByRequest[variables.TenantCommonVariablesResource](client.HttpSession(), tenant.Links["CommonVariables"], body)
+func GetCommonVariables(client newclient.Client, spaceID string, ID string) (*variables.TenantCommonVariablesResource, error) {
+	return newclient.GetByID[variables.TenantCommonVariablesResource](client, tenantCommonVariableTemplate, spaceID, ID)
 }
 
 // UpdateProjectVariables modifies tenant project variables based on the ones provided as input.
-func UpdateProjectVariables(client newclient.Client, tenant *Tenant, projectVariables *variables.ModifyTenantProjectVariablesCommand) (*variables.TenantProjectVariablesResource, error) {
-	return newclient.Update[variables.TenantProjectVariablesResource](client, tenant.Links["ProjectVariables"], tenant.SpaceID, tenant.ID, projectVariables)
+func UpdateProjectVariables(client newclient.Client, spaceID string, ID string, projectVariables *variables.ModifyTenantProjectVariablesCommand) (*variables.TenantProjectVariablesResource, error) {
+	return newclient.Update[variables.TenantProjectVariablesResource](client, tenantProjectVariableTemplate, spaceID, ID, projectVariables)
 }
 
 // UpdateCommonVariables modifies tenant common variables based on the ones provided as input.
-func UpdateCommonVariables(client newclient.Client, tenant *Tenant, commonVariables *variables.ModifyTenantCommonVariablesCommand) (*variables.TenantCommonVariablesResource, error) {
-	return newclient.Update[variables.TenantCommonVariablesResource](client, tenant.Links["CommonVariables"], tenant.SpaceID, tenant.ID, commonVariables)
+func UpdateCommonVariables(client newclient.Client, spaceID string, ID string, commonVariables *variables.ModifyTenantCommonVariablesCommand) (*variables.TenantCommonVariablesResource, error) {
+	return newclient.Update[variables.TenantCommonVariablesResource](client, tenantCommonVariableTemplate, spaceID, ID, commonVariables)
 }
 
 // AddProjectVariables creates new tenant project variables.
-func AddProjectVariables(client newclient.Client, tenant *Tenant, projectVariables *variables.ModifyTenantProjectVariablesCommand) (*variables.TenantProjectVariablesResource, error) {
-	return newclient.Add[variables.TenantProjectVariablesResource](client, tenant.Links["ProjectVariables"], tenant.SpaceID, projectVariables)
+func AddProjectVariables(client newclient.Client, spaceID string, projectVariables *variables.ModifyTenantProjectVariablesCommand) (*variables.TenantProjectVariablesResource, error) {
+	return newclient.Add[variables.TenantProjectVariablesResource](client, tenantProjectVariableTemplate, spaceID, projectVariables)
 }
 
 // AddCommonVariables creates new tenant common variables.
-func AddCommonVariables(client newclient.Client, tenant *Tenant, commonVariables *variables.ModifyTenantCommonVariablesCommand) (*variables.TenantCommonVariablesResource, error) {
-	return newclient.Add[variables.TenantCommonVariablesResource](client, tenant.Links["CommonVariables"], tenant.SpaceID, commonVariables)
+func AddCommonVariables(client newclient.Client, spaceID string, commonVariables *variables.ModifyTenantCommonVariablesCommand) (*variables.TenantCommonVariablesResource, error) {
+	return newclient.Add[variables.TenantCommonVariablesResource](client, tenantCommonVariableTemplate, spaceID, commonVariables)
 }

--- a/pkg/variables/tenant_common_variable.go
+++ b/pkg/variables/tenant_common_variable.go
@@ -31,8 +31,8 @@ type TenantCommonVariable struct {
 }
 
 type ModifyTenantCommonVariablesCommand struct {
-	TenantID        string                        `json:"TenantId,omitempty"`
-	CommonVariables []TenantCommonVariableCommand `json:"CommonVariables,omitempty"`
+	TenantID  string                        `json:"TenantId,omitempty"`
+	Variables []TenantCommonVariableCommand `json:"Variables,omitempty"`
 }
 
 type TenantCommonVariableCommand struct {

--- a/pkg/variables/tenant_common_variable.go
+++ b/pkg/variables/tenant_common_variable.go
@@ -26,7 +26,7 @@ type TenantCommonVariable struct {
 }
 
 type ModifyTenantCommonVariablesCommand struct {
-	Variables []TenantCommonVariableCommand `json:"Variables,omitempty"`
+	Variables []TenantCommonVariableCommand `json:"Variables"`
 }
 
 type TenantCommonVariableCommand struct {

--- a/pkg/variables/tenant_common_variable.go
+++ b/pkg/variables/tenant_common_variable.go
@@ -1,6 +1,7 @@
 package variables
 
 import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actiontemplates"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 )
@@ -18,10 +19,28 @@ type TenantCommonVariablesResource struct {
 }
 
 type TenantCommonVariable struct {
-	Id         string              `json:"Links,omitempty"`
-	ProjectID  string              `json:"ProjectId"`
-	TemplateID string              `json:"TemplateId"`
-	Value      core.PropertyValue  `json:"Value"`
-	Scope      TenantVariableScope `json:"Scope"`
-	Links      map[string]string   `json:"Links,omitempty"`
+	Id                     string                                  `json:"Id,omitempty"`
+	LibraryVariableSetId   string                                  `json:"LibraryVariableSetId"`
+	LibraryVariableSetName string                                  `json:"LibraryVariableSetName,omitempty"`
+	TemplateID             string                                  `json:"TemplateId"`
+	Template               actiontemplates.ActionTemplateParameter `json:"Template"`
+	Value                  core.PropertyValue                      `json:"Value"`
+	Scope                  TenantVariableScope                     `json:"Scope"`
+
+	resources.Resource
+}
+
+type ModifyTenantCommonVariablesCommand struct {
+	TenantID        string                        `json:"TenantId,omitempty"`
+	CommonVariables []TenantCommonVariableCommand `json:"CommonVariables,omitempty"`
+}
+
+type TenantCommonVariableCommand struct {
+	Id                   string              `json:"Id,omitempty"`
+	LibraryVariableSetId string              `json:"LibraryVariableSetId"`
+	TemplateID           string              `json:"TemplateId"`
+	Value                core.PropertyValue  `json:"Value"`
+	Scope                TenantVariableScope `json:"Scope"`
+
+	resources.Resource
 }

--- a/pkg/variables/tenant_common_variable.go
+++ b/pkg/variables/tenant_common_variable.go
@@ -1,0 +1,27 @@
+package variables
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+)
+
+type GetTenantCommonVariablesQuery struct {
+	TenantID string `json:"TenantId"`
+	SpaceID  string `json:"SpaceId"`
+}
+
+type TenantCommonVariablesResource struct {
+	TenantID        string                 `json:"TenantId,omitempty"`
+	CommonVariables []TenantCommonVariable `json:"CommonVariables,omitempty"`
+
+	resources.Resource
+}
+
+type TenantCommonVariable struct {
+	Id         string              `json:"Links,omitempty"`
+	ProjectID  string              `json:"ProjectId"`
+	TemplateID string              `json:"TemplateId"`
+	Value      core.PropertyValue  `json:"Value"`
+	Scope      TenantVariableScope `json:"Scope"`
+	Links      map[string]string   `json:"Links,omitempty"`
+}

--- a/pkg/variables/tenant_common_variable.go
+++ b/pkg/variables/tenant_common_variable.go
@@ -6,11 +6,6 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 )
 
-type GetTenantCommonVariablesQuery struct {
-	TenantID string `json:"TenantId"`
-	SpaceID  string `json:"SpaceId"`
-}
-
 type TenantCommonVariablesResource struct {
 	TenantID        string                 `json:"TenantId,omitempty"`
 	CommonVariables []TenantCommonVariable `json:"CommonVariables,omitempty"`
@@ -31,7 +26,6 @@ type TenantCommonVariable struct {
 }
 
 type ModifyTenantCommonVariablesCommand struct {
-	TenantID  string                        `json:"TenantId,omitempty"`
 	Variables []TenantCommonVariableCommand `json:"Variables,omitempty"`
 }
 

--- a/pkg/variables/tenant_common_variable.go
+++ b/pkg/variables/tenant_common_variable.go
@@ -6,7 +6,7 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 )
 
-type TenantCommonVariablesResource struct {
+type TenantCommonVariablesResponse struct {
 	TenantID        string                 `json:"TenantId,omitempty"`
 	CommonVariables []TenantCommonVariable `json:"CommonVariables,omitempty"`
 
@@ -14,7 +14,6 @@ type TenantCommonVariablesResource struct {
 }
 
 type TenantCommonVariable struct {
-	Id                     string                                  `json:"Id,omitempty"`
 	LibraryVariableSetId   string                                  `json:"LibraryVariableSetId"`
 	LibraryVariableSetName string                                  `json:"LibraryVariableSetName,omitempty"`
 	TemplateID             string                                  `json:"TemplateId"`
@@ -30,11 +29,9 @@ type ModifyTenantCommonVariablesCommand struct {
 }
 
 type TenantCommonVariableCommand struct {
-	Id                   string              `json:"Id,omitempty"`
+	ID                   string              `json:"Id,omitempty"`
 	LibraryVariableSetId string              `json:"LibraryVariableSetId"`
 	TemplateID           string              `json:"TemplateId"`
 	Value                core.PropertyValue  `json:"Value"`
 	Scope                TenantVariableScope `json:"Scope"`
-
-	resources.Resource
 }

--- a/pkg/variables/tenant_project_variable.go
+++ b/pkg/variables/tenant_project_variable.go
@@ -32,16 +32,16 @@ type TenantProjectVariable struct {
 }
 
 type ModifyTenantProjectVariablesCommand struct {
-	TenantID        string                         `json:"TenantId,omitempty"`
-	CommonVariables []TenantProjectVariableCommand `json:"CommonVariables,omitempty"`
+	TenantID  string                         `json:"TenantId,omitempty"`
+	Variables []TenantProjectVariableCommand `json:"Variables,omitempty"`
 }
 
 type TenantProjectVariableCommand struct {
-	Id                   string              `json:"Id,omitempty"`
-	LibraryVariableSetId string              `json:"LibraryVariableSetId"`
-	TemplateID           string              `json:"TemplateId"`
-	Value                core.PropertyValue  `json:"Value"`
-	Scope                TenantVariableScope `json:"Scope"`
+	Id         string              `json:"Id,omitempty"`
+	ProjectID  string              `json:"ProjectId"`
+	TemplateID string              `json:"TemplateId"`
+	Value      core.PropertyValue  `json:"Value"`
+	Scope      TenantVariableScope `json:"Scope"`
 
 	resources.Resource
 }

--- a/pkg/variables/tenant_project_variable.go
+++ b/pkg/variables/tenant_project_variable.go
@@ -6,7 +6,7 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 )
 
-type TenantProjectVariablesResource struct {
+type TenantProjectVariablesResponse struct {
 	TenantID         string                  `json:"TenantId,omitempty"`
 	ProjectVariables []TenantProjectVariable `json:"ProjectVariables,omitempty"`
 
@@ -14,7 +14,6 @@ type TenantProjectVariablesResource struct {
 }
 
 type TenantProjectVariable struct {
-	Id          string                                  `json:"Id,omitempty"`
 	ProjectID   string                                  `json:"ProjectId"`
 	ProjectName string                                  `json:"ProjectName,omitempty"`
 	TemplateID  string                                  `json:"TemplateId"`
@@ -31,11 +30,9 @@ type ModifyTenantProjectVariablesCommand struct {
 }
 
 type TenantProjectVariableCommand struct {
-	Id         string              `json:"Id,omitempty"`
+	ID         string              `json:"Id,omitempty"`
 	ProjectID  string              `json:"ProjectId"`
 	TemplateID string              `json:"TemplateId"`
 	Value      core.PropertyValue  `json:"Value"`
 	Scope      TenantVariableScope `json:"Scope"`
-
-	resources.Resource
 }

--- a/pkg/variables/tenant_project_variable.go
+++ b/pkg/variables/tenant_project_variable.go
@@ -27,7 +27,7 @@ type TenantProjectVariable struct {
 }
 
 type ModifyTenantProjectVariablesCommand struct {
-	Variables []TenantProjectVariableCommand `json:"Variables,omitempty"`
+	Variables []TenantProjectVariableCommand `json:"Variables"`
 }
 
 type TenantProjectVariableCommand struct {

--- a/pkg/variables/tenant_project_variable.go
+++ b/pkg/variables/tenant_project_variable.go
@@ -1,0 +1,27 @@
+package variables
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+)
+
+type GetTenantProjectVariablesQuery struct {
+	TenantID string `json:"TenantId"`
+	SpaceID  string `json:"SpaceId"`
+}
+
+type TenantProjectVariablesResource struct {
+	TenantID         string                  `json:"TenantId,omitempty"`
+	ProjectVariables []TenantProjectVariable `json:"ProjectVariables,omitempty"`
+
+	resources.Resource
+}
+
+type TenantProjectVariable struct {
+	Id         string              `json:"Links,omitempty"`
+	ProjectID  string              `json:"ProjectId"`
+	TemplateID string              `json:"TemplateId"`
+	Value      core.PropertyValue  `json:"Value"`
+	Scope      TenantVariableScope `json:"Scope"`
+	Links      map[string]string   `json:"Links,omitempty"`
+}

--- a/pkg/variables/tenant_project_variable.go
+++ b/pkg/variables/tenant_project_variable.go
@@ -6,11 +6,6 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 )
 
-type GetTenantProjectVariablesQuery struct {
-	TenantID string `json:"TenantId"`
-	SpaceID  string `json:"SpaceId"`
-}
-
 type TenantProjectVariablesResource struct {
 	TenantID         string                  `json:"TenantId,omitempty"`
 	ProjectVariables []TenantProjectVariable `json:"ProjectVariables,omitempty"`
@@ -32,7 +27,6 @@ type TenantProjectVariable struct {
 }
 
 type ModifyTenantProjectVariablesCommand struct {
-	TenantID  string                         `json:"TenantId,omitempty"`
 	Variables []TenantProjectVariableCommand `json:"Variables,omitempty"`
 }
 

--- a/pkg/variables/tenant_project_variable.go
+++ b/pkg/variables/tenant_project_variable.go
@@ -1,6 +1,7 @@
 package variables
 
 import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actiontemplates"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 )
@@ -18,10 +19,29 @@ type TenantProjectVariablesResource struct {
 }
 
 type TenantProjectVariable struct {
-	Id         string              `json:"Links,omitempty"`
-	ProjectID  string              `json:"ProjectId"`
-	TemplateID string              `json:"TemplateId"`
-	Value      core.PropertyValue  `json:"Value"`
-	Scope      TenantVariableScope `json:"Scope"`
-	Links      map[string]string   `json:"Links,omitempty"`
+	Id          string                                  `json:"Id,omitempty"`
+	ProjectID   string                                  `json:"ProjectId"`
+	ProjectName string                                  `json:"ProjectName,omitempty"`
+	TemplateID  string                                  `json:"TemplateId"`
+	Template    actiontemplates.ActionTemplateParameter `json:"Template"`
+	Value       core.PropertyValue                      `json:"Value"`
+	Scope       TenantVariableScope                     `json:"Scope"`
+	Links       map[string]string                       `json:"Links,omitempty"`
+
+	resources.Resource
+}
+
+type ModifyTenantProjectVariablesCommand struct {
+	TenantID        string                         `json:"TenantId,omitempty"`
+	CommonVariables []TenantProjectVariableCommand `json:"CommonVariables,omitempty"`
+}
+
+type TenantProjectVariableCommand struct {
+	Id                   string              `json:"Id,omitempty"`
+	LibraryVariableSetId string              `json:"LibraryVariableSetId"`
+	TemplateID           string              `json:"TemplateId"`
+	Value                core.PropertyValue  `json:"Value"`
+	Scope                TenantVariableScope `json:"Scope"`
+
+	resources.Resource
 }

--- a/pkg/variables/tenant_variable_scope.go
+++ b/pkg/variables/tenant_variable_scope.go
@@ -1,0 +1,9 @@
+package variables
+
+import "github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+
+type TenantVariableScope struct {
+	EnvironmentIds []string `json:"EnvironmentIds"`
+
+	resources.Resource
+}


### PR DESCRIPTION
[SC-93476] [SC-101710]

New tenant variables endpoints have been added to Octopus Server to allow multi-environment scoping for Common and Project Tenant Variables. This PR adds support for the new endpoints, and for the feature toggles endpoint to allow verification of whether the endpoints are available:

- `/api/{SpaceId}/tenants/{TenantId}/commonvariables` (GET/PUT/POST)
- `/api/{SpaceId}/tenants/{TenantId}/projectvariables` (GET/PUT/POST)

Feature toggles can be queried by name - both of the above endpoints are under `CommonVariableScopingFeatureToggle`.