### PR TITLE
Add package cache retention setting to machine policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,28 @@ Operations like `Add`, `DeleteByID`, `GetByID`, and `Update` are supported by mo
 
 Numerous code samples that showcase the API and this client are available in the [examples](/examples) directory. There are also many [integration](/test) and unit tests available to examine that demonstrate the capabilities of this API client.
 
+## Testing
+
+### Running Tests Locally using Visual Studio Code
+
+> [!CAUTION]
+> The integration tests will create and delete resources on your instance. Use a dedicated instance to run tests
+
+To run the tests against an instance of Octopus Deploy, create a `.env` file at the root directory of this repository
+
+```
+OCTOPUS_HOST=http://your-octopus-instance-url
+OCTOPUS_API_KEY=API-YOURAPIKEY
+```
+
+and add a Visual Studio Code workspace setting (`.vscode/settings.json`) for the test environment settings
+
+```
+{
+    "go.testEnvFile": "${workspaceFolder}/.env"
+}
+```
+
 ## 🤝 Contributions
 
 Contributions are welcome! :heart: Please read our [Contributing Guide](CONTRIBUTING.md) for information about how to get involved in this project.

--- a/pkg/machinepolicies/machine_package_cache_retention_policy.go
+++ b/pkg/machinepolicies/machine_package_cache_retention_policy.go
@@ -8,8 +8,18 @@ type MachinePackageCacheRetentionPolicy struct {
 	VersionUnit              string `json:"VersionUnit,omitempty" validate:"omitempty,oneof=Items"`
 }
 
