### PR TITLE
feat: Update runbook preview response add form field

### DIFF
--- a/pkg/runbooks/run_preview.go
+++ b/pkg/runbooks/run_preview.go
@@ -5,6 +5,7 @@ import (
 )
 
 type RunPreview struct {
+	Form                          *deployments.Form                     `json:"Form,omitempty"`
 	StepsToExecute                []*deployments.DeploymentTemplateStep `json:"StepsToExecute,omitempty"`
 	UseGuidedFailureModeByDefault bool                                  `json:"UseGuidedFailureModeByDefault"`
 }


### PR DESCRIPTION

Fixes [sc-103259](https://app.shortcut.com/octopusdeploy/story/103259/sev-3-running-a-runbook-with-the-cli-will-prompt-user-for-a-variable-value-if-there-is-a-prompted-variable-scoped-to-a-different)