### PR TITLE
Add support for BeginContainerLogsSession

### DIFF
--- a/pkg/observability/container_logs.go
+++ b/pkg/observability/container_logs.go
@@ -68,3 +68,65 @@ func (r *GetContainerLogsResponse) Validate() error {
 func (c *ContainerLogLineResource) Validate() error {
 	return validator.New().Struct(c)
 }
+
+// BeginContainerLogsSessionCommand represents a request to begin a container logs session
+// Command to request the Kubernetes monitor to start sending logs for the specified container
+type BeginContainerLogsSessionCommand struct {
+	SpaceID                             string  `json:"spaceId" validate:"required"`
+	ProjectID                           string  `json:"projectId" validate:"required"`
+	EnvironmentID                       string  `json:"environmentId" validate:"required"`
+	TenantID                            *string `json:"tenantId,omitempty"`
+	MachineID                           string  `json:"machineId" validate:"required"`
+	DesiredOrKubernetesMonitoredResourceID string  `json:"desiredOrKubernetesMonitoredResourceId" validate:"required"`
+	PodName                             string  `json:"podName" validate:"required"`
+	ContainerName                       string  `json:"containerName" validate:"required"`
+	ShowPreviousContainer               bool    `json:"showPreviousContainer"`
+}
+
+// BeginContainerLogsSessionResponse represents the response from beginning a container logs session
+// Response containing the session ID for a new container logs session
+type BeginContainerLogsSessionResponse struct {
+	SessionID ContainerLogSessionId `json:"sessionId" validate:"required"`
+	Error     *MonitorErrorResource `json:"error,omitempty"`
+}
+
+// NewBeginContainerLogsSessionCommand creates a new BeginContainerLogsSessionCommand
+func NewBeginContainerLogsSessionCommand(
+	spaceID,
+	projectID,
+	environmentID,
+	machineID,
+	desiredOrKubernetesMonitoredResourceID,
+	podName,
+	containerName string,
+	showPreviousContainer bool,
+) *BeginContainerLogsSessionCommand {
+	return &BeginContainerLogsSessionCommand{
+		SpaceID:                             spaceID,
+		ProjectID:                           projectID,
+		EnvironmentID:                       environmentID,
+		MachineID:                           machineID,
+		DesiredOrKubernetesMonitoredResourceID: desiredOrKubernetesMonitoredResourceID,
+		PodName:                             podName,
+		ContainerName:                       containerName,
+		ShowPreviousContainer:               showPreviousContainer,
+	}
+}
+
+// NewBeginContainerLogsSessionResponse creates a new BeginContainerLogsSessionResponse
+func NewBeginContainerLogsSessionResponse(sessionID ContainerLogSessionId) *BeginContainerLogsSessionResponse {
+	return &BeginContainerLogsSessionResponse{
+		SessionID: sessionID,
+	}
+}
+
+// Validate checks the state of the command and returns an error if invalid
+func (c *BeginContainerLogsSessionCommand) Validate() error {
+	return validator.New().Struct(c)
+}
+
+// Validate checks the state of the response and returns an error if invalid
+func (r *BeginContainerLogsSessionResponse) Validate() error {
+	return validator.New().Struct(r)
+}
+

--- a/pkg/observability/container_logs_service.go
+++ b/pkg/observability/container_logs_service.go
@@ -6,7 +6,8 @@ import (
 )
 
 const (
-	containerLogsTemplate = "/api/{spaceId}/observability/logs/sessions/{sessionId}"
+	containerLogsTemplate      = "/api/{spaceId}/observability/logs/sessions/{sessionId}"
+	beginContainerLogsTemplate = "/api/{spaceId}/observability/logs/sessions"
 )
 
 // GetContainerLogsWithClient retrieves container logs using the new client implementation
@@ -31,6 +32,34 @@ func GetContainerLogsWithClient(client newclient.Client, request *GetContainerLo
 	}
 
 	resp, err := newclient.Get[GetContainerLogsResponse](client.HttpSession(), expandedUri)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// BeginContainerLogsSessionWithClient begins a container logs session using the new client implementation
+func BeginContainerLogsSessionWithClient(client newclient.Client, command *BeginContainerLogsSessionCommand) (*BeginContainerLogsSessionResponse, error) {
+	if command == nil {
+		return nil, internal.CreateInvalidParameterError("BeginContainerLogsSession", "command")
+	}
+
+	spaceID, err := internal.GetSpaceID(command.SpaceID, client.GetSpaceID())
+	if err != nil {
+		return nil, err
+	}
+
+	pathVars := map[string]interface{}{
+		"spaceId": spaceID,
+	}
+
+	expandedUri, err := client.URITemplateCache().Expand(beginContainerLogsTemplate, pathVars)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := newclient.Post[BeginContainerLogsSessionResponse](client.HttpSession(), expandedUri, command)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/observability/container_logs_service.go
+++ b/pkg/observability/container_logs_service.go
@@ -6,8 +6,7 @@ import (
 )
 
 const (
-	containerLogsTemplate      = "/api/{spaceId}/observability/logs/sessions/{sessionId}"
-	beginContainerLogsTemplate = "/api/{spaceId}/observability/logs/sessions"
+	containerLogsTemplate = "/api/{spaceId}/observability/logs/sessions{/sessionId}"
 )
 
 // GetContainerLogsWithClient retrieves container logs using the new client implementation
@@ -54,7 +53,7 @@ func BeginContainerLogsSessionWithClient(client newclient.Client, command *Begin
 		"spaceId": spaceID,
 	}
 
-	expandedUri, err := client.URITemplateCache().Expand(beginContainerLogsTemplate, pathVars)
+	expandedUri, err := client.URITemplateCache().Expand(containerLogsTemplate, pathVars)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/observability/container_logs_test.go
+++ b/pkg/observability/container_logs_test.go
@@ -121,3 +121,123 @@ func TestGetContainerLogsResponseWithError(t *testing.T) {
 	assert.Equal(t, expected, response)
 	assert.NoError(t, response.Validate())
 }
+
+func TestBeginContainerLogsSessionCommand_Validate(t *testing.T) {
+	// Test valid command
+	validCommand := &BeginContainerLogsSessionCommand{
+		SpaceID:                                "Spaces-1",
+		ProjectID:                              "Projects-1",
+		EnvironmentID:                          "Environments-1",
+		MachineID:                              "Machines-1",
+		DesiredOrKubernetesMonitoredResourceID: "resource-123",
+		PodName:                                "my-pod",
+		ContainerName:                          "app-container",
+		ShowPreviousContainer:                  false,
+	}
+
+	err := validCommand.Validate()
+	assert.NoError(t, err)
+
+	// Test valid command with tenant ID (optional)
+	tenantID := "Tenants-1"
+	validCommandWithTenant := &BeginContainerLogsSessionCommand{
+		SpaceID:                                "Spaces-1",
+		ProjectID:                              "Projects-1",
+		EnvironmentID:                          "Environments-1",
+		TenantID:                               &tenantID,
+		MachineID:                              "Machines-1",
+		DesiredOrKubernetesMonitoredResourceID: "resource-123",
+		PodName:                                "my-pod",
+		ContainerName:                          "app-container",
+		ShowPreviousContainer:                  true,
+	}
+
+	err = validCommandWithTenant.Validate()
+	assert.NoError(t, err)
+
+	// Test invalid command (missing required fields)
+	invalidCommand := &BeginContainerLogsSessionCommand{}
+
+	err = invalidCommand.Validate()
+	assert.Error(t, err)
+
+	// Test invalid command (missing SpaceID)
+	invalidCommandNoSpace := &BeginContainerLogsSessionCommand{
+		ProjectID:                              "Projects-1",
+		EnvironmentID:                          "Environments-1",
+		MachineID:                              "Machines-1",
+		DesiredOrKubernetesMonitoredResourceID: "resource-123",
+		PodName:                                "my-pod",
+		ContainerName:                          "app-container",
+	}
+
+	err = invalidCommandNoSpace.Validate()
+	assert.Error(t, err)
+
+	// Test invalid command (missing ProjectID)
+	invalidCommandNoProject := &BeginContainerLogsSessionCommand{
+		SpaceID:                                "Spaces-1",
+		EnvironmentID:                          "Environments-1",
+		MachineID:                              "Machines-1",
+		DesiredOrKubernetesMonitoredResourceID: "resource-123",
+		PodName:                                "my-pod",
+		ContainerName:                          "app-container",
+	}
+
+	err = invalidCommandNoProject.Validate()
+	assert.Error(t, err)
+
+	// Test invalid command (missing PodName)
+	invalidCommandNoPod := &BeginContainerLogsSessionCommand{
+		SpaceID:                                "Spaces-1",
+		ProjectID:                              "Projects-1",
+		EnvironmentID:                          "Environments-1",
+		MachineID:                              "Machines-1",
+		DesiredOrKubernetesMonitoredResourceID: "resource-123",
+		ContainerName:                          "app-container",
+	}
+
+	err = invalidCommandNoPod.Validate()
+	assert.Error(t, err)
+
+	// Test invalid command (missing ContainerName)
+	invalidCommandNoContainer := &BeginContainerLogsSessionCommand{
+		SpaceID:                                "Spaces-1",
+		ProjectID:                              "Projects-1",
+		EnvironmentID:                          "Environments-1",
+		MachineID:                              "Machines-1",
+		DesiredOrKubernetesMonitoredResourceID: "resource-123",
+		PodName:                                "my-pod",
+	}
+
+	err = invalidCommandNoContainer.Validate()
+	assert.Error(t, err)
+}
+
+func TestBeginContainerLogsSessionResponse_Validate(t *testing.T) {
+	// Test valid response
+	validResponse := &BeginContainerLogsSessionResponse{
+		SessionID: ContainerLogSessionId("session-abc123"),
+	}
+
+	err := validResponse.Validate()
+	assert.NoError(t, err)
+
+	// Test valid response with error
+	validResponseWithError := &BeginContainerLogsSessionResponse{
+		SessionID: ContainerLogSessionId("session-def456"),
+		Error: &MonitorErrorResource{
+			Message: "Connection timeout",
+			Code:    "ERR_TIMEOUT",
+		},
+	}
+
+	err = validResponseWithError.Validate()
+	assert.NoError(t, err)
+
+	// Test invalid response (missing SessionID)
+	invalidResponse := &BeginContainerLogsSessionResponse{}
+
+	err = invalidResponse.Validate()
+	assert.Error(t, err)
+}


### PR DESCRIPTION
This PR adds support for the BeginContainerLogsSession API

**Testing evidence:**

Using a local go client:

```
2. Testing with New Client (BeginContainerLogsSessionWithClient)...
New client created successfully
Making API call with new client, command: &{SpaceID:Spaces-1 ProjectID:Projects-101 EnvironmentID:Environments-3 TenantID:<nil> MachineID:Machines-61 DesiredOrKubernetesMonitoredResourceID:0992a29a-5070-4314-9b34-034a81200dc9 PodName:test-api-deploy-7bb97cf98-d7rb6 ContainerName:test-nginx ShowPreviousContainer:false}
API call succeeded: &{SessionID:ed557d12-c676-4b1e-b4ac-154c75abefb7 Error:<nil>}
Response - Full object (JSON):
{
  "sessionId": "ed557d12-c676-4b1e-b4ac-154c75abefb7"
}
```

Matches actual request and response structure on UI:

Request payload:
```
{"ProjectId":"Projects-101","EnvironmentId":"Environments-3","MachineId":"Machines-61","PodName":"test-api-deploy-7bb97cf98-d7rb6","ContainerName":"test-nginx","ShowPreviousContainer":false,"DesiredOrKubernetesMonitoredResourceId":"0992a29a-5070-4314-9b34-034a81200dc9"}
```

Response:
```
{
  "SessionId": "b68662fa-f8d6-4e3c-8d0e-0b0adb8324ee"
}
```