-func NewMachinePackageCacheRetentionPolicy() *MachinePackageCacheRetentionPolicy {
+func NewDefaultMachinePackageCacheRetentionPolicy() *MachinePackageCacheRetentionPolicy {
 	return &MachinePackageCacheRetentionPolicy{
 		Strategy: "Default",
+	}
+}
+
+func NewMachinePackageCacheRetentionPolicy(strategy string, quantityOfPackages int32, packageUnit string, quantityOfVersions int32, versionUnit string) *MachinePackageCacheRetentionPolicy {
+	return &MachinePackageCacheRetentionPolicy{
+		Strategy:                 strategy,
+		QuantityOfPackagesToKeep: quantityOfPackages,
+		PackageUnit:              packageUnit,
+		QuantityOfVersionsToKeep: quantityOfVersions,
+		VersionUnit:              versionUnit,
 	}
 }

--- a/pkg/machinepolicies/machine_package_cache_retention_policy.go
+++ b/pkg/machinepolicies/machine_package_cache_retention_policy.go
@@ -1,28 +1,15 @@
 package machinepolicies
 
-type MachinePackageCacheRetentionUnit int
-
-const (
-	Item MachinePackageCacheRetentionUnit = iota
-)
-
-type MachinePackageCacheRetentionStrategy int
-
-const (
-	Default MachinePackageCacheRetentionStrategy = iota
-	Quantities
-)
-
 type MachinePackageCacheRetentionPolicy struct {
-	Strategy                 MachinePackageCacheRetentionStrategy `json:"Strategy" validate:"required"`
-	QuantityOfPackagesToKeep *int32                               `json:"QuantityOfPackagesToKeep"`
-	PackageUnit              *MachinePackageCacheRetentionUnit    `json:"PackageUnit"`
-	QuantityOfVersionsToKeep *int32                               `json:"QuantityOfVersionsToKeep"`
-	VersionUnit              *MachinePackageCacheRetentionUnit    `json:"VersionUnit"`
+	Strategy                 string `json:"Strategy" validate:"required,oneof=Default Quantities"`
+	QuantityOfPackagesToKeep int32  `json:"QuantityOfPackagesToKeep,omitempty"`
+	PackageUnit              string `json:"PackageUnit,omitempty" validate:"omitempty,oneof=Items"`
+	QuantityOfVersionsToKeep int32  `json:"QuantityOfVersionsToKeep,omitempty"`
+	VersionUnit              string `json:"VersionUnit,omitempty" validate:"omitempty,oneof=Items"`
 }
 
 func NewMachinePackageCacheRetentionPolicy() *MachinePackageCacheRetentionPolicy {
 	return &MachinePackageCacheRetentionPolicy{
-		Strategy: Default,
+		Strategy: "Default",
 	}
 }

--- a/pkg/machinepolicies/machine_package_cache_retention_policy.go
+++ b/pkg/machinepolicies/machine_package_cache_retention_policy.go
@@ -1,0 +1,28 @@
+package machinepolicies
+
+type MachinePackageCacheRetentionUnit int
+
+const (
+	Item MachinePackageCacheRetentionUnit = iota
+)
+
+type MachinePackageCacheRetentionStrategy int
+
+const (
+	Default MachinePackageCacheRetentionStrategy = iota
+	Quantities
+)
+
+type MachinePackageCacheRetentionPolicy struct {
+	Strategy                 MachinePackageCacheRetentionStrategy `json:"Strategy" validate:"required"`
+	QuantityOfPackagesToKeep *int32                               `json:"QuantityOfPackagesToKeep"`
+	PackageUnit              *MachinePackageCacheRetentionUnit    `json:"PackageUnit"`
+	QuantityOfVersionsToKeep *int32                               `json:"QuantityOfVersionsToKeep"`
+	VersionUnit              *MachinePackageCacheRetentionUnit    `json:"VersionUnit"`
+}
+
+func NewMachinePackageCacheRetentionPolicy() *MachinePackageCacheRetentionPolicy {
+	return &MachinePackageCacheRetentionPolicy{
+		Strategy: Default,
+	}
+}

--- a/pkg/machinepolicies/machine_policy.go
+++ b/pkg/machinepolicies/machine_policy.go
@@ -10,20 +10,21 @@ import (
 )
 
 type MachinePolicy struct {
-	ConnectionConnectTimeout                      time.Duration              `json:"ConnectionConnectTimeout" validate:"required,min=10s"`
-	ConnectionRetryCountLimit                     int32                      `json:"ConnectionRetryCountLimit" validate:"required,gte=2"`
-	ConnectionRetrySleepInterval                  time.Duration              `json:"ConnectionRetrySleepInterval" validate:"required"`
-	ConnectionRetryTimeLimit                      time.Duration              `json:"ConnectionRetryTimeLimit" validate:"required,min=10s"`
-	Description                                   string                     `json:"Description,omitempty"`
-	IsDefault                                     bool                       `json:"IsDefault"`
-	MachineCleanupPolicy                          *MachineCleanupPolicy      `json:"MachineCleanupPolicy"`
-	MachineConnectivityPolicy                     *MachineConnectivityPolicy `json:"MachineConnectivityPolicy"`
-	MachineHealthCheckPolicy                      *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
-	MachineUpdatePolicy                           *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
-	Name                                          string                     `json:"Name" validate:"required,notblank"`
-	PollingRequestMaximumMessageProcessingTimeout time.Duration              `json:"PollingRequestMaximumMessageProcessingTimeout,omitempty"`
-	PollingRequestQueueTimeout                    time.Duration              `json:"PollingRequestQueueTimeout" validate:"required"`
-	SpaceID                                       string                     `json:"SpaceId,omitempty"`
+	ConnectionConnectTimeout                      time.Duration                       `json:"ConnectionConnectTimeout" validate:"required,min=10s"`
+	ConnectionRetryCountLimit                     int32                               `json:"ConnectionRetryCountLimit" validate:"required,gte=2"`
+	ConnectionRetrySleepInterval                  time.Duration                       `json:"ConnectionRetrySleepInterval" validate:"required"`
+	ConnectionRetryTimeLimit                      time.Duration                       `json:"ConnectionRetryTimeLimit" validate:"required,min=10s"`
+	Description                                   string                              `json:"Description,omitempty"`
+	IsDefault                                     bool                                `json:"IsDefault"`
+	MachineCleanupPolicy                          *MachineCleanupPolicy               `json:"MachineCleanupPolicy"`
+	MachineConnectivityPolicy                     *MachineConnectivityPolicy          `json:"MachineConnectivityPolicy"`
+	MachineHealthCheckPolicy                      *MachineHealthCheckPolicy           `json:"MachineHealthCheckPolicy"`
+	MachineUpdatePolicy                           *MachineUpdatePolicy                `json:"MachineUpdatePolicy"`
+	MachinePackageCacheRetentionPolicy            *MachinePackageCacheRetentionPolicy `json:"MachinePackageCacheRetentionPolicy"`
+	Name                                          string                              `json:"Name" validate:"required,notblank"`
+	PollingRequestMaximumMessageProcessingTimeout time.Duration                       `json:"PollingRequestMaximumMessageProcessingTimeout,omitempty"`
+	PollingRequestQueueTimeout                    time.Duration                       `json:"PollingRequestQueueTimeout" validate:"required"`
+	SpaceID                                       string                              `json:"SpaceId,omitempty"`
 
 	resources.Resource
 }
@@ -38,6 +39,7 @@ func NewMachinePolicy(name string) *MachinePolicy {
 		MachineConnectivityPolicy:                     NewMachineConnectivityPolicy(),
 		MachineHealthCheckPolicy:                      NewMachineHealthCheckPolicy(),
 		MachineUpdatePolicy:                           NewMachineUpdatePolicy(),
+		MachinePackageCacheRetentionPolicy:            NewMachinePackageCacheRetentionPolicy(),
 		Name:                                          name,
 		PollingRequestMaximumMessageProcessingTimeout: 10 * time.Minute,
 		PollingRequestQueueTimeout:                    2 * time.Minute,
@@ -48,33 +50,35 @@ func NewMachinePolicy(name string) *MachinePolicy {
 // MarshalJSON returns a machine policy as its JSON encoding.
 func (m *MachinePolicy) MarshalJSON() ([]byte, error) {
 	machinePolicy := struct {
-		ConnectionConnectTimeout                      string                     `json:"ConnectionConnectTimeout" validate:"required"`
-		ConnectionRetryCountLimit                     int32                      `json:"ConnectionRetryCountLimit" validate:"required"`
-		ConnectionRetrySleepInterval                  string                     `json:"ConnectionRetrySleepInterval" validate:"required"`
-		ConnectionRetryTimeLimit                      string                     `json:"ConnectionRetryTimeLimit" validate:"required"`
-		Description                                   string                     `json:"Description,omitempty"`
-		IsDefault                                     bool                       `json:"IsDefault"`
-		MachineCleanupPolicy                          *MachineCleanupPolicy      `json:"MachineCleanupPolicy"`
-		MachineConnectivityPolicy                     *MachineConnectivityPolicy `json:"MachineConnectivityPolicy"`
-		MachineHealthCheckPolicy                      *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
-		MachineUpdatePolicy                           *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
-		Name                                          string                     `json:"Name" validate:"required,notblank"`
-		PollingRequestMaximumMessageProcessingTimeout string                     `json:"PollingRequestMaximumMessageProcessingTimeout,omitempty"`
-		PollingRequestQueueTimeout                    string                     `json:"PollingRequestQueueTimeout" validate:"required"`
-		SpaceID                                       string                     `json:"SpaceId,omitempty"`
+		ConnectionConnectTimeout                      string                              `json:"ConnectionConnectTimeout" validate:"required"`
+		ConnectionRetryCountLimit                     int32                               `json:"ConnectionRetryCountLimit" validate:"required"`
+		ConnectionRetrySleepInterval                  string                              `json:"ConnectionRetrySleepInterval" validate:"required"`
+		ConnectionRetryTimeLimit                      string                              `json:"ConnectionRetryTimeLimit" validate:"required"`
+		Description                                   string                              `json:"Description,omitempty"`
+		IsDefault                                     bool                                `json:"IsDefault"`
+		MachineCleanupPolicy                          *MachineCleanupPolicy               `json:"MachineCleanupPolicy"`
+		MachineConnectivityPolicy                     *MachineConnectivityPolicy          `json:"MachineConnectivityPolicy"`
+		MachineHealthCheckPolicy                      *MachineHealthCheckPolicy           `json:"MachineHealthCheckPolicy"`
+		MachineUpdatePolicy                           *MachineUpdatePolicy                `json:"MachineUpdatePolicy"`
+		MachinePackageCacheRetentionPolicy            *MachinePackageCacheRetentionPolicy `json:"MachinePackageCacheRetentionPolicy"`
+		Name                                          string                              `json:"Name" validate:"required,notblank"`
+		PollingRequestMaximumMessageProcessingTimeout string                              `json:"PollingRequestMaximumMessageProcessingTimeout,omitempty"`
+		PollingRequestQueueTimeout                    string                              `json:"PollingRequestQueueTimeout" validate:"required"`
+		SpaceID                                       string                              `json:"SpaceId,omitempty"`
 		resources.Resource
 	}{
-		ConnectionConnectTimeout:     ToTimeSpan(m.ConnectionConnectTimeout),
-		ConnectionRetryCountLimit:    m.ConnectionRetryCountLimit,
-		ConnectionRetrySleepInterval: ToTimeSpan(m.ConnectionRetrySleepInterval),
-		ConnectionRetryTimeLimit:     ToTimeSpan(m.ConnectionRetryTimeLimit),
-		Description:                  m.Description,
-		IsDefault:                    m.IsDefault,
-		MachineCleanupPolicy:         m.MachineCleanupPolicy,
-		MachineConnectivityPolicy:    m.MachineConnectivityPolicy,
-		MachineHealthCheckPolicy:     m.MachineHealthCheckPolicy,
-		MachineUpdatePolicy:          m.MachineUpdatePolicy,
-		Name:                         m.Name,
+		ConnectionConnectTimeout:                      ToTimeSpan(m.ConnectionConnectTimeout),
+		ConnectionRetryCountLimit:                     m.ConnectionRetryCountLimit,
+		ConnectionRetrySleepInterval:                  ToTimeSpan(m.ConnectionRetrySleepInterval),
+		ConnectionRetryTimeLimit:                      ToTimeSpan(m.ConnectionRetryTimeLimit),
+		Description:                                   m.Description,
+		IsDefault:                                     m.IsDefault,
+		MachineCleanupPolicy:                          m.MachineCleanupPolicy,
+		MachineConnectivityPolicy:                     m.MachineConnectivityPolicy,
+		MachineHealthCheckPolicy:                      m.MachineHealthCheckPolicy,
+		MachineUpdatePolicy:                           m.MachineUpdatePolicy,
+		MachinePackageCacheRetentionPolicy:            m.MachinePackageCacheRetentionPolicy,
+		Name:                                          m.Name,
 		PollingRequestMaximumMessageProcessingTimeout: ToTimeSpan(m.PollingRequestMaximumMessageProcessingTimeout),
 		PollingRequestQueueTimeout:                    ToTimeSpan(m.PollingRequestQueueTimeout),
 		SpaceID:                                       m.SpaceID,
@@ -87,20 +91,21 @@ func (m *MachinePolicy) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON sets this Kubernetes endpoint to its representation in JSON.
 func (m *MachinePolicy) UnmarshalJSON(data []byte) error {
 	var fields struct {
-		ConnectionConnectTimeout                      string                     `json:"ConnectionConnectTimeout" validate:"required"`
-		ConnectionRetryCountLimit                     int32                      `json:"ConnectionRetryCountLimit" validate:"required"`
-		ConnectionRetrySleepInterval                  string                     `json:"ConnectionRetrySleepInterval" validate:"required"`
-		ConnectionRetryTimeLimit                      string                     `json:"ConnectionRetryTimeLimit" validate:"required"`
-		Description                                   string                     `json:"Description,omitempty"`
-		IsDefault                                     bool                       `json:"IsDefault"`
-		MachineCleanupPolicy                          *MachineCleanupPolicy      `json:"MachineCleanupPolicy"`
-		MachineConnectivityPolicy                     *MachineConnectivityPolicy `json:"MachineConnectivityPolicy"`
-		MachineHealthCheckPolicy                      *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
-		MachineUpdatePolicy                           *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
-		Name                                          string                     `json:"Name"`
-		PollingRequestMaximumMessageProcessingTimeout string                     `json:"PollingRequestMaximumMessageProcessingTimeout,omitempty"`
-		PollingRequestQueueTimeout                    string                     `json:"PollingRequestQueueTimeout" validate:"required"`
-		SpaceID                                       string                     `json:"SpaceId,omitempty"`
+		ConnectionConnectTimeout                      string                              `json:"ConnectionConnectTimeout" validate:"required"`
+		ConnectionRetryCountLimit                     int32                               `json:"ConnectionRetryCountLimit" validate:"required"`
+		ConnectionRetrySleepInterval                  string                              `json:"ConnectionRetrySleepInterval" validate:"required"`
+		ConnectionRetryTimeLimit                      string                              `json:"ConnectionRetryTimeLimit" validate:"required"`
+		Description                                   string                              `json:"Description,omitempty"`
+		IsDefault                                     bool                                `json:"IsDefault"`
+		MachineCleanupPolicy                          *MachineCleanupPolicy               `json:"MachineCleanupPolicy"`
+		MachineConnectivityPolicy                     *MachineConnectivityPolicy          `json:"MachineConnectivityPolicy"`
+		MachineHealthCheckPolicy                      *MachineHealthCheckPolicy           `json:"MachineHealthCheckPolicy"`
+		MachineUpdatePolicy                           *MachineUpdatePolicy                `json:"MachineUpdatePolicy"`
+		MachinePackageCacheRetentionPolicy            *MachinePackageCacheRetentionPolicy `json:"MachinePackageCacheRetentionPolicy"`
+		Name                                          string                              `json:"Name"`
+		PollingRequestMaximumMessageProcessingTimeout string                              `json:"PollingRequestMaximumMessageProcessingTimeout,omitempty"`
+		PollingRequestQueueTimeout                    string                              `json:"PollingRequestQueueTimeout" validate:"required"`
+		SpaceID                                       string                              `json:"SpaceId,omitempty"`
 		resources.Resource
 	}
 	err := json.Unmarshal(data, &fields)
@@ -146,6 +151,7 @@ func (m *MachinePolicy) UnmarshalJSON(data []byte) error {
 	m.MachineConnectivityPolicy = fields.MachineConnectivityPolicy
 	m.MachineHealthCheckPolicy = fields.MachineHealthCheckPolicy
 	m.MachineUpdatePolicy = fields.MachineUpdatePolicy
+	m.MachinePackageCacheRetentionPolicy = fields.MachinePackageCacheRetentionPolicy
 	m.Name = fields.Name
 	m.SpaceID = fields.SpaceID
 	m.Resource = fields.Resource

--- a/pkg/machinepolicies/machine_policy.go
+++ b/pkg/machinepolicies/machine_policy.go
@@ -39,7 +39,7 @@ func NewMachinePolicy(name string) *MachinePolicy {
 		MachineConnectivityPolicy:                     NewMachineConnectivityPolicy(),
 		MachineHealthCheckPolicy:                      NewMachineHealthCheckPolicy(),
 		MachineUpdatePolicy:                           NewMachineUpdatePolicy(),
-		MachinePackageCacheRetentionPolicy:            NewMachinePackageCacheRetentionPolicy(),
+		MachinePackageCacheRetentionPolicy:            NewDefaultMachinePackageCacheRetentionPolicy(),
 		Name:                                          name,
 		PollingRequestMaximumMessageProcessingTimeout: 10 * time.Minute,
 		PollingRequestQueueTimeout:                    2 * time.Minute,

--- a/pkg/machines/machine_package-cache_retention_policy.go
+++ b/pkg/machines/machine_package-cache_retention_policy.go
@@ -1,0 +1,25 @@
+package machines
+
+type MachinePackageCacheRetentionPolicy struct {
+	Strategy                 string `json:"Strategy" validate:"required,oneof=Default Quantities"`
+	QuantityOfPackagesToKeep int32  `json:"QuantityOfPackagesToKeep,omitempty"`
+	PackageUnit              string `json:"PackageUnit,omitempty" validate:"omitempty,oneof=Items"`
+	QuantityOfVersionsToKeep int32  `json:"QuantityOfVersionsToKeep,omitempty"`
+	VersionUnit              string `json:"VersionUnit,omitempty" validate:"omitempty,oneof=Items"`
+}
+
+func NewDefaultMachinePackageCacheRetentionPolicy() *MachinePackageCacheRetentionPolicy {
+	return &MachinePackageCacheRetentionPolicy{
+		Strategy: "Default",
+	}
+}
+
+func NewMachinePackageCacheRetentionPolicy(strategy string, quantityOfPackages int32, packageUnit string, quantityOfVersions int32, versionUnit string) *MachinePackageCacheRetentionPolicy {
+	return &MachinePackageCacheRetentionPolicy{
+		Strategy:                 strategy,
+		QuantityOfPackagesToKeep: quantityOfPackages,
+		PackageUnit:              packageUnit,
+		QuantityOfVersionsToKeep: quantityOfVersions,
+		VersionUnit:              versionUnit,
+	}
+}

--- a/pkg/machines/machine_policy.go
+++ b/pkg/machines/machine_policy.go
@@ -10,20 +10,21 @@ import (
 )
 
 type MachinePolicy struct {
-	ConnectionConnectTimeout                      time.Duration              `json:"ConnectionConnectTimeout" validate:"required,min=10s"`
-	ConnectionRetryCountLimit                     int32                      `json:"ConnectionRetryCountLimit" validate:"required,gte=2"`
-	ConnectionRetrySleepInterval                  time.Duration              `json:"ConnectionRetrySleepInterval" validate:"required"`
-	ConnectionRetryTimeLimit                      time.Duration              `json:"ConnectionRetryTimeLimit" validate:"required,min=10s"`
-	Description                                   string                     `json:"Description,omitempty"`
-	IsDefault                                     bool                       `json:"IsDefault"`
-	MachineCleanupPolicy                          *MachineCleanupPolicy      `json:"MachineCleanupPolicy"`
-	MachineConnectivityPolicy                     *MachineConnectivityPolicy `json:"MachineConnectivityPolicy"`
-	MachineHealthCheckPolicy                      *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
-	MachineUpdatePolicy                           *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
-	Name                                          string                     `json:"Name" validate:"required,notblank"`
-	PollingRequestMaximumMessageProcessingTimeout time.Duration              `json:"PollingRequestMaximumMessageProcessingTimeout,omitempty"`
-	PollingRequestQueueTimeout                    time.Duration              `json:"PollingRequestQueueTimeout" validate:"required"`
-	SpaceID                                       string                     `json:"SpaceId,omitempty"`
+	ConnectionConnectTimeout                      time.Duration                       `json:"ConnectionConnectTimeout" validate:"required,min=10s"`
+	ConnectionRetryCountLimit                     int32                               `json:"ConnectionRetryCountLimit" validate:"required,gte=2"`
+	ConnectionRetrySleepInterval                  time.Duration                       `json:"ConnectionRetrySleepInterval" validate:"required"`
+	ConnectionRetryTimeLimit                      time.Duration                       `json:"ConnectionRetryTimeLimit" validate:"required,min=10s"`
+	Description                                   string                              `json:"Description,omitempty"`
+	IsDefault                                     bool                                `json:"IsDefault"`
+	MachineCleanupPolicy                          *MachineCleanupPolicy               `json:"MachineCleanupPolicy"`
+	MachineConnectivityPolicy                     *MachineConnectivityPolicy          `json:"MachineConnectivityPolicy"`
+	MachineHealthCheckPolicy                      *MachineHealthCheckPolicy           `json:"MachineHealthCheckPolicy"`
+	MachineUpdatePolicy                           *MachineUpdatePolicy                `json:"MachineUpdatePolicy"`
+	MachinePackageCacheRetentionPolicy            *MachinePackageCacheRetentionPolicy `json:"MachinePackageCacheRetentionPolicy"`
+	Name                                          string                              `json:"Name" validate:"required,notblank"`
+	PollingRequestMaximumMessageProcessingTimeout time.Duration                       `json:"PollingRequestMaximumMessageProcessingTimeout,omitempty"`
+	PollingRequestQueueTimeout                    time.Duration                       `json:"PollingRequestQueueTimeout" validate:"required"`
+	SpaceID                                       string                              `json:"SpaceId,omitempty"`
 
 	resources.Resource
 }
@@ -38,6 +39,7 @@ func NewMachinePolicy(name string) *MachinePolicy {
 		MachineConnectivityPolicy:                     NewMachineConnectivityPolicy(),
 		MachineHealthCheckPolicy:                      NewMachineHealthCheckPolicy(),
 		MachineUpdatePolicy:                           NewMachineUpdatePolicy(),
+		MachinePackageCacheRetentionPolicy:            NewDefaultMachinePackageCacheRetentionPolicy(),
 		Name:                                          name,
 		PollingRequestMaximumMessageProcessingTimeout: 10 * time.Minute,
 		PollingRequestQueueTimeout:                    2 * time.Minute,
@@ -48,33 +50,35 @@ func NewMachinePolicy(name string) *MachinePolicy {
 // MarshalJSON returns a machine policy as its JSON encoding.
 func (m *MachinePolicy) MarshalJSON() ([]byte, error) {
 	machinePolicy := struct {
-		ConnectionConnectTimeout                      string                     `json:"ConnectionConnectTimeout" validate:"required"`
-		ConnectionRetryCountLimit                     int32                      `json:"ConnectionRetryCountLimit" validate:"required"`
-		ConnectionRetrySleepInterval                  string                     `json:"ConnectionRetrySleepInterval" validate:"required"`
-		ConnectionRetryTimeLimit                      string                     `json:"ConnectionRetryTimeLimit" validate:"required"`
-		Description                                   string                     `json:"Description,omitempty"`
-		IsDefault                                     bool                       `json:"IsDefault"`
-		MachineCleanupPolicy                          *MachineCleanupPolicy      `json:"MachineCleanupPolicy"`
-		MachineConnectivityPolicy                     *MachineConnectivityPolicy `json:"MachineConnectivityPolicy"`
-		MachineHealthCheckPolicy                      *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
-		MachineUpdatePolicy                           *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
-		Name                                          string                     `json:"Name" validate:"required,notblank"`
-		PollingRequestMaximumMessageProcessingTimeout string                     `json:"PollingRequestMaximumMessageProcessingTimeout,omitempty"`
-		PollingRequestQueueTimeout                    string                     `json:"PollingRequestQueueTimeout" validate:"required"`
-		SpaceID                                       string                     `json:"SpaceId,omitempty"`
+		ConnectionConnectTimeout                      string                              `json:"ConnectionConnectTimeout" validate:"required"`
+		ConnectionRetryCountLimit                     int32                               `json:"ConnectionRetryCountLimit" validate:"required"`
+		ConnectionRetrySleepInterval                  string                              `json:"ConnectionRetrySleepInterval" validate:"required"`
+		ConnectionRetryTimeLimit                      string                              `json:"ConnectionRetryTimeLimit" validate:"required"`
+		Description                                   string                              `json:"Description,omitempty"`
+		IsDefault                                     bool                                `json:"IsDefault"`
+		MachineCleanupPolicy                          *MachineCleanupPolicy               `json:"MachineCleanupPolicy"`
+		MachineConnectivityPolicy                     *MachineConnectivityPolicy          `json:"MachineConnectivityPolicy"`
+		MachineHealthCheckPolicy                      *MachineHealthCheckPolicy           `json:"MachineHealthCheckPolicy"`
+		MachineUpdatePolicy                           *MachineUpdatePolicy                `json:"MachineUpdatePolicy"`
+		MachinePackageCacheRetentionPolicy            *MachinePackageCacheRetentionPolicy `json:"MachinePackageCacheRetentionPolicy"`
+		Name                                          string                              `json:"Name" validate:"required,notblank"`
+		PollingRequestMaximumMessageProcessingTimeout string                              `json:"PollingRequestMaximumMessageProcessingTimeout,omitempty"`
+		PollingRequestQueueTimeout                    string                              `json:"PollingRequestQueueTimeout" validate:"required"`
+		SpaceID                                       string                              `json:"SpaceId,omitempty"`
 		resources.Resource
 	}{
-		ConnectionConnectTimeout:     ToTimeSpan(m.ConnectionConnectTimeout),
-		ConnectionRetryCountLimit:    m.ConnectionRetryCountLimit,
-		ConnectionRetrySleepInterval: ToTimeSpan(m.ConnectionRetrySleepInterval),
-		ConnectionRetryTimeLimit:     ToTimeSpan(m.ConnectionRetryTimeLimit),
-		Description:                  m.Description,
-		IsDefault:                    m.IsDefault,
-		MachineCleanupPolicy:         m.MachineCleanupPolicy,
-		MachineConnectivityPolicy:    m.MachineConnectivityPolicy,
-		MachineHealthCheckPolicy:     m.MachineHealthCheckPolicy,
-		MachineUpdatePolicy:          m.MachineUpdatePolicy,
-		Name:                         m.Name,
+		ConnectionConnectTimeout:                      ToTimeSpan(m.ConnectionConnectTimeout),
+		ConnectionRetryCountLimit:                     m.ConnectionRetryCountLimit,
+		ConnectionRetrySleepInterval:                  ToTimeSpan(m.ConnectionRetrySleepInterval),
+		ConnectionRetryTimeLimit:                      ToTimeSpan(m.ConnectionRetryTimeLimit),
+		Description:                                   m.Description,
+		IsDefault:                                     m.IsDefault,
+		MachineCleanupPolicy:                          m.MachineCleanupPolicy,
+		MachineConnectivityPolicy:                     m.MachineConnectivityPolicy,
+		MachineHealthCheckPolicy:                      m.MachineHealthCheckPolicy,
+		MachineUpdatePolicy:                           m.MachineUpdatePolicy,
+		MachinePackageCacheRetentionPolicy:            m.MachinePackageCacheRetentionPolicy,
+		Name:                                          m.Name,
 		PollingRequestMaximumMessageProcessingTimeout: ToTimeSpan(m.PollingRequestMaximumMessageProcessingTimeout),
 		PollingRequestQueueTimeout:                    ToTimeSpan(m.PollingRequestQueueTimeout),
 		SpaceID:                                       m.SpaceID,
@@ -87,20 +91,21 @@ func (m *MachinePolicy) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON sets this Kubernetes endpoint to its representation in JSON.
 func (m *MachinePolicy) UnmarshalJSON(data []byte) error {
 	var fields struct {
-		ConnectionConnectTimeout                      string                     `json:"ConnectionConnectTimeout" validate:"required"`
-		ConnectionRetryCountLimit                     int32                      `json:"ConnectionRetryCountLimit" validate:"required"`
-		ConnectionRetrySleepInterval                  string                     `json:"ConnectionRetrySleepInterval" validate:"required"`
-		ConnectionRetryTimeLimit                      string                     `json:"ConnectionRetryTimeLimit" validate:"required"`
-		Description                                   string                     `json:"Description,omitempty"`
-		IsDefault                                     bool                       `json:"IsDefault"`
-		MachineCleanupPolicy                          *MachineCleanupPolicy      `json:"MachineCleanupPolicy"`
-		MachineConnectivityPolicy                     *MachineConnectivityPolicy `json:"MachineConnectivityPolicy"`
-		MachineHealthCheckPolicy                      *MachineHealthCheckPolicy  `json:"MachineHealthCheckPolicy"`
-		MachineUpdatePolicy                           *MachineUpdatePolicy       `json:"MachineUpdatePolicy"`
-		Name                                          string                     `json:"Name"`
-		PollingRequestMaximumMessageProcessingTimeout string                     `json:"PollingRequestMaximumMessageProcessingTimeout,omitempty"`
-		PollingRequestQueueTimeout                    string                     `json:"PollingRequestQueueTimeout" validate:"required"`
-		SpaceID                                       string                     `json:"SpaceId,omitempty"`
+		ConnectionConnectTimeout                      string                              `json:"ConnectionConnectTimeout" validate:"required"`
+		ConnectionRetryCountLimit                     int32                               `json:"ConnectionRetryCountLimit" validate:"required"`
+		ConnectionRetrySleepInterval                  string                              `json:"ConnectionRetrySleepInterval" validate:"required"`
+		ConnectionRetryTimeLimit                      string                              `json:"ConnectionRetryTimeLimit" validate:"required"`
+		Description                                   string                              `json:"Description,omitempty"`
+		IsDefault                                     bool                                `json:"IsDefault"`
+		MachineCleanupPolicy                          *MachineCleanupPolicy               `json:"MachineCleanupPolicy"`
+		MachineConnectivityPolicy                     *MachineConnectivityPolicy          `json:"MachineConnectivityPolicy"`
+		MachineHealthCheckPolicy                      *MachineHealthCheckPolicy           `json:"MachineHealthCheckPolicy"`
+		MachineUpdatePolicy                           *MachineUpdatePolicy                `json:"MachineUpdatePolicy"`
+		MachinePackageCacheRetentionPolicy            *MachinePackageCacheRetentionPolicy `json:"MachinePackageCacheRetentionPolicy"`
+		Name                                          string                              `json:"Name"`
+		PollingRequestMaximumMessageProcessingTimeout string                              `json:"PollingRequestMaximumMessageProcessingTimeout,omitempty"`
+		PollingRequestQueueTimeout                    string                              `json:"PollingRequestQueueTimeout" validate:"required"`
+		SpaceID                                       string                              `json:"SpaceId,omitempty"`
 		resources.Resource
 	}
 	err := json.Unmarshal(data, &fields)
@@ -146,6 +151,7 @@ func (m *MachinePolicy) UnmarshalJSON(data []byte) error {
 	m.MachineConnectivityPolicy = fields.MachineConnectivityPolicy
 	m.MachineHealthCheckPolicy = fields.MachineHealthCheckPolicy
 	m.MachineUpdatePolicy = fields.MachineUpdatePolicy
+	m.MachinePackageCacheRetentionPolicy = fields.MachinePackageCacheRetentionPolicy
 	m.Name = fields.Name
 	m.SpaceID = fields.SpaceID
 	m.Resource = fields.Resource

--- a/pkg/machines/machine_policy_service_test.go
+++ b/pkg/machines/machine_policy_service_test.go
@@ -37,6 +37,7 @@ func CreateTestMachinePolicy(t *testing.T, service *MachinePolicyService) *Machi
 	machineHealthCheckPolicy.HealthCheckInterval = getRandomDuration(1)
 
 	machineUpdatePolicy := NewMachineUpdatePolicy()
+	machinePackageCacheRetentionPolicy := NewDefaultMachinePackageCacheRetentionPolicy()
 
 	machinePolicy := NewMachinePolicy(name)
 	machinePolicy.ConnectionConnectTimeout = connectionConnectTimeout
@@ -45,6 +46,7 @@ func CreateTestMachinePolicy(t *testing.T, service *MachinePolicyService) *Machi
 	machinePolicy.MachineCleanupPolicy = machineCleanupPolicy
 	machinePolicy.MachineHealthCheckPolicy = machineHealthCheckPolicy
 	machinePolicy.MachineUpdatePolicy = machineUpdatePolicy
+	machinePolicy.MachinePackageCacheRetentionPolicy = machinePackageCacheRetentionPolicy
 	machinePolicy.PollingRequestMaximumMessageProcessingTimeout = pollingRequestMaximumMessageProcessingTimeout
 	machinePolicy.PollingRequestQueueTimeout = pollingRequestQueueTimeout
 	require.NoError(t, machinePolicy.Validate())
@@ -100,6 +102,7 @@ func IsEqualMachinePolicies(t *testing.T, expected *MachinePolicy, actual *Machi
 	assert.Equal(t, expected.MachineConnectivityPolicy, actual.MachineConnectivityPolicy)
 	assert.Equal(t, expected.MachineHealthCheckPolicy, actual.MachineHealthCheckPolicy)
 	assert.Equal(t, expected.MachineUpdatePolicy, actual.MachineUpdatePolicy)
+	assert.Equal(t, expected.MachinePackageCacheRetentionPolicy, actual.MachinePackageCacheRetentionPolicy)
 	assert.Equal(t, expected.Name, actual.Name)
 	assert.Equal(t, expected.PollingRequestMaximumMessageProcessingTimeout, actual.PollingRequestMaximumMessageProcessingTimeout)
 	assert.Equal(t, expected.PollingRequestQueueTimeout, actual.PollingRequestQueueTimeout)


### PR DESCRIPTION
# Background

The machine policy has a new field for package cache retention settings, which enables configurable package cache on deployment targets and workers.

# Result
This PR adds the new field to the Go client.
[sc-112057]
Related: https://github.com/OctopusDeploy/Issues/issues/9421