### PR TITLE
Add support for Git Credential Repository Restrictions

### DIFF
--- a/pkg/credentials/resource.go
+++ b/pkg/credentials/resource.go
@@ -6,11 +6,11 @@ import (
 )
 
 type Resource struct {
-	Description            string                 `json:"Description,omitempty"`
-	Details                GitCredential          `json:"Details"`
-	Name                   string                 `json:"Name"`
-	SpaceID                string                 `json:"SpaceId,omitempty"`
-	RepositoryRestrictions RepositoryRestrictions `json:"RepositoryRestrictions"`
+	Description            string                  `json:"Description,omitempty"`
+	Details                GitCredential           `json:"Details"`
+	Name                   string                  `json:"Name"`
+	SpaceID                string                  `json:"SpaceId,omitempty"`
+	RepositoryRestrictions *RepositoryRestrictions `json:"RepositoryRestrictions"`
 	resources.Resource
 }
 
@@ -66,7 +66,7 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 		if err := json.Unmarshal(*restrictionsValue, &repositoryRestrictions); err != nil {
 			return err
 		}
-		r.RepositoryRestrictions = repositoryRestrictions
+		r.RepositoryRestrictions = &repositoryRestrictions
 	}
 
 	var gitCredentials *json.RawMessage

--- a/pkg/credentials/resource.go
+++ b/pkg/credentials/resource.go
@@ -2,17 +2,21 @@ package credentials
 
 import (
 	"encoding/json"
-
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 )
 
 type Resource struct {
-	Description string        `json:"Description,omitempty"`
-	Details     GitCredential `json:"Details"`
-	Name        string        `json:"Name"`
-	SpaceID     string        `json:"SpaceId,omitempty"`
-
+	Description            string                 `json:"Description,omitempty"`
+	Details                GitCredential          `json:"Details"`
+	Name                   string                 `json:"Name"`
+	SpaceID                string                 `json:"SpaceId,omitempty"`
+	RepositoryRestrictions RepositoryRestrictions `json:"RepositoryRestrictions"`
 	resources.Resource
+}
+
+type RepositoryRestrictions struct {
+	Enabled             bool     `json:"Enabled"`
+	AllowedRepositories []string `json:"AllowedRepositories"`
 }
 
 func NewResource(name string, credential GitCredential) *Resource {
@@ -53,6 +57,16 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 	var rawResource map[string]*json.RawMessage
 	if err := json.Unmarshal(b, &rawResource); err != nil {
 		return err
+	}
+
+	var repositoryRestrictions RepositoryRestrictions
+	if rawResource["RepositoryRestrictions"] != nil {
+		restrictionsValue := rawResource["RepositoryRestrictions"]
+
+		if err := json.Unmarshal(*restrictionsValue, &repositoryRestrictions); err != nil {
+			return err
+		}
+		r.RepositoryRestrictions = repositoryRestrictions
 	}
 
 	var gitCredentials *json.RawMessage

--- a/pkg/credentials/resource_test.go
+++ b/pkg/credentials/resource_test.go
@@ -60,6 +60,10 @@ func TestResourceWithAnonymousAsJSON(t *testing.T) {
 		AllowedRepositories: []string{},
 	}
 
+	restrictionsAsJSON, err := json.Marshal(restrictions)
+	require.NoError(t, err)
+	require.NotNil(t, restrictionsAsJSON)
+
 	anonymousdAsJSON, err := json.Marshal(anonymous)
 	require.NoError(t, err)
 	require.NotNil(t, anonymousdAsJSON)
@@ -78,7 +82,7 @@ func TestResourceWithAnonymousAsJSON(t *testing.T) {
 		"Links": {
 			"Self": "%s"
 		}
-	}`, description, anonymousdAsJSON, restrictions, id, name, selfLink)
+	}`, description, anonymousdAsJSON, restrictionsAsJSON, id, name, selfLink)
 
 	resourceAsJSON, err := json.Marshal(resource)
 	require.NoError(t, err)

