### PR TITLE
Add support for BeginResourceEventsSession API

### DIFF
--- a/pkg/observability/resource_events.go
+++ b/pkg/observability/resource_events.go
@@ -9,6 +9,23 @@ import (
 // ResourceEventsSessionId represents a resource events session identifier
 type ResourceEventsSessionId string
 
+// BeginResourceEventsSessionRequest represents a request to begin a resource events session
+// Request to start monitoring events for a specific Kubernetes resource
+type BeginResourceEventsSessionRequest struct {
+	SpaceID                            string `json:"spaceId" validate:"required"`
+	ProjectID                          string `json:"projectId" validate:"required"`
+	EnvironmentID                      string `json:"environmentId" validate:"required"`
+	TenantID                          *string `json:"tenantId,omitempty"`
+	MachineID                         string `json:"machineId" validate:"required"`
+	DesiredOrKubernetesMonitoredResourceID string `json:"desiredOrKubernetesMonitoredResourceId" validate:"required"`
+}
+
+// BeginResourceEventsSessionResponse represents the response for beginning a resource events session
+// Response containing a session ID for the event monitoring session
+type BeginResourceEventsSessionResponse struct {
+	SessionID ResourceEventsSessionId `json:"sessionId" validate:"required"`
+}
+
 // GetResourceEventsRequest represents a request to get resource events for a session
 // Request for retrieving all the events for the specified session
 type GetResourceEventsRequest struct {
@@ -42,6 +59,24 @@ type KubernetesEventResource struct {
 type MonitorErrorResource struct {
 	Message string `json:"message" validate:"required"`
 	Code    string `json:"code,omitempty"`
+}
+
+// NewBeginResourceEventsSessionRequest creates a new BeginResourceEventsSessionRequest
+func NewBeginResourceEventsSessionRequest(spaceID, projectID, environmentID, machineID, desiredOrKubernetesMonitoredResourceID string) *BeginResourceEventsSessionRequest {
+	return &BeginResourceEventsSessionRequest{
+		SpaceID:                            spaceID,
+		ProjectID:                          projectID,
+		EnvironmentID:                      environmentID,
+		MachineID:                         machineID,
+		DesiredOrKubernetesMonitoredResourceID: desiredOrKubernetesMonitoredResourceID,
+	}
+}
+
+// NewBeginResourceEventsSessionResponse creates a new BeginResourceEventsSessionResponse
+func NewBeginResourceEventsSessionResponse(sessionID ResourceEventsSessionId) *BeginResourceEventsSessionResponse {
+	return &BeginResourceEventsSessionResponse{
+		SessionID: sessionID,
+	}
 }
 
 // NewGetResourceEventsRequest creates a new GetResourceEventsRequest
@@ -93,6 +128,16 @@ func NewMonitorErrorResource(message string, code string) *MonitorErrorResource 
 		Message: message,
 		Code:    code,
 	}
+}
+
+// Validate checks the state of the request and returns an error if invalid
+func (r *BeginResourceEventsSessionRequest) Validate() error {
+	return validator.New().Struct(r)
+}
+
+// Validate checks the state of the response and returns an error if invalid
+func (r *BeginResourceEventsSessionResponse) Validate() error {
+	return validator.New().Struct(r)
 }
 
 // Validate checks the state of the request and returns an error if invalid

--- a/pkg/observability/resource_events_service.go
+++ b/pkg/observability/resource_events_service.go
@@ -6,8 +6,7 @@ import (
 )
 
 const (
-	beginResourceEventsSessionTemplate = "/api/{spaceId}/observability/events/sessions"
-	resourceEventsTemplate = "/api/{spaceId}/observability/events/sessions/{sessionId}"
+	resourceEventsTemplate = "/api/{spaceId}/observability/events/sessions{/sessionId}"
 )
 
 // BeginResourceEventsSessionWithClient begins a resource events session using the new client implementation
@@ -25,7 +24,7 @@ func BeginResourceEventsSessionWithClient(client newclient.Client, request *Begi
 		"spaceId": spaceID,
 	}
 
-	expandedUri, err := client.URITemplateCache().Expand(beginResourceEventsSessionTemplate, pathVars)
+	expandedUri, err := client.URITemplateCache().Expand(resourceEventsTemplate, pathVars)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/observability/resource_events_service.go
+++ b/pkg/observability/resource_events_service.go
@@ -6,8 +6,37 @@ import (
 )
 
 const (
+	beginResourceEventsSessionTemplate = "/api/{spaceId}/observability/events/sessions"
 	resourceEventsTemplate = "/api/{spaceId}/observability/events/sessions/{sessionId}"
 )
+
+// BeginResourceEventsSessionWithClient begins a resource events session using the new client implementation
+func BeginResourceEventsSessionWithClient(client newclient.Client, request *BeginResourceEventsSessionRequest) (*BeginResourceEventsSessionResponse, error) {
+	if request == nil {
+		return nil, internal.CreateInvalidParameterError("BeginResourceEventsSession", "request")
+	}
+
+	spaceID, err := internal.GetSpaceID(request.SpaceID, client.GetSpaceID())
+	if err != nil {
+		return nil, err
+	}
+
+	pathVars := map[string]interface{}{
+		"spaceId": spaceID,
+	}
+
+	expandedUri, err := client.URITemplateCache().Expand(beginResourceEventsSessionTemplate, pathVars)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := newclient.Post[BeginResourceEventsSessionResponse](client.HttpSession(), expandedUri, request)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
 
 // GetResourceEventsWithClient retrieves resource events using the new client implementation
 func GetResourceEventsWithClient(client newclient.Client, request *GetResourceEventsRequest) (*GetResourceEventsResponse, error) {

--- a/pkg/observability/resource_events_test.go
+++ b/pkg/observability/resource_events_test.go
@@ -7,6 +7,67 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestBeginResourceEventsSessionRequest_Validate(t *testing.T) {
+	// Test valid request
+	validRequest := &BeginResourceEventsSessionRequest{
+		SpaceID:                            "Spaces-1",
+		ProjectID:                          "Projects-1",
+		EnvironmentID:                      "Environments-1",
+		MachineID:                         "Machines-1",
+		DesiredOrKubernetesMonitoredResourceID: "resource-123",
+	}
+
+	err := validRequest.Validate()
+	assert.NoError(t, err)
+
+	// Test valid request with optional TenantID
+	tenantID := "Tenants-1"
+	validRequestWithTenant := &BeginResourceEventsSessionRequest{
+		SpaceID:                            "Spaces-1",
+		ProjectID:                          "Projects-1",
+		EnvironmentID:                      "Environments-1",
+		TenantID:                          &tenantID,
+		MachineID:                         "Machines-1",
+		DesiredOrKubernetesMonitoredResourceID: "resource-123",
+	}
+
+	err = validRequestWithTenant.Validate()
+	assert.NoError(t, err)
+
+	// Test invalid request (missing required fields)
+	invalidRequest := &BeginResourceEventsSessionRequest{}
+
+	err = invalidRequest.Validate()
+	assert.Error(t, err)
+
+	// Test invalid request (missing SpaceID)
+	invalidRequestNoSpace := &BeginResourceEventsSessionRequest{
+		ProjectID:                          "Projects-1",
+		EnvironmentID:                      "Environments-1",
+		MachineID:                         "Machines-1",
+		DesiredOrKubernetesMonitoredResourceID: "resource-123",
+	}
+
+	err = invalidRequestNoSpace.Validate()
+	assert.Error(t, err)
+}
+
+func TestBeginResourceEventsSessionResponse_Validate(t *testing.T) {
+	// Test valid response
+	validResponse := &BeginResourceEventsSessionResponse{
+		SessionID: ResourceEventsSessionId("session-123"),
+	}
+
+	err := validResponse.Validate()
+	assert.NoError(t, err)
+
+	// Test invalid response (missing required SessionID)
+	invalidResponse := &BeginResourceEventsSessionResponse{}
+
+	err = invalidResponse.Validate()
+	assert.Error(t, err)
+}
+
 func TestGetResourceEventsRequest_Validate(t *testing.T) {
 	// Test valid request
 	validRequest := &GetResourceEventsRequest{


### PR DESCRIPTION
This PR adds support for the BeginResourceEventsSession API

**Testing evidence**

Actual UI:

Request:
```
{
    "ProjectId": "Projects-101",
    "EnvironmentId": "Environments-3",
    "MachineId": "Machines-61",
    "DesiredOrKubernetesMonitoredResourceId": "98dca12e-eb95-4757-bac9-d54018e75310"
}
```
Response:
```
{
  "SessionId": "dbc67366-b02f-4148-8aae-da335325e178"
}
```

Test go client:

```
2. Testing with New Client (BeginResourceEventsSessionWithClient)...
New client created successfully
Making API call with new client, request: &{SpaceID:Spaces-1 ProjectID:Projects-101 EnvironmentID:Environments-3 TenantID:<nil> MachineID:Machines-61 DesiredOrKubernetesMonitoredResourceID:98dca12e-eb95-4757-bac9-d54018e75310}
API call succeeded: &{SessionID:79861439-124e-46f4-951a-3e527af03e41}
Response - Full object (JSON):
{
  "sessionId": "79861439-124e-46f4-951a-3e527af03e41"
}
```