### PR TITLE
add DeletePackagesAssociatedWithReleases property

### DIFF
--- a/pkg/feeds/built_in_feed.go
+++ b/pkg/feeds/built_in_feed.go
@@ -9,10 +9,10 @@ import (
 // BuiltInFeed represents a built-in feed.
 type BuiltInFeed struct {
 	DeletePackagesAssociatedWithReleases bool `json:"DeletePackagesAssociatedWithReleases"`
-	DeleteUnreleasedPackagesAfterDays int  `json:"DeleteUnreleasedPackagesAfterDays"`
-	DownloadAttempts                  int  `json:"DownloadAttempts"`
-	DownloadRetryBackoffSeconds       int  `json:"DownloadRetryBackoffSeconds"`
-	IsBuiltInRepoSyncEnabled          bool `json:"IsBuiltInRepoSyncEnabled"`
+	DeleteUnreleasedPackagesAfterDays 	 int  `json:"DeleteUnreleasedPackagesAfterDays"`
+	DownloadAttempts                  	 int  `json:"DownloadAttempts"`
+	DownloadRetryBackoffSeconds       	 int  `json:"DownloadRetryBackoffSeconds"`
+	IsBuiltInRepoSyncEnabled          	 bool `json:"IsBuiltInRepoSyncEnabled"`
 
 	feed
 }

--- a/pkg/feeds/built_in_feed.go
+++ b/pkg/feeds/built_in_feed.go
@@ -9,10 +9,10 @@ import (
 // BuiltInFeed represents a built-in feed.
 type BuiltInFeed struct {
 	DeletePackagesAssociatedWithReleases bool `json:"DeletePackagesAssociatedWithReleases"`
-	DeleteUnreleasedPackagesAfterDays 	 int  `json:"DeleteUnreleasedPackagesAfterDays"`
-	DownloadAttempts                  	 int  `json:"DownloadAttempts"`
-	DownloadRetryBackoffSeconds       	 int  `json:"DownloadRetryBackoffSeconds"`
-	IsBuiltInRepoSyncEnabled          	 bool `json:"IsBuiltInRepoSyncEnabled"`
+	DeleteUnreleasedPackagesAfterDays    int  `json:"DeleteUnreleasedPackagesAfterDays"`
+	DownloadAttempts                     int  `json:"DownloadAttempts"`
+	DownloadRetryBackoffSeconds          int  `json:"DownloadRetryBackoffSeconds"`
+	IsBuiltInRepoSyncEnabled             bool `json:"IsBuiltInRepoSyncEnabled"`
 
 	feed
 }

--- a/pkg/feeds/built_in_feed.go
+++ b/pkg/feeds/built_in_feed.go
@@ -8,6 +8,7 @@ import (
 
 // BuiltInFeed represents a built-in feed.
 type BuiltInFeed struct {
+	DeletePackagesAssociatedWithReleases bool `json:"DeletePackagesAssociatedWithReleases"`
 	DeleteUnreleasedPackagesAfterDays int  `json:"DeleteUnreleasedPackagesAfterDays"`
 	DownloadAttempts                  int  `json:"DownloadAttempts"`
 	DownloadRetryBackoffSeconds       int  `json:"DownloadRetryBackoffSeconds"`
@@ -23,6 +24,7 @@ func NewBuiltInFeed(name string) (*BuiltInFeed, error) {
 	}
 
 	feed := BuiltInFeed{
+		DeletePackagesAssociatedWithReleases: false,
 		DeleteUnreleasedPackagesAfterDays: 30,
 		DownloadAttempts:                  5,
 		DownloadRetryBackoffSeconds:       10,

--- a/pkg/feeds/built_in_feed.go
+++ b/pkg/feeds/built_in_feed.go
@@ -25,11 +25,11 @@ func NewBuiltInFeed(name string) (*BuiltInFeed, error) {
 
 	feed := BuiltInFeed{
 		DeletePackagesAssociatedWithReleases: false,
-		DeleteUnreleasedPackagesAfterDays: 30,
-		DownloadAttempts:                  5,
-		DownloadRetryBackoffSeconds:       10,
-		IsBuiltInRepoSyncEnabled:          false,
-		feed:                              *newFeed(name, FeedTypeBuiltIn),
+		DeleteUnreleasedPackagesAfterDays:    30,
+		DownloadAttempts:                     5,
+		DownloadRetryBackoffSeconds:          10,
+		IsBuiltInRepoSyncEnabled:             false,
+		feed:                                 *newFeed(name, FeedTypeBuiltIn),
 	}
 
 	// validate to ensure that all expectations are met

--- a/pkg/feeds/feed_resource.go
+++ b/pkg/feeds/feed_resource.go
@@ -12,7 +12,7 @@ type FeedResource struct {
 	AzureContainerRegistryOidcAuthentication   *AzureContainerRegistryOidcAuthentication      `json:"AzureContainerRegistryOidcAuthentication,omitempty"`
 	ElasticContainerRegistryOidcAuthentication *AwsElasticContainerRegistryOidcAuthentication `json:"OidcAuthentication,omitempty"`
 	APIVersion                                 string                                         `json:"ApiVersion,omitempty"`
-	DeletePackagesAssociatedWithReleases	   bool											  `json:"DeletePackagesAssociatedWithReleases"`
+	DeletePackagesAssociatedWithReleases       bool                                           `json:"DeletePackagesAssociatedWithReleases"`
 	DeleteUnreleasedPackagesAfterDays          int                                            `json:"DeleteUnreleasedPackagesAfterDays"`
 	DownloadAttempts                           int                                            `json:"DownloadAttempts"`
 	DownloadRetryBackoffSeconds                int                                            `json:"DownloadRetryBackoffSeconds"`

--- a/pkg/feeds/feed_resource.go
+++ b/pkg/feeds/feed_resource.go
@@ -12,6 +12,7 @@ type FeedResource struct {
 	AzureContainerRegistryOidcAuthentication   *AzureContainerRegistryOidcAuthentication      `json:"AzureContainerRegistryOidcAuthentication,omitempty"`
 	ElasticContainerRegistryOidcAuthentication *AwsElasticContainerRegistryOidcAuthentication `json:"OidcAuthentication,omitempty"`
 	APIVersion                                 string                                         `json:"ApiVersion,omitempty"`
+	DeletePackagesAssociatedWithReleases	bool												`json:"DeletePackagesAssociatedWithReleases"`
 	DeleteUnreleasedPackagesAfterDays          int                                            `json:"DeleteUnreleasedPackagesAfterDays"`
 	DownloadAttempts                           int                                            `json:"DownloadAttempts"`
 	DownloadRetryBackoffSeconds                int                                            `json:"DownloadRetryBackoffSeconds"`

--- a/pkg/feeds/feed_resource.go
+++ b/pkg/feeds/feed_resource.go
@@ -12,7 +12,7 @@ type FeedResource struct {
 	AzureContainerRegistryOidcAuthentication   *AzureContainerRegistryOidcAuthentication      `json:"AzureContainerRegistryOidcAuthentication,omitempty"`
 	ElasticContainerRegistryOidcAuthentication *AwsElasticContainerRegistryOidcAuthentication `json:"OidcAuthentication,omitempty"`
 	APIVersion                                 string                                         `json:"ApiVersion,omitempty"`
-	DeletePackagesAssociatedWithReleases	bool												`json:"DeletePackagesAssociatedWithReleases"`
+	DeletePackagesAssociatedWithReleases	   bool											  `json:"DeletePackagesAssociatedWithReleases"`
 	DeleteUnreleasedPackagesAfterDays          int                                            `json:"DeleteUnreleasedPackagesAfterDays"`
 	DownloadAttempts                           int                                            `json:"DownloadAttempts"`
 	DownloadRetryBackoffSeconds                int                                            `json:"DownloadRetryBackoffSeconds"`

--- a/pkg/feeds/feed_utilities.go
+++ b/pkg/feeds/feed_utilities.go
@@ -3,6 +3,7 @@ package feeds
 import (
 	"errors"
 	"fmt"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 )

--- a/pkg/feeds/feed_utilities.go
+++ b/pkg/feeds/feed_utilities.go
@@ -39,6 +39,7 @@ func ToFeed(feedResource *FeedResource) (IFeed, error) {
 		if err != nil {
 			return nil, err
 		}
+		builtInFeed.DeletePackagesAssociatedWithReleases = feedResource.DeletePackagesAssociatedWithReleases
 		builtInFeed.DeleteUnreleasedPackagesAfterDays = feedResource.DeleteUnreleasedPackagesAfterDays
 		builtInFeed.DownloadAttempts = feedResource.DownloadAttempts
 		builtInFeed.DownloadRetryBackoffSeconds = feedResource.DownloadRetryBackoffSeconds
@@ -189,6 +190,7 @@ func ToFeedResource(feed IFeed) (*FeedResource, error) {
 		}
 	case FeedTypeBuiltIn:
 		builtInFeed := feed.(*BuiltInFeed)
+		feedResource.DeletePackagesAssociatedWithReleases = builtInFeed.DeletePackagesAssociatedWithReleases
 		feedResource.DeleteUnreleasedPackagesAfterDays = builtInFeed.DeleteUnreleasedPackagesAfterDays
 		feedResource.DownloadAttempts = builtInFeed.DownloadAttempts
 		feedResource.DownloadRetryBackoffSeconds = builtInFeed.DownloadRetryBackoffSeconds

--- a/pkg/feeds/feed_utilities_test.go
+++ b/pkg/feeds/feed_utilities_test.go
@@ -1,9 +1,10 @@
 package feeds
 
 import (
+	"testing"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
-	"testing"
 )
 
 func TestUnexpectedFeed(t *testing.T) {

--- a/test/resources/feed_utilities_test.go
+++ b/test/resources/feed_utilities_test.go
@@ -33,4 +33,13 @@ func TestToFeed(t *testing.T) {
 	require.NotNil(t, feed)
 	require.NoError(t, err)
 	require.EqualValues(t, feed.GetFeedType(), "AwsElasticContainerRegistry")
+
+	feedResource = feeds.NewFeedResource(internal.GetRandomName(), feeds.FeedTypeBuiltIn)
+	feedResource.DeletePackagesAssociatedWithReleases = true
+	feed, err = feeds.ToFeed(feedResource)
+	require.NoError(t, err)
+	builtinFeed, ok := feed.(*feeds.BuiltInFeed)
+	require.True(t, ok)
+	require.EqualValues(t, builtinFeed.DeletePackagesAssociatedWithReleases, true)
+
 }

--- a/test/resources/feed_utilities_test.go
+++ b/test/resources/feed_utilities_test.go
@@ -40,5 +40,4 @@ func TestToFeed(t *testing.T) {
 	builtinFeed, ok := feed.(*feeds.BuiltInFeed)
 	require.True(t, ok)
 	require.EqualValues(t, builtinFeed.DeletePackagesAssociatedWithReleases, false)
-
 }

--- a/test/resources/feed_utilities_test.go
+++ b/test/resources/feed_utilities_test.go
@@ -35,11 +35,10 @@ func TestToFeed(t *testing.T) {
 	require.EqualValues(t, feed.GetFeedType(), "AwsElasticContainerRegistry")
 
 	feedResource = feeds.NewFeedResource(internal.GetRandomName(), feeds.FeedTypeBuiltIn)
-	feedResource.DeletePackagesAssociatedWithReleases = true
 	feed, err = feeds.ToFeed(feedResource)
 	require.NoError(t, err)
 	builtinFeed, ok := feed.(*feeds.BuiltInFeed)
 	require.True(t, ok)
-	require.EqualValues(t, builtinFeed.DeletePackagesAssociatedWithReleases, true)
+	require.EqualValues(t, builtinFeed.DeletePackagesAssociatedWithReleases, false)
 
 }


### PR DESCRIPTION
# Background

[On an octopus server PR](https://github.com/OctopusDeploy/OctopusDeploy/pull/33384) a new property was added to enable users to delete packages while still saving releases - `DeletePackagesAssociatedWithReleases`.

Here we add the`DeletePackagesAssociatedWithReleases` to the go client as well. 

[[sc-111133]](https://app.shortcut.com/octopusdeploy/story/111133/are-there-are-any-clients-that-can-configure-the-built-in-feed)
