### PR TITLE
fix: populate script syntax and body when retrieving all script modules

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
           --health-retries 10
           --health-start-period 10s
       octopusserver:
-        image: docker.packages.octopushq.com/octopusdeploy/octopusdeploy
+        image: docker.packages.octopushq.com/octopusdeploy/octopusdeploy@sha256:1dcebecf95409822823d0a7930f012ae4920437ee5b9ed69d8da36bf4c3f1a51
         env:
           ACCEPT_EULA: Y
           DB_CONNECTION_STRING: 'Server=sqlserver;Database=OctopusDeploy;User Id=sa;Password=${{ env.SA_PASSWORD }};'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
           --health-retries 10
           --health-start-period 10s
       octopusserver:
-        image: docker.packages.octopushq.com/octopusdeploy/octopusdeploy@sha256:1dcebecf95409822823d0a7930f012ae4920437ee5b9ed69d8da36bf4c3f1a51
+        image: docker.packages.octopushq.com/octopusdeploy/octopusdeploy
         env:
           ACCEPT_EULA: Y
           DB_CONNECTION_STRING: 'Server=sqlserver;Database=OctopusDeploy;User Id=sa;Password=${{ env.SA_PASSWORD }};'

--- a/pkg/scriptmodules/script_module_service.go
+++ b/pkg/scriptmodules/script_module_service.go
@@ -91,13 +91,13 @@ func Get(client newclient.Client, spaceID string, libraryVariablesQuery variable
 		return &resources.Resources[*variables.ScriptModule]{}, err
 	}
 
-	for i, scriptModule := range scriptModulesResponse.Items {
-		scriptModuleWithSyntaxAndBody, err := getScriptModuleWithSyntaxAndBody(client, spaceID, scriptModule)
+	for _, scriptModule := range scriptModulesResponse.Items {
+		err := populateScriptModuleSyntaxAndBody(client, spaceID, scriptModule)
 		if err != nil {
 			return nil, err
 		}
 
-		scriptModulesResponse.Items[i] = scriptModuleWithSyntaxAndBody
+		//scriptModulesResponse.Items[i] = scriptModuleWithSyntaxAndBody
 	}
 
 	return scriptModulesResponse, nil
@@ -126,7 +126,7 @@ func GetByID(client newclient.Client, spaceID string, id string) (*variables.Scr
 		return nil, err
 	}
 
-	scriptModuleResponse, err = getScriptModuleWithSyntaxAndBody(client, spaceID, scriptModuleResponse)
+	err = populateScriptModuleSyntaxAndBody(client, spaceID, scriptModuleResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +215,7 @@ func DeleteByID(client newclient.Client, spaceID string, id string) error {
 	return newclient.Delete(client.HttpSession(), expandedUri)
 }
 
-func getScriptModuleWithSyntaxAndBody(client newclient.Client, spaceID string, scriptModuleResponse *variables.ScriptModule) (*variables.ScriptModule, error) {
+func populateScriptModuleSyntaxAndBody(client newclient.Client, spaceID string, scriptModuleResponse *variables.ScriptModule) error {
 	// get associated variable set
 	variablesPath, err := client.URITemplateCache().Expand(uritemplates.Variables, map[string]any{
 		"spaceId": spaceID,
@@ -224,7 +224,7 @@ func getScriptModuleWithSyntaxAndBody(client newclient.Client, spaceID string, s
 
 	variablesResponse, err := newclient.Get[variables.VariableSet](client.HttpSession(), variablesPath)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	variableSet := *variablesResponse
@@ -238,5 +238,5 @@ func getScriptModuleWithSyntaxAndBody(client newclient.Client, spaceID string, s
 		}
 	}
 
-	return scriptModuleResponse, nil
+	return nil
 }

--- a/pkg/scriptmodules/script_module_service.go
+++ b/pkg/scriptmodules/script_module_service.go
@@ -96,8 +96,6 @@ func Get(client newclient.Client, spaceID string, libraryVariablesQuery variable
 		if err != nil {
 			return nil, err
 		}
-
-		//scriptModulesResponse.Items[i] = scriptModuleWithSyntaxAndBody
 	}
 
 	return scriptModulesResponse, nil

--- a/test/e2e/script_module_service_test.go
+++ b/test/e2e/script_module_service_test.go
@@ -1,0 +1,84 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/scriptmodules"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScriptModuleAddGetAndDelete_NewClient(t *testing.T) {
+	client := getOctopusClient()
+	require.NotNil(t, client)
+
+	space := GetDefaultSpace(t, client)
+	require.NotNil(t, space)
+
+	name := internal.GetRandomName()
+	description := internal.GetRandomName()
+	scriptBody := "function Say-Hello()\r\n{\r\n    Write-Output \"Hello, Octopus!\"\r\n}\r\n"
+	syntax := "PowerShell"
+
+	scriptModule := variables.NewScriptModule(name)
+	scriptModule.Description = description
+	scriptModule.ScriptBody = scriptBody
+	scriptModule.Syntax = syntax
+	require.NoError(t, scriptModule.Validate())
+
+	createdScriptModule, err := scriptmodules.Add(client, scriptModule)
+	require.NoError(t, err)
+	require.NotNil(t, createdScriptModule)
+	require.NotEmpty(t, createdScriptModule.GetID())
+	require.Equal(t, description, createdScriptModule.Description)
+	require.Equal(t, name, createdScriptModule.Name)
+	require.Equal(t, scriptBody, createdScriptModule.ScriptBody)
+	require.Equal(t, syntax, createdScriptModule.Syntax)
+
+	allScriptModules, err := scriptmodules.Get(client, space.GetID(), variables.LibraryVariablesQuery{
+		ContentType: "ScriptModules",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, allScriptModules)
+
+	for _, resource := range allScriptModules.Items {
+		resourceToCompare, err := scriptmodules.GetByID(client, space.GetID(), resource.GetID())
+		require.NoError(t, err)
+		IsEqualScriptModules(t, resource, resourceToCompare)
+	}
+
+	DeleteTestScriptModule(t, client, space.GetID(), createdScriptModule)
+}
+
+func IsEqualScriptModules(t *testing.T, expected *variables.ScriptModule, actual *variables.ScriptModule) {
+	// equality cannot be determined through a direct comparison (below)
+	// because APIs like GetByPartialName do not include the fields,
+	// LastModifiedBy and LastModifiedOn
+	//
+	// assert.EqualValues(expected, actual)
+	//
+	// this statement (above) is expected to succeed, but it fails due to these
+	// missing fields
+
+	// IResource
+	assert.Equal(t, expected.GetID(), actual.GetID())
+	assert.True(t, internal.IsLinksEqual(expected.GetLinks(), actual.GetLinks()))
+
+	// script module
+	assert.Equal(t, expected.Description, actual.Description)
+	assert.Equal(t, expected.Name, actual.Name)
+	assert.Equal(t, expected.ScriptBody, actual.ScriptBody)
+	assert.Equal(t, expected.SpaceID, actual.SpaceID)
+	assert.Equal(t, expected.Syntax, actual.Syntax)
+	assert.Equal(t, expected.VariableSetID, actual.VariableSetID)
+}
+
+func DeleteTestScriptModule(t *testing.T, client *client.Client, spaceID string, scriptModule *variables.ScriptModule) error {
+	require.NotNil(t, scriptModule)
+
+	return scriptmodules.DeleteByID(client, spaceID, scriptModule.GetID())
+}


### PR DESCRIPTION
When retrieving all script modules we do not populate the script syntax and body like we do when retrieving a single script module, this PR updates the logic to populate these fields when listing all script modules.

[sc-103152]