### PR TITLE
Fix missing docker registry field mappings for ACR and GCR feed conversions

### DIFF
--- a/pkg/feeds/feed_utilities.go
+++ b/pkg/feeds/feed_utilities.go
@@ -26,11 +26,14 @@ func ToFeed(feedResource *FeedResource) (IFeed, error) {
 		}
 		feed = awsElasticContainerRegistry
 	case FeedTypeAzureContainerRegistry:
-		AzureContainerRegistry, err := NewAzureContainerRegistry(feedResource.GetName(), feedResource.GetUsername(), feedResource.GetPassword(), feedResource.AzureContainerRegistryOidcAuthentication)
+		azureContainerRegistry, err := NewAzureContainerRegistry(feedResource.GetName(), feedResource.GetUsername(), feedResource.GetPassword(), feedResource.AzureContainerRegistryOidcAuthentication)
 		if err != nil {
 			return nil, err
 		}
-		feed = AzureContainerRegistry
+		azureContainerRegistry.APIVersion = feedResource.APIVersion
+		azureContainerRegistry.FeedURI = feedResource.FeedURI
+		azureContainerRegistry.RegistryPath = feedResource.RegistryPath
+		feed = azureContainerRegistry
 	case FeedTypeBuiltIn:
 		builtInFeed, err := NewBuiltInFeed(feedResource.GetName())
 		if err != nil {

--- a/pkg/feeds/feed_utilities.go
+++ b/pkg/feeds/feed_utilities.go
@@ -63,11 +63,14 @@ func ToFeed(feedResource *FeedResource) (IFeed, error) {
 		gitHubRepositoryFeed.FeedURI = feedResource.FeedURI
 		feed = gitHubRepositoryFeed
 	case FeedTypeGoogleContainerRegistry:
-		GoogleContainerRegistry, err := NewGoogleContainerRegistry(feedResource.GetName(), feedResource.GetUsername(), feedResource.GetPassword(), feedResource.GoogleContainerRegistryOidcAuthentication)
+		googleContainerRegistry, err := NewGoogleContainerRegistry(feedResource.GetName(), feedResource.GetUsername(), feedResource.GetPassword(), feedResource.GoogleContainerRegistryOidcAuthentication)
 		if err != nil {
 			return nil, err
 		}
-		feed = GoogleContainerRegistry
+		googleContainerRegistry.APIVersion = feedResource.APIVersion
+		googleContainerRegistry.FeedURI = feedResource.FeedURI
+		googleContainerRegistry.RegistryPath = feedResource.RegistryPath
+		feed = googleContainerRegistry
 	case FeedTypeHelm:
 		helmFeed, err := NewHelmFeed(feedResource.GetName())
 		if err != nil {


### PR DESCRIPTION
[sc-108604]

Fixes a bug introduced in https://github.com/OctopusDeploy/go-octopusdeploy/pull/322 and duplicated in https://github.com/OctopusDeploy/go-octopusdeploy/pull/324.

As part of the work adding OIDC to ACR feeds, ACR resources were decoupled from docker feed resources.

Some field mappings were not migrated to the new `ToFeed` conversion logic, causing errors handling `APIVersion`, `FeedURI` and `RegistryPath` attributes. This oversight was also duplicated in the GCR OIDC changes.