### PR TITLE
fix: 336 - make audience ref

### DIFF
--- a/pkg/serviceaccounts/oidc_identities.go
+++ b/pkg/serviceaccounts/oidc_identities.go
@@ -14,11 +14,11 @@ type OIDCIdentityQuery struct {
 }
 
 type OIDCIdentity struct {
-	Audience         string `json:"Audience"`
-	Issuer           string `json:"Issuer"`
-	Name             string `json:"Name"`
-	ServiceAccountID string `json:"ServiceAccountId"`
-	Subject          string `json:"Subject"`
+	Audience         *string `json:"Audience"`
+	Issuer           string  `json:"Issuer"`
+	Name             string  `json:"Name"`
+	ServiceAccountID string  `json:"ServiceAccountId"`
+	Subject          string  `json:"Subject"`
 	resources.Resource
 }
 


### PR DESCRIPTION
https://github.com/OctopusDeploy/go-octopusdeploy/issues/338

Make audience a ref. I can't see any usage, getters or setters in the codebase. So provided it passes the tests we should be good.

This is a blocker for adopting the terraform provider as it's currently none functional for deploying OIDC on service accounts