### PR TITLE
feat(octopus-deploy): update max char limit for space name to 50

### DIFF
--- a/pkg/spaces/space.go
+++ b/pkg/spaces/space.go
@@ -9,7 +9,7 @@ type Space struct {
 	Description              string   `json:"Description,omitempty"`
 	Slug                     string   `json:"Slug"` // deliberately send empty string
 	IsDefault                bool     `json:"IsDefault"`
-	Name                     string   `json:"Name" validate:"required,max=20"`
+	Name                     string   `json:"Name" validate:"required,max=50"`
 	SpaceManagersTeamMembers []string `json:"SpaceManagersTeamMembers"` // deliberately send empty array
 	SpaceManagersTeams       []string `json:"SpaceManagersTeams"`       // deliberately send empty array
 	TaskQueueStopped         bool     `json:"TaskQueueStopped"`


### PR DESCRIPTION
Issue: https://github.com/OctopusDeploy/go-octopusdeploy/issues/316
Updated the maximum character limit for a space name/slug in `go-octopusdeploy` from 20 to 50, aligning with the update made in release `2025.2.1408` of Octopus (see: https://github.com/OctopusDeploy/Issues/issues/9272).