--- a/pkg/credentials/resource_test.go
+++ b/pkg/credentials/resource_test.go
@@ -55,6 +55,11 @@ func TestResourceWithAnonymousAsJSON(t *testing.T) {
 	name := internal.GetRandomName()
 	selfLink := internal.GetRandomName()
 
+	restrictions := credentials.RepositoryRestrictions{
+		Enabled:             false,
+		AllowedRepositories: []string{},
+	}
+
 	anonymousdAsJSON, err := json.Marshal(anonymous)
 	require.NoError(t, err)
 	require.NotNil(t, anonymousdAsJSON)
@@ -67,12 +72,13 @@ func TestResourceWithAnonymousAsJSON(t *testing.T) {
 	expectedJSON := fmt.Sprintf(`{
 		"Description": "%s",
 		"Details": %s,
+        "RepositoryRestrictions": %s,
 		"Id": "%s",
 		"Name": "%s",
 		"Links": {
 			"Self": "%s"
 		}
-	}`, description, anonymousdAsJSON, id, name, selfLink)
+	}`, description, anonymousdAsJSON, restrictions, id, name, selfLink)
 
 	resourceAsJSON, err := json.Marshal(resource)
 	require.NoError(t, err)

--- a/pkg/credentials/resource_test.go
+++ b/pkg/credentials/resource_test.go
@@ -39,7 +39,7 @@ func TestResourceWithUsernamePasswordAsJSON(t *testing.T) {
 	resource.Description = description
 	resource.ID = id
 	resource.Links["Self"] = selfLink
-	resource.RepositoryRestrictions = restrictions
+	resource.RepositoryRestrictions = &restrictions
 
 	expectedJSON := fmt.Sprintf(`{
 		"Description": "%s",
@@ -83,7 +83,7 @@ func TestResourceWithAnonymousAsJSON(t *testing.T) {
 	resource.Description = description
 	resource.ID = id
 	resource.Links["Self"] = selfLink
-	resource.RepositoryRestrictions = restrictions
+	resource.RepositoryRestrictions = &restrictions
 
 	expectedJSON := fmt.Sprintf(`{
 		"Description": "%s",
@@ -128,7 +128,7 @@ func TestResourceWithReferenceAsJSON(t *testing.T) {
 	resource.Description = description
 	resource.ID = id
 	resource.Links["Self"] = selfLink
-	resource.RepositoryRestrictions = restrictions
+	resource.RepositoryRestrictions = &restrictions
 
 	expectedJSON := fmt.Sprintf(`{
 		"Description": "%s",

--- a/pkg/credentials/resource_test.go
+++ b/pkg/credentials/resource_test.go
@@ -20,6 +20,15 @@ func TestResourceWithUsernamePasswordAsJSON(t *testing.T) {
 	selfLink := internal.GetRandomName()
 	username := internal.GetRandomName()
 
+	restrictions := credentials.RepositoryRestrictions{
+		Enabled:             false,
+		AllowedRepositories: []string{},
+	}
+
+	restrictionsAsJSON, err := json.Marshal(restrictions)
+	require.NoError(t, err)
+	require.NotNil(t, restrictionsAsJSON)
+
 	usernamePassword := credentials.NewUsernamePassword(username, password)
 
 	usernamePasswordAsJSON, err := json.Marshal(usernamePassword)
@@ -30,16 +39,18 @@ func TestResourceWithUsernamePasswordAsJSON(t *testing.T) {
 	resource.Description = description
 	resource.ID = id
 	resource.Links["Self"] = selfLink
+	resource.RepositoryRestrictions = restrictions
 
 	expectedJSON := fmt.Sprintf(`{
 		"Description": "%s",
 		"Details": %s,
-		"Id": "%s",
+		"RepositoryRestrictions": %s,
+        "Id": "%s",
 		"Name": "%s",
 		"Links": {
 			"Self": "%s"
 		}
-	}`, description, usernamePasswordAsJSON, id, name, selfLink)
+	}`, description, usernamePasswordAsJSON, restrictionsAsJSON, id, name, selfLink)
 
 	resourceAsJSON, err := json.Marshal(resource)
 	require.NoError(t, err)
@@ -72,6 +83,7 @@ func TestResourceWithAnonymousAsJSON(t *testing.T) {
 	resource.Description = description
 	resource.ID = id
 	resource.Links["Self"] = selfLink
+	resource.RepositoryRestrictions = restrictions
 
 	expectedJSON := fmt.Sprintf(`{
 		"Description": "%s",
@@ -103,20 +115,31 @@ func TestResourceWithReferenceAsJSON(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, referenceAsJSON)
 
+	restrictions := credentials.RepositoryRestrictions{
+		Enabled:             false,
+		AllowedRepositories: []string{},
+	}
+
+	restrictionsAsJSON, err := json.Marshal(restrictions)
+	require.NoError(t, err)
+	require.NotNil(t, restrictionsAsJSON)
+
 	resource := credentials.NewResource(name, reference)
 	resource.Description = description
 	resource.ID = id
 	resource.Links["Self"] = selfLink
+	resource.RepositoryRestrictions = restrictions
 
 	expectedJSON := fmt.Sprintf(`{
 		"Description": "%s",
 		"Details": %s,
+		"RepositoryRestrictions": %s,
 		"Id": "%s",
 		"Name": "%s",
 		"Links": {
 			"Self": "%s"
 		}
-	}`, description, referenceAsJSON, id, name, selfLink)
+	}`, description, referenceAsJSON, restrictionsAsJSON, id, name, selfLink)
 
 	resourceAsJSON, err := json.Marshal(resource)
 	require.NoError(t, err)

--- a/test/e2e/git_credential_service_test.go
+++ b/test/e2e/git_credential_service_test.go
@@ -26,7 +26,7 @@ func CreateTestGitCredentialResource(t *testing.T, client *client.Client) *crede
 
 	resource := credentials.NewResource(name, usernamePassword)
 	resource.Description = description
-	resource.RepositoryRestrictions = credentials.RepositoryRestrictions{
+	resource.RepositoryRestrictions = &credentials.RepositoryRestrictions{
 		Enabled:             true,
 		AllowedRepositories: []string{"https://github.com/*", "http://gitlab.com"},
 	}
@@ -152,7 +152,7 @@ func TestCredentialServiceUpdate(t *testing.T) {
 	resource.Description = newDescription
 	resource.Name = newName
 	allowedRepositories := []string{"https://foo.com/*", "http://bar.com"}
-	resource.RepositoryRestrictions = credentials.RepositoryRestrictions{
+	resource.RepositoryRestrictions = &credentials.RepositoryRestrictions{
 		Enabled:             true,
 		AllowedRepositories: allowedRepositories,
 	}

--- a/test/e2e/git_credential_service_test.go
+++ b/test/e2e/git_credential_service_test.go
@@ -165,6 +165,27 @@ func TestCredentialServiceUpdate(t *testing.T) {
 	require.ElementsMatch(t, allowedRepositories, updatedCredential.RepositoryRestrictions.AllowedRepositories)
 }
 
+func TestCredentialServiceUpdateWithNullRepositoryRestrictions(t *testing.T) {
+	client := getOctopusClient()
+	require.NotNil(t, client)
+
+	resource := CreateTestGitCredentialResource(t, client)
+	defer DeleteTestGitCredentialResource(t, client, resource)
+
+	resource, err := client.GitCredentials.GetByID(resource.GetID())
+	require.NotNil(t, resource)
+	require.NoError(t, err)
+	originalAllowedRepositories := []string{"https://github.com/*", "http://gitlab.com"}
+	require.ElementsMatch(t, originalAllowedRepositories, resource.RepositoryRestrictions.AllowedRepositories)
+
+	resource.RepositoryRestrictions = nil
+
+	updatedCredential := UpdateTestGitCredentialResource(t, client, resource)
+	require.NotNil(t, updatedCredential)
+	require.NotEmpty(t, updatedCredential.GetID())
+	require.ElementsMatch(t, originalAllowedRepositories, updatedCredential.RepositoryRestrictions.AllowedRepositories)
+}
+
 func TestCredentialServiceAddGetDelete_NewClient(t *testing.T) {
 	client := getOctopusClient()
 	require.NotNil(t, client)

--- a/test/e2e/git_credential_service_test.go
+++ b/test/e2e/git_credential_service_test.go
@@ -151,13 +151,18 @@ func TestCredentialServiceUpdate(t *testing.T) {
 
 	resource.Description = newDescription
 	resource.Name = newName
-
+	allowedRepositories := []string{"https://foo.com/*", "http://bar.com"}
+	resource.RepositoryRestrictions = credentials.RepositoryRestrictions{
+		Enabled:             true,
+		AllowedRepositories: allowedRepositories,
+	}
 	updatedCredential := UpdateTestGitCredentialResource(t, client, resource)
 	require.NotNil(t, updatedCredential)
 	require.NotEmpty(t, updatedCredential.GetID())
 	require.Equal(t, updatedCredential.GetID(), updatedCredential.GetID())
 	require.Equal(t, newDescription, updatedCredential.Description)
 	require.Equal(t, newName, updatedCredential.Name)
+	require.ElementsMatch(t, allowedRepositories, updatedCredential.RepositoryRestrictions.AllowedRepositories)
 }
 
 func TestCredentialServiceAddGetDelete_NewClient(t *testing.T) {

--- a/test/e2e/git_credential_service_test.go
+++ b/test/e2e/git_credential_service_test.go
@@ -26,7 +26,10 @@ func CreateTestGitCredentialResource(t *testing.T, client *client.Client) *crede
 
 	resource := credentials.NewResource(name, usernamePassword)
 	resource.Description = description
-
+	resource.RepositoryRestrictions = credentials.RepositoryRestrictions{
+		Enabled:             true,
+		AllowedRepositories: []string{"https://github.com/*", "http://gitlab.com"},
+	}
 	require.NoError(t, resource.Validate())
 
 	createdResource, err := client.GitCredentials.Add(resource)


### PR DESCRIPTION
[sc-112803]

Part of [#project-argo-cd-in-octopus](https://octopusdeploy.slack.com/archives/C08QKUX0LHW)

Updating the client to add the new repository restriction property. [Corresponding server changes here](https://github.com/OctopusDeploy/OctopusDeploy/commit/0bf2e63b5e114cfd5dd8fa8f9a8c8fd5425fb204#diff-98ba59e06c23b45f71e7e0471869dc3f402b7d107545bf4e5ef6cd9479417996).

Related to: https://github.com/OctopusDeploy/Issues/issues/9471