### PR TITLE
fix: Fix issue root get call wrong endpoint

### DIFF
--- a/pkg/client/root_service.go
+++ b/pkg/client/root_service.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/constants"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/services"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/services/api"
 	"github.com/dghubble/sling"
@@ -17,12 +19,12 @@ func NewRootService(sling *sling.Sling, uriTemplate string) *RootService {
 	}
 }
 
-func (s *RootService) Get() (*RootResource, error) {
-	path, err := services.GetPath(s)
-	if err != nil {
-		return nil, err
-	}
+func (s *RootService) GetPath() string {
+	return "/api"
+}
 
+func (s *RootService) Get() (*RootResource, error) {
+	path := s.GetPath()
 	resp, err := api.ApiGet(s.GetClient(), new(RootResource), path)
 	if err != nil {
 		return nil, err
@@ -32,3 +34,20 @@ func (s *RootService) Get() (*RootResource, error) {
 }
 
 var _ services.IService = &RootService{}
+
+const (
+	template = "/api/{spaceId}"
+)
+
+func GetSpaceRoot(client newclient.Client, spaceID string) (*resources.Resource, error) {
+	values := map[string]any{
+		"spaceId": spaceID,
+	}
+	path, err := client.URITemplateCache().Expand(template, values)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return newclient.Get[resources.Resource](client.HttpSession(), path)
+}

--- a/test/e2e/root_test.go
+++ b/test/e2e/root_test.go
@@ -3,6 +3,8 @@ package e2e
 import (
 	"testing"
 
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
@@ -25,4 +27,19 @@ func TestGetRoot(t *testing.T) {
 	assert.NotEmpty(t, root.APIVersion)
 	assert.NotEqual(t, root.InstallationID, uuid.Nil)
 	assert.NotEmpty(t, root.Links)
+}
+
+func TestGetSpaceRoot(t *testing.T) {
+	octopusClient := getOctopusClient()
+
+	resource, err := client.GetSpaceRoot(octopusClient, octopusClient.GetSpaceID())
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, resource)
+
+	if resource == nil {
+		return
+	}
+
+	assert.NotEmpty(t, resource.Links)
 }


### PR DESCRIPTION
[sc-103873](https://app.shortcut.com/octopusdeploy/story/103873/sev-3-go-client-returns-an-empty-result-when-calling-root-get-requested-by-matthew-casperson)
Fixes [#309](https://github.com/OctopusDeploy/go-octopusdeploy/issues/309)
- Fixed `Root.Get()` to correctly call the root API endpoint at `/api`
- Added new [GetSpaceRoot()](cci:1://file:///d:/Octopus/go-octopusdeploy/pkg/client/root_service.go:41:0-52:1) function to get space-scoped root resources at `/api/{space-id}`
- Added e2e test to verify space root endpoint functionality
