### PR TITLE
chore: change response to match cli integration tests

### DIFF
--- a/pkg/client/root_service.go
+++ b/pkg/client/root_service.go
@@ -20,7 +20,7 @@ func NewRootService(sling *sling.Sling, uriTemplate string) *RootService {
 }
 
 func (s *RootService) GetPath() string {
-	return "/api"
+	return "/api/"
 }
 
 func (s *RootService) Get() (*RootResource, error) {


### PR DESCRIPTION
The cli tests are failing:

```
FAIL pkg/apiclient.TestClient_GetSystemClient/GetSystemClient_returns_the_client (0.00s)
      fakeoctopusserver.go:151: 
          	Error Trace:	/home/runner/work/cli/cli/test/testutil/fakeoctopusserver.go:151
          	            				/home/runner/work/cli/cli/pkg/apiclient/apiclient_test.go:34
          	Error:      	Not equal: 
          	            	expected: "/api/"
          	            	actual  : "/api"
          	            	
          	            	Diff:
          	            	--- Expected
          	            	+++ Actual
          	            	@@ -1 +1 @@
          	            	-/api/
          	            	+/api
          	Test:       	TestClient_GetSystemClient/GetSystemClient_returns_the_client
```

This PR changes the path to the path expected by the cli tests.