### PR TITLE
Fix bad password validation

### DIFF
--- a/internal/validation.go
+++ b/internal/validation.go
@@ -92,15 +92,3 @@ func ValidateSemanticVersion(propertyName string, version string) error {
 
 	return fmt.Errorf("%s is must be a semantic version string", propertyName)
 }
-
-func ValidateUsernamePasswordProperties(username string, password string) error {
-	if IsEmpty(username) && !IsEmpty(password) {
-		return CreateRequiredParameterIsEmptyOrNilError("username")
-	}
-
-	if !IsEmpty(username) && IsEmpty(password) {
-		return CreateRequiredParameterIsEmptyOrNilError("password")
-	}
-
-	return nil
-}

--- a/pkg/core/sensitive_value.go
+++ b/pkg/core/sensitive_value.go
@@ -14,13 +14,6 @@ func NewSensitiveValue(newValue string) *SensitiveValue {
 	}
 }
 
-func (sensitiveValue SensitiveValue) String() string {
-	if sensitiveValue.HasValue {
-		return *sensitiveValue.NewValue
-	}
-	return ""
-}
-
 type SensitiveValue struct {
 	HasValue bool
 	Hint     *string

--- a/pkg/feeds/azure_container_registry.go
+++ b/pkg/feeds/azure_container_registry.go
@@ -24,9 +24,11 @@ type AzureContainerRegistryOidcAuthentication struct {
 // NewAzureContainerRegistry creates and initializes an Azure Container Registry (ACR).
 func NewAzureContainerRegistry(name string, username string, password *core.SensitiveValue, oidcAuthentication *AzureContainerRegistryOidcAuthentication) (*AzureContainerRegistry, error) {
 	if oidcAuthentication == nil {
-		err := internal.ValidateUsernamePasswordProperties(username, password.String())
-		if err != nil {
-			return nil, err
+		if internal.IsEmpty(username) && password.HasValue {
+			return nil, internal.CreateRequiredParameterIsEmptyOrNilError("username")
+		}
+		if !internal.IsEmpty(username) && !password.HasValue {
+			return nil, internal.CreateRequiredParameterIsEmptyOrNilError("password")
 		}
 	}
 

--- a/pkg/feeds/google_container_registry.go
+++ b/pkg/feeds/google_container_registry.go
@@ -22,9 +22,11 @@ type GoogleContainerRegistryOidcAuthentication struct {
 // NewGoogleContainerRegistry creates and initializes a Google Container Registry (GCR).
 func NewGoogleContainerRegistry(name string, username string, password *core.SensitiveValue, oidcAuthentication *GoogleContainerRegistryOidcAuthentication) (*GoogleContainerRegistry, error) {
 	if oidcAuthentication == nil {
-		err := internal.ValidateUsernamePasswordProperties(username, password.String())
-		if err != nil {
-			return nil, err
+		if internal.IsEmpty(username) && password.HasValue {
+			return nil, internal.CreateRequiredParameterIsEmptyOrNilError("username")
+		}
+		if !internal.IsEmpty(username) && !password.HasValue {
+			return nil, internal.CreateRequiredParameterIsEmptyOrNilError("password")
 		}
 	}
 


### PR DESCRIPTION
[sc-108576]

Fixes a bug introduced in https://github.com/OctopusDeploy/go-octopusdeploy/pull/324.

A misunderstanding of how sensitive values are handled was causing unexpected errors when creating ACR and GCR resources using password authentication. This was discovered while testing ACR/GCR creation via the terraform provider.