### PR TITLE
Consolidate the OidcAuthentication properties on FeedResource into a single property

### DIFF
--- a/pkg/feeds/aws_elastic_container_registry.go
+++ b/pkg/feeds/aws_elastic_container_registry.go
@@ -36,7 +36,7 @@ func NewAwsElasticContainerRegistry(name string, accessKey string, secretKey *co
 		return nil, internal.CreateRequiredParameterIsEmptyOrNilError("accessKey")
 	}
 
-	if !internal.IsEmpty(accessKey) && secretKey == nil && oidcAuthentication == nil {
+	if !internal.IsEmpty(accessKey) && secretKey == nil {
 		return nil, internal.CreateRequiredParameterIsEmptyOrNilError("secretKey")
 	}
 

--- a/pkg/feeds/aws_elastic_container_registry.go
+++ b/pkg/feeds/aws_elastic_container_registry.go
@@ -36,7 +36,7 @@ func NewAwsElasticContainerRegistry(name string, accessKey string, secretKey *co
 		return nil, internal.CreateRequiredParameterIsEmptyOrNilError("accessKey")
 	}
 
-	if !internal.IsEmpty(accessKey) && secretKey == nil {
+	if !internal.IsEmpty(accessKey) && secretKey == nil && oidcAuthentication == nil {
 		return nil, internal.CreateRequiredParameterIsEmptyOrNilError("secretKey")
 	}
 

--- a/pkg/feeds/feed_resource.go
+++ b/pkg/feeds/feed_resource.go
@@ -9,8 +9,7 @@ import (
 
 type FeedResource struct {
 	AccessKey                                  string                                         `json:"AccessKey,omitempty"`
-	AzureContainerRegistryOidcAuthentication   *AzureContainerRegistryOidcAuthentication      `json:"AzureContainerRegistryOidcAuthentication,omitempty"`
-	ElasticContainerRegistryOidcAuthentication *AwsElasticContainerRegistryOidcAuthentication `json:"OidcAuthentication,omitempty"`
+	OidcAuthentication                         *OidcAuthentication                            `json:"OidcAuthentication,omitempty"`
 	APIVersion                                 string                                         `json:"ApiVersion,omitempty"`
 	DeletePackagesAssociatedWithReleases       bool                                           `json:"DeletePackagesAssociatedWithReleases"`
 	DeleteUnreleasedPackagesAfterDays          int                                            `json:"DeleteUnreleasedPackagesAfterDays"`
@@ -19,7 +18,6 @@ type FeedResource struct {
 	EnhancedMode                               bool                                           `json:"EnhancedMode"`
 	FeedType                                   FeedType                                       `json:"FeedType" validate:"required,notblank"`
 	FeedURI                                    string                                         `json:"FeedUri,omitempty"`
-	GoogleContainerRegistryOidcAuthentication  *GoogleContainerRegistryOidcAuthentication     `json:"GoogleContainerRegistryOidcAuthentication,omitempty"`
 	IsBuiltInRepoSyncEnabled                   bool                                           `json:"IsBuiltInRepoSyncEnabled"`
 	Name                                       string                                         `json:"Name" validate:"required,notblank"`
 	Password                                   *core.SensitiveValue                           `json:"Password,omitempty"`

--- a/pkg/feeds/google_container_registry.go
+++ b/pkg/feeds/google_container_registry.go
@@ -30,7 +30,7 @@ func NewGoogleContainerRegistry(name string, username string, password *core.Sen
 		}
 	}
 
-	dockerContainerRegistry, err := NewDockerContainerRegistryWithFeedType(name, FeedTypeAzureContainerRegistry)
+	dockerContainerRegistry, err := NewDockerContainerRegistryWithFeedType(name, FeedTypeGoogleContainerRegistry)
 
 	if err != nil {
 		return nil, err

--- a/pkg/feeds/oidc_authentication.go
+++ b/pkg/feeds/oidc_authentication.go
@@ -166,9 +166,6 @@ func (o *OidcAuthentication) UnmarshalJSON(data []byte) error {
 	switch o.Type {
 	case OidcAuthenticationTypeAzure:
 		var azure AzureContainerRegistryOidcAuthentication
-		if err := json.Unmarshal(data, &azure); err != nil {
-			return err
-		}
 		o.Type = OidcAuthenticationTypeAzure
 		o.ClientId = azure.ClientId
 		o.TenantId = azure.TenantId
@@ -177,9 +174,6 @@ func (o *OidcAuthentication) UnmarshalJSON(data []byte) error {
 
 	case OidcAuthenticationTypeAWS:
 		var aws AwsElasticContainerRegistryOidcAuthentication
-		if err := json.Unmarshal(data, &aws); err != nil {
-			return err
-		}
 		o.Type = OidcAuthenticationTypeAWS
 		o.SessionDuration = aws.SessionDuration
 		o.Audience = aws.Audience
@@ -188,9 +182,6 @@ func (o *OidcAuthentication) UnmarshalJSON(data []byte) error {
 
 	case OidcAuthenticationTypeGoogle:
 		var google GoogleContainerRegistryOidcAuthentication
-		if err := json.Unmarshal(data, &google); err != nil {
-			return err
-		}
 		o.Type = OidcAuthenticationTypeGoogle
 		o.Audience = google.Audience
 		o.SubjectKeys = google.SubjectKeys

--- a/pkg/feeds/oidc_authentication.go
+++ b/pkg/feeds/oidc_authentication.go
@@ -1,0 +1,200 @@
+package feeds
+
+import (
+	"encoding/json"
+)
+
+// OidcAuthentication represents a union type that can hold any of the three OIDC authentication types
+// The properties are flattened at the top level for API compatibility
+type OidcAuthentication struct {
+	// Type indicates which OIDC authentication type this represents
+	Type OidcAuthenticationType `json:"Type"`
+
+	// Common fields across all OIDC types
+	Audience    string   `json:"Audience,omitempty"`
+	SubjectKeys []string `json:"SubjectKeys,omitempty"`
+
+	// Azure-specific fields
+	ClientId string `json:"ClientId,omitempty"`
+	TenantId string `json:"TenantId,omitempty"`
+
+	// AWS-specific fields
+	SessionDuration string `json:"SessionDuration,omitempty"`
+	RoleArn         string `json:"RoleArn,omitempty"`
+}
+
+// OidcAuthenticationType represents the type of OIDC authentication
+type OidcAuthenticationType string
+
+const (
+	OidcAuthenticationTypeAzure  OidcAuthenticationType = "Azure"
+	OidcAuthenticationTypeAWS    OidcAuthenticationType = "AWS"
+	OidcAuthenticationTypeGoogle OidcAuthenticationType = "Google"
+)
+
+// NewAzureOidcAuthentication creates a new OIDC authentication for Azure
+func NewAzureOidcAuthentication(clientId, tenantId, audience string, subjectKeys []string) *OidcAuthentication {
+	return &OidcAuthentication{
+		Type:        OidcAuthenticationTypeAzure,
+		ClientId:    clientId,
+		TenantId:    tenantId,
+		Audience:    audience,
+		SubjectKeys: subjectKeys,
+	}
+}
+
+// NewAwsOidcAuthentication creates a new OIDC authentication for AWS
+func NewAwsOidcAuthentication(sessionDuration, audience, roleArn string, subjectKeys []string) *OidcAuthentication {
+	return &OidcAuthentication{
+		Type:            OidcAuthenticationTypeAWS,
+		SessionDuration: sessionDuration,
+		Audience:        audience,
+		RoleArn:         roleArn,
+		SubjectKeys:     subjectKeys,
+	}
+}
+
+// NewGoogleOidcAuthentication creates a new OIDC authentication for Google
+func NewGoogleOidcAuthentication(audience string, subjectKeys []string) *OidcAuthentication {
+	return &OidcAuthentication{
+		Type:        OidcAuthenticationTypeGoogle,
+		Audience:    audience,
+		SubjectKeys: subjectKeys,
+	}
+}
+
+// GetAzure returns the Azure OIDC authentication data if this is an Azure type
+func (o *OidcAuthentication) GetAzure() (*AzureContainerRegistryOidcAuthentication, bool) {
+	if o.Type == OidcAuthenticationTypeAzure {
+		return &AzureContainerRegistryOidcAuthentication{
+			ClientId:    o.ClientId,
+			TenantId:    o.TenantId,
+			Audience:    o.Audience,
+			SubjectKeys: o.SubjectKeys,
+		}, true
+	}
+	return nil, false
+}
+
+// GetAWS returns the AWS OIDC authentication data if this is an AWS type
+func (o *OidcAuthentication) GetAWS() (*AwsElasticContainerRegistryOidcAuthentication, bool) {
+	if o.Type == OidcAuthenticationTypeAWS {
+		return &AwsElasticContainerRegistryOidcAuthentication{
+			SessionDuration: o.SessionDuration,
+			Audience:        o.Audience,
+			SubjectKeys:     o.SubjectKeys,
+			RoleArn:         o.RoleArn,
+		}, true
+	}
+	return nil, false
+}
+
+// GetGoogle returns the Google OIDC authentication data if this is a Google type
+func (o *OidcAuthentication) GetGoogle() (*GoogleContainerRegistryOidcAuthentication, bool) {
+	if o.Type == OidcAuthenticationTypeGoogle {
+		return &GoogleContainerRegistryOidcAuthentication{
+			Audience:    o.Audience,
+			SubjectKeys: o.SubjectKeys,
+		}, true
+	}
+	return nil, false
+}
+
+// MarshalJSON implements custom JSON marshaling to handle the union type
+func (o *OidcAuthentication) MarshalJSON() ([]byte, error) {
+	// Create a map to hold the fields we want to serialize
+	result := make(map[string]interface{})
+
+	// Always include the Type field
+	result["Type"] = o.Type
+
+	// Add common fields
+	if o.Audience != "" {
+		result["Audience"] = o.Audience
+	}
+	if len(o.SubjectKeys) > 0 {
+		result["SubjectKeys"] = o.SubjectKeys
+	}
+
+	// Add type-specific fields based on the type
+	switch o.Type {
+	case OidcAuthenticationTypeAzure:
+		if o.ClientId != "" {
+			result["ClientId"] = o.ClientId
+		}
+		if o.TenantId != "" {
+			result["TenantId"] = o.TenantId
+		}
+	case OidcAuthenticationTypeAWS:
+		if o.SessionDuration != "" {
+			result["SessionDuration"] = o.SessionDuration
+		}
+		if o.RoleArn != "" {
+			result["RoleArn"] = o.RoleArn
+		}
+	case OidcAuthenticationTypeGoogle:
+		// Google only has common fields, no additional ones
+	}
+
+	return json.Marshal(result)
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling to handle the union type
+func (o *OidcAuthentication) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		*o = OidcAuthentication{}
+		return nil
+	}
+
+	// First, unmarshal into a map to inspect the fields
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	// Discriminate based on properties. This is hacky, but we would have to add a "Type" property to the API
+	// To handle this properly
+	if _, hasClientId := raw["ClientId"]; hasClientId {
+		o.Type = OidcAuthenticationTypeAzure
+	} else if _, hasRoleArn := raw["RoleArn"]; hasRoleArn {
+		o.Type = OidcAuthenticationTypeAWS
+	} else {
+		o.Type = OidcAuthenticationTypeGoogle
+	}
+
+	// Now unmarshal into the appropriate struct to get all fields
+	switch o.Type {
+	case OidcAuthenticationTypeAzure:
+		var azure AzureContainerRegistryOidcAuthentication
+		if err := json.Unmarshal(data, &azure); err != nil {
+			return err
+		}
+		o.Type = OidcAuthenticationTypeAzure
+		o.ClientId = azure.ClientId
+		o.TenantId = azure.TenantId
+		o.Audience = azure.Audience
+		o.SubjectKeys = azure.SubjectKeys
+
+	case OidcAuthenticationTypeAWS:
+		var aws AwsElasticContainerRegistryOidcAuthentication
+		if err := json.Unmarshal(data, &aws); err != nil {
+			return err
+		}
+		o.Type = OidcAuthenticationTypeAWS
+		o.SessionDuration = aws.SessionDuration
+		o.Audience = aws.Audience
+		o.SubjectKeys = aws.SubjectKeys
+		o.RoleArn = aws.RoleArn
+
+	case OidcAuthenticationTypeGoogle:
+		var google GoogleContainerRegistryOidcAuthentication
+		if err := json.Unmarshal(data, &google); err != nil {
+			return err
+		}
+		o.Type = OidcAuthenticationTypeGoogle
+		o.Audience = google.Audience
+		o.SubjectKeys = google.SubjectKeys
+	}
+
+	return nil
+}

--- a/pkg/feeds/oidc_authentication.go
+++ b/pkg/feeds/oidc_authentication.go
@@ -166,6 +166,9 @@ func (o *OidcAuthentication) UnmarshalJSON(data []byte) error {
 	switch o.Type {
 	case OidcAuthenticationTypeAzure:
 		var azure AzureContainerRegistryOidcAuthentication
+		if err := json.Unmarshal(data, &azure); err != nil {
+			return err
+		}
 		o.Type = OidcAuthenticationTypeAzure
 		o.ClientId = azure.ClientId
 		o.TenantId = azure.TenantId
@@ -174,6 +177,9 @@ func (o *OidcAuthentication) UnmarshalJSON(data []byte) error {
 
 	case OidcAuthenticationTypeAWS:
 		var aws AwsElasticContainerRegistryOidcAuthentication
+		if err := json.Unmarshal(data, &aws); err != nil {
+			return err
+		}
 		o.Type = OidcAuthenticationTypeAWS
 		o.SessionDuration = aws.SessionDuration
 		o.Audience = aws.Audience
@@ -182,6 +188,9 @@ func (o *OidcAuthentication) UnmarshalJSON(data []byte) error {
 
 	case OidcAuthenticationTypeGoogle:
 		var google GoogleContainerRegistryOidcAuthentication
+		if err := json.Unmarshal(data, &google); err != nil {
+			return err
+		}
 		o.Type = OidcAuthenticationTypeGoogle
 		o.Audience = google.Audience
 		o.SubjectKeys = google.SubjectKeys

--- a/pkg/feeds/oidc_authentication_test.go
+++ b/pkg/feeds/oidc_authentication_test.go
@@ -1,0 +1,238 @@
+package feeds
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOidcAuthentication_NewAzureOidcAuthentication(t *testing.T) {
+	oidc := NewAzureOidcAuthentication("client-id", "tenant-id", "audience", []string{"subject1", "subject2"})
+	
+	assert.Equal(t, OidcAuthenticationTypeAzure, oidc.Type)
+	assert.Equal(t, "client-id", oidc.ClientId)
+	assert.Equal(t, "tenant-id", oidc.TenantId)
+	assert.Equal(t, "audience", oidc.Audience)
+	assert.Equal(t, []string{"subject1", "subject2"}, oidc.SubjectKeys)
+	
+	azure, ok := oidc.GetAzure()
+	assert.True(t, ok)
+	assert.Equal(t, "client-id", azure.ClientId)
+	assert.Equal(t, "tenant-id", azure.TenantId)
+	assert.Equal(t, "audience", azure.Audience)
+	assert.Equal(t, []string{"subject1", "subject2"}, azure.SubjectKeys)
+}
+
+func TestOidcAuthentication_NewAwsOidcAuthentication(t *testing.T) {
+	oidc := NewAwsOidcAuthentication("3600", "audience", "role-arn", []string{"subject1", "subject2"})
+	
+	assert.Equal(t, OidcAuthenticationTypeAWS, oidc.Type)
+	assert.Equal(t, "3600", oidc.SessionDuration)
+	assert.Equal(t, "audience", oidc.Audience)
+	assert.Equal(t, "role-arn", oidc.RoleArn)
+	assert.Equal(t, []string{"subject1", "subject2"}, oidc.SubjectKeys)
+	
+	aws, ok := oidc.GetAWS()
+	assert.True(t, ok)
+	assert.Equal(t, "3600", aws.SessionDuration)
+	assert.Equal(t, "audience", aws.Audience)
+	assert.Equal(t, "role-arn", aws.RoleArn)
+	assert.Equal(t, []string{"subject1", "subject2"}, aws.SubjectKeys)
+}
+
+func TestOidcAuthentication_NewGoogleOidcAuthentication(t *testing.T) {
+	oidc := NewGoogleOidcAuthentication("audience", []string{"subject1", "subject2"})
+	
+	assert.Equal(t, OidcAuthenticationTypeGoogle, oidc.Type)
+	assert.Equal(t, "audience", oidc.Audience)
+	assert.Equal(t, []string{"subject1", "subject2"}, oidc.SubjectKeys)
+	
+	google, ok := oidc.GetGoogle()
+	assert.True(t, ok)
+	assert.Equal(t, "audience", google.Audience)
+	assert.Equal(t, []string{"subject1", "subject2"}, google.SubjectKeys)
+}
+
+func TestOidcAuthentication_MarshalJSON_Azure(t *testing.T) {
+	oidc := NewAzureOidcAuthentication("client-id", "tenant-id", "audience", []string{"subject1"})
+	
+	data, err := json.Marshal(oidc)
+	assert.NoError(t, err)
+	
+	// Verify the JSON structure is flattened
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	
+	assert.Equal(t, "Azure", result["Type"])
+	assert.Equal(t, "client-id", result["ClientId"])
+	assert.Equal(t, "tenant-id", result["TenantId"])
+	assert.Equal(t, "audience", result["Audience"])
+	assert.Equal(t, []interface{}{"subject1"}, result["SubjectKeys"])
+	
+	// Should not have nested Data field
+	assert.Nil(t, result["Data"])
+}
+
+func TestOidcAuthentication_MarshalJSON_AWS(t *testing.T) {
+	oidc := NewAwsOidcAuthentication("3600", "audience", "role-arn", []string{"subject1"})
+	
+	data, err := json.Marshal(oidc)
+	assert.NoError(t, err)
+	
+	// Verify the JSON structure is flattened
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	
+	assert.Equal(t, "AWS", result["Type"])
+	assert.Equal(t, "3600", result["SessionDuration"])
+	assert.Equal(t, "audience", result["Audience"])
+	assert.Equal(t, "role-arn", result["RoleArn"])
+	assert.Equal(t, []interface{}{"subject1"}, result["SubjectKeys"])
+	
+	// Should not have nested Data field
+	assert.Nil(t, result["Data"])
+}
+
+func TestOidcAuthentication_MarshalJSON_Google(t *testing.T) {
+	oidc := NewGoogleOidcAuthentication("audience", []string{"subject1"})
+	
+	data, err := json.Marshal(oidc)
+	assert.NoError(t, err)
+	
+	// Verify the JSON structure is flattened
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	
+	assert.Equal(t, "Google", result["Type"])
+	assert.Equal(t, "audience", result["Audience"])
+	assert.Equal(t, []interface{}{"subject1"}, result["SubjectKeys"])
+	
+	// Should not have nested Data field
+	assert.Nil(t, result["Data"])
+}
+
+func TestOidcAuthentication_UnmarshalJSON_Azure(t *testing.T) {
+	// Create Azure OIDC using constructor
+	expectedOidc := NewAzureOidcAuthentication("client-id", "tenant-id", "audience", []string{"subject1", "subject2"})
+	
+	// Marshal to JSON
+	data, err := json.Marshal(expectedOidc)
+	assert.NoError(t, err)
+	
+	// Unmarshal back
+	var oidc OidcAuthentication
+	err = json.Unmarshal(data, &oidc)
+	assert.NoError(t, err)
+	
+	// Verify the unmarshaled data matches the original
+	assert.Equal(t, expectedOidc.Type, oidc.Type)
+	assert.Equal(t, expectedOidc.ClientId, oidc.ClientId)
+	assert.Equal(t, expectedOidc.TenantId, oidc.TenantId)
+	assert.Equal(t, expectedOidc.Audience, oidc.Audience)
+	assert.Equal(t, expectedOidc.SubjectKeys, oidc.SubjectKeys)
+}
+
+func TestOidcAuthentication_UnmarshalJSON_AWS(t *testing.T) {
+	// Create AWS OIDC using constructor
+	expectedOidc := NewAwsOidcAuthentication("3600", "audience", "role-arn", []string{"subject1", "subject2"})
+	
+	// Marshal to JSON
+	data, err := json.Marshal(expectedOidc)
+	assert.NoError(t, err)
+	
+	// Unmarshal back
+	var oidc OidcAuthentication
+	err = json.Unmarshal(data, &oidc)
+	assert.NoError(t, err)
+	
+	// Verify the unmarshaled data matches the original
+	assert.Equal(t, expectedOidc.Type, oidc.Type)
+	assert.Equal(t, expectedOidc.SessionDuration, oidc.SessionDuration)
+	assert.Equal(t, expectedOidc.Audience, oidc.Audience)
+	assert.Equal(t, expectedOidc.RoleArn, oidc.RoleArn)
+	assert.Equal(t, expectedOidc.SubjectKeys, oidc.SubjectKeys)
+}
+
+func TestOidcAuthentication_UnmarshalJSON_Google(t *testing.T) {
+	// Create Google OIDC using constructor
+	expectedOidc := NewGoogleOidcAuthentication("audience", []string{"subject1", "subject2"})
+	
+	// Marshal to JSON
+	data, err := json.Marshal(expectedOidc)
+	assert.NoError(t, err)
+	
+	// Unmarshal back
+	var oidc OidcAuthentication
+	err = json.Unmarshal(data, &oidc)
+	assert.NoError(t, err)
+	
+	// Verify the unmarshaled data matches the original
+	assert.Equal(t, expectedOidc.Type, oidc.Type)
+	assert.Equal(t, expectedOidc.Audience, oidc.Audience)
+	assert.Equal(t, expectedOidc.SubjectKeys, oidc.SubjectKeys)
+}
+
+func TestOidcAuthentication_GetWrongType(t *testing.T) {
+	oidc := NewAzureOidcAuthentication("client-id", "tenant-id", "audience", []string{"subject1"})
+	
+	// Try to get AWS data from Azure OIDC
+	aws, ok := oidc.GetAWS()
+	assert.False(t, ok)
+	assert.Nil(t, aws)
+	
+	// Try to get Google data from Azure OIDC
+	google, ok := oidc.GetGoogle()
+	assert.False(t, ok)
+	assert.Nil(t, google)
+}
+
+func TestOidcAuthentication_UnmarshalJSON_EmptyClientId_IsAzure(t *testing.T) {
+	jsonData := `{
+		"ClientId": "",
+		"TenantId": "tenant-id",
+		"Audience": "audience",
+		"SubjectKeys": ["subject1"]
+	}`
+	var oidc OidcAuthentication
+	err := json.Unmarshal([]byte(jsonData), &oidc)
+	assert.NoError(t, err)
+	assert.Equal(t, OidcAuthenticationTypeAzure, oidc.Type)
+	assert.Equal(t, "", oidc.ClientId)
+	assert.Equal(t, "tenant-id", oidc.TenantId)
+	assert.Equal(t, "audience", oidc.Audience)
+	assert.Equal(t, []string{"subject1"}, oidc.SubjectKeys)
+}
+
+func TestOidcAuthentication_UnmarshalJSON_EmptyRoleArn_IsAWS(t *testing.T) {
+	jsonData := `{
+		"SessionDuration": "3600",
+		"RoleArn": "",
+		"Audience": "audience",
+		"SubjectKeys": ["subject1"]
+	}`
+	var oidc OidcAuthentication
+	err := json.Unmarshal([]byte(jsonData), &oidc)
+	assert.NoError(t, err)
+	assert.Equal(t, OidcAuthenticationTypeAWS, oidc.Type)
+	assert.Equal(t, "", oidc.RoleArn)
+	assert.Equal(t, "3600", oidc.SessionDuration)
+	assert.Equal(t, "audience", oidc.Audience)
+	assert.Equal(t, []string{"subject1"}, oidc.SubjectKeys)
+}
+
+func TestOidcAuthentication_UnmarshalJSON_OnlyAudienceAndSubjectKeys_IsGoogle(t *testing.T) {
+	jsonData := `{
+		"Audience": "audience",
+		"SubjectKeys": ["subject1"]
+	}`
+	var oidc OidcAuthentication
+	err := json.Unmarshal([]byte(jsonData), &oidc)
+	assert.NoError(t, err)
+	assert.Equal(t, OidcAuthenticationTypeGoogle, oidc.Type)
+	assert.Equal(t, "audience", oidc.Audience)
+	assert.Equal(t, []string{"subject1"}, oidc.SubjectKeys)
+} 

--- a/pkg/spaces/space.go
+++ b/pkg/spaces/space.go
@@ -20,8 +20,9 @@ type Space struct {
 // NewSpace initializes a Space with a name.
 func NewSpace(name string) *Space {
 	return &Space{
-		Name:     name,
-		Resource: *resources.NewResource(),
+		Name:               name,
+		Resource:           *resources.NewResource(),
+		SpaceManagersTeams: []string{}, // ensure required field is always present
 	}
 }
 


### PR DESCRIPTION
When updating ACR, GCR and ECS feeds the OidcAuthentication property is not being bound on the server side modify calls. This happens because the FeedResource properties `AzureContainerRegistryOidcAuthentication`, `ElasticContainerRegistryOidcAuthentication` and `GoogleContainerRegistryOidcAuthentication` do not match the server side values. This change consolidates these into a single property OidcAuthentication which has a type property to discriminate on. The JSON unmarshalling here isn't pretty but works, it determines the OidcAuthentication type based on the available properties, in this case the properties are always available, and we're just checking it's there the value itself is not required.

Related to - https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/pull/40/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6