### PR TITLE
Add support for GetContainerLogs API

### DIFF
--- a/pkg/observability/container_logs.go
+++ b/pkg/observability/container_logs.go
@@ -1,0 +1,70 @@
+package observability
+
+import (
+	"time"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// ContainerLogSessionId represents a container logs session identifier
+type ContainerLogSessionId string
+
+// GetContainerLogsRequest represents a request to get container logs for a session
+// Request for retrieving all the logs for the specified session
+type GetContainerLogsRequest struct {
+	SpaceID   string                `json:"spaceId" validate:"required"`
+	SessionID ContainerLogSessionId `json:"sessionId" validate:"required" uri:"sessionId" url:"sessionId"`
+}
+
+// GetContainerLogsResponse represents the response containing logs for a sessionID
+// Response containing the logs for a sessionID
+type GetContainerLogsResponse struct {
+	Logs               []ContainerLogLineResource `json:"logs" validate:"required"`
+	IsSessionCompleted bool                       `json:"isSessionCompleted"`
+	Error              *MonitorErrorResource      `json:"error,omitempty"`
+}
+
+// ContainerLogLineResource represents a single container log line
+type ContainerLogLineResource struct {
+	Timestamp time.Time `json:"timestamp" validate:"required"`
+	Message   string    `json:"message" validate:"required"`
+}
+
+// NewGetContainerLogsRequest creates a new GetContainerLogsRequest
+func NewGetContainerLogsRequest(spaceID string, sessionID ContainerLogSessionId) *GetContainerLogsRequest {
+	return &GetContainerLogsRequest{
+		SpaceID:   spaceID,
+		SessionID: sessionID,
+	}
+}
+
+// NewGetContainerLogsResponse creates a new GetContainerLogsResponse
+func NewGetContainerLogsResponse(logs []ContainerLogLineResource, isSessionCompleted bool) *GetContainerLogsResponse {
+	return &GetContainerLogsResponse{
+		Logs:               logs,
+		IsSessionCompleted: isSessionCompleted,
+	}
+}
+
+// NewContainerLogLineResource creates a new ContainerLogLineResource
+func NewContainerLogLineResource(timestamp time.Time, message string) *ContainerLogLineResource {
+	return &ContainerLogLineResource{
+		Timestamp: timestamp,
+		Message:   message,
+	}
+}
+
+// Validate checks the state of the request and returns an error if invalid
+func (r *GetContainerLogsRequest) Validate() error {
+	return validator.New().Struct(r)
+}
+
+// Validate checks the state of the response and returns an error if invalid
+func (r *GetContainerLogsResponse) Validate() error {
+	return validator.New().Struct(r)
+}
+
+// Validate checks the state of the log line resource and returns an error if invalid
+func (c *ContainerLogLineResource) Validate() error {
+	return validator.New().Struct(c)
+}

--- a/pkg/observability/container_logs_service.go
+++ b/pkg/observability/container_logs_service.go
@@ -1,0 +1,39 @@
+package observability
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+)
+
+const (
+	containerLogsTemplate = "/api/{spaceId}/observability/logs/sessions/{sessionId}"
+)
+
+// GetContainerLogsWithClient retrieves container logs using the new client implementation
+func GetContainerLogsWithClient(client newclient.Client, request *GetContainerLogsRequest) (*GetContainerLogsResponse, error) {
+	if request == nil {
+		return nil, internal.CreateInvalidParameterError("GetContainerLogs", "request")
+	}
+
+	spaceID, err := internal.GetSpaceID(request.SpaceID, client.GetSpaceID())
+	if err != nil {
+		return nil, err
+	}
+
+	pathVars := map[string]interface{}{
+		"spaceId":   spaceID,
+		"sessionId": string(request.SessionID),
+	}
+
+	expandedUri, err := client.URITemplateCache().Expand(containerLogsTemplate, pathVars)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := newclient.Get[GetContainerLogsResponse](client.HttpSession(), expandedUri)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/pkg/observability/container_logs_test.go
+++ b/pkg/observability/container_logs_test.go
@@ -1,0 +1,123 @@
+package observability
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetContainerLogsRequest_Validate(t *testing.T) {
+	// Test valid request
+	validRequest := &GetContainerLogsRequest{
+		SpaceID:   "Spaces-1",
+		SessionID: ContainerLogSessionId("session-123"),
+	}
+
+	err := validRequest.Validate()
+	assert.NoError(t, err)
+
+	// Test invalid request (missing required fields)
+	invalidRequest := &GetContainerLogsRequest{}
+
+	err = invalidRequest.Validate()
+	assert.Error(t, err)
+
+	// Test invalid request (missing SessionID)
+	invalidRequestNoSession := &GetContainerLogsRequest{
+		SpaceID: "Spaces-1",
+	}
+
+	err = invalidRequestNoSession.Validate()
+	assert.Error(t, err)
+
+	// Test invalid request (missing SpaceID)
+	invalidRequestNoSpace := &GetContainerLogsRequest{
+		SessionID: ContainerLogSessionId("session-123"),
+	}
+
+	err = invalidRequestNoSpace.Validate()
+	assert.Error(t, err)
+}
+
+func TestGetContainerLogsResponse_Validate(t *testing.T) {
+	// Test valid response with empty logs
+	validResponse := &GetContainerLogsResponse{
+		Logs:               []ContainerLogLineResource{},
+		IsSessionCompleted: true,
+	}
+
+	err := validResponse.Validate()
+	assert.NoError(t, err)
+
+	// Test valid response with logs
+	logLine := &ContainerLogLineResource{
+		Timestamp: time.Now(),
+		Message:   "Application started successfully",
+	}
+
+	validResponseWithLogs := &GetContainerLogsResponse{
+		Logs:               []ContainerLogLineResource{*logLine},
+		IsSessionCompleted: false,
+	}
+
+	err = validResponseWithLogs.Validate()
+	assert.NoError(t, err)
+}
+
+func TestContainerLogLineResource_Validate(t *testing.T) {
+	// Test valid log line resource
+	validLogLine := &ContainerLogLineResource{
+		Timestamp: time.Now(),
+		Message:   "Application started successfully",
+	}
+
+	err := validLogLine.Validate()
+	assert.NoError(t, err)
+
+	// Test invalid log line resource (missing required fields)
+	invalidLogLine := &ContainerLogLineResource{}
+
+	err = invalidLogLine.Validate()
+	assert.Error(t, err)
+
+	// Test invalid log line resource (missing message)
+	invalidLogLineNoMessage := &ContainerLogLineResource{
+		Timestamp: time.Now(),
+	}
+
+	err = invalidLogLineNoMessage.Validate()
+	assert.Error(t, err)
+
+	// Test invalid log line resource (missing timestamp)
+	invalidLogLineNoTimestamp := &ContainerLogLineResource{
+		Message: "Application started successfully",
+	}
+
+	err = invalidLogLineNoTimestamp.Validate()
+	assert.Error(t, err)
+}
+
+func TestGetContainerLogsResponseWithError(t *testing.T) {
+	logs := []ContainerLogLineResource{}
+	isSessionCompleted := false
+	errorResource := NewMonitorErrorResource("Session timeout", "ERR_TIMEOUT")
+
+	response := &GetContainerLogsResponse{
+		Logs:               logs,
+		IsSessionCompleted: isSessionCompleted,
+		Error:              errorResource,
+	}
+
+	expected := &GetContainerLogsResponse{
+		Logs:               logs,
+		IsSessionCompleted: isSessionCompleted,
+		Error: &MonitorErrorResource{
+			Message: "Session timeout",
+			Code:    "ERR_TIMEOUT",
+		},
+	}
+
+	assert.Equal(t, expected, response)
+	assert.NoError(t, response.Validate())
+}


### PR DESCRIPTION
This PR adds support for the GetContainerLogs API, which is one of the new APIs for KLOS.

Testing evidence:

Expected structure matches the structure for an actual response:
```
{
  "Logs": [
    {
      "Timestamp": "2025-08-01T05:54:35.2024751Z",
      "Message": "/usr/local/bin/docker-entrypoint.sh: /docker-entrypoint.d/ is empty, skipping initial configuration..."
    },
    {
      "Timestamp": "2025-08-01T05:54:35.2221895Z",
      "Message": "2025/08/01 05:54:35 [info] 1#1 unit started"
    },
    {
      "Timestamp": "2025-08-01T05:54:35.2236993Z",
      "Message": "2025/08/01 05:54:35 [info] 14#14 discovery started"
    },
    {
      "Timestamp": "2025-08-01T05:54:35.2472801Z",
      "Message": "2025/08/01 05:54:35 [notice] 14#14 module: java 11.0.8 \"/usr/lib/unit/modules/java11.unit.so\""
    },
    {
      "Timestamp": "2025-08-01T05:54:35.2515771Z",
      "Message": "2025/08/01 05:54:35 [notice] 14#14 module: perl 5.28.1 \"/usr/lib/unit/modules/perl.unit.so\""
    },
    {
      "Timestamp": "2025-08-01T05:54:35.264013Z",
      "Message": "2025/08/01 05:54:35 [notice] 14#14 module: php 7.3.19-1~deb10u1 \"/usr/lib/unit/modules/php.unit.so\""
    },
    {
      "Timestamp": "2025-08-01T05:54:35.267768Z",
      "Message": "2025/08/01 05:54:35 [notice] 14#14 module: python 2.7.16 \"/usr/lib/unit/modules/python2.7.unit.so\""
    },
    {
      "Timestamp": "2025-08-01T05:54:35.2718367Z",
      "Message": "2025/08/01 05:54:35 [notice] 14#14 module: python 3.7.3 \"/usr/lib/unit/modules/python3.7.unit.so\""
    },
    {
      "Timestamp": "2025-08-01T05:54:35.2746325Z",
      "Message": "2025/08/01 05:54:35 [notice] 14#14 module: ruby 2.5.5 \"/usr/lib/unit/modules/ruby.unit.so\""
    },
    {
      "Timestamp": "2025-08-01T05:54:35.2774997Z",
      "Message": "2025/08/01 05:54:35 [info] 1#1 controller started"
    },
    {
      "Timestamp": "2025-08-01T05:54:35.2789818Z",
      "Message": "2025/08/01 05:54:35 [notice] 1#1 process 14 exited with code 0"
    },
    {
      "Timestamp": "2025-08-01T05:54:35.2793115Z",
      "Message": "2025/08/01 05:54:35 [info] 16#16 router started"
    },
    {
      "Timestamp": "2025-08-01T05:54:35.2874526Z",
      "Message": "2025/08/01 05:54:35 [info] 16#16 OpenSSL 1.1.1d  10 Sep 2019, 1010104f"
    }
  ],
  "IsSessionCompleted": true,
  "Error": null
}
```