### PR TITLE
Add support for RegisterKubernetesMonitor API

### DIFF
--- a/pkg/observability/kubernetes_monitor.go
+++ b/pkg/observability/kubernetes_monitor.go
@@ -1,0 +1,79 @@
+package observability
+
+import (
+	"github.com/go-playground/validator/v10"
+)
+
+// KubernetesMonitorInstallationId represents a Kubernetes Monitor installation identifier
+type KubernetesMonitorInstallationId string
+
+// KubernetesMonitorId represents a Kubernetes Monitor identifier
+type KubernetesMonitorId string
+
+// RegisterKubernetesMonitorCommand represents a request to register a new Kubernetes Monitor
+// Registers and trusts new Kubernetes Monitor.
+type RegisterKubernetesMonitorCommand struct {
+	InstallationID KubernetesMonitorInstallationId `json:"installationId" validate:"required"`
+	SpaceID        string                          `json:"spaceId" validate:"required"`
+	MachineID      string                          `json:"machineId" validate:"required"`
+}
+
+// RegisterKubernetesMonitorResponse represents the response from registering a Kubernetes Monitor
+// Response containing the registered agent.
+type RegisterKubernetesMonitorResponse struct {
+	Resource              *KubernetesMonitorResource `json:"resource" validate:"required"`
+	AuthenticationToken   string                     `json:"authenticationToken" validate:"required"`
+	CertificateThumbprint string                     `json:"certificateThumbprint" validate:"required"`
+}
+
+// KubernetesMonitorResource represents an installation of the Kubernetes Monitor
+// Represents an installation of the Kubernetes Monitor.
+type KubernetesMonitorResource struct {
+	ID             KubernetesMonitorId             `json:"id" validate:"required"`
+	SpaceID        string                          `json:"spaceId" validate:"required"`
+	InstallationID KubernetesMonitorInstallationId `json:"installationId" validate:"required"`
+	MachineID      string                          `json:"machineId" validate:"required"`
+}
+
+// NewRegisterKubernetesMonitorCommand creates a new RegisterKubernetesMonitorCommand
+func NewRegisterKubernetesMonitorCommand(installationID KubernetesMonitorInstallationId, spaceID string, machineID string) *RegisterKubernetesMonitorCommand {
+	return &RegisterKubernetesMonitorCommand{
+		InstallationID: installationID,
+		SpaceID:        spaceID,
+		MachineID:      machineID,
+	}
+}
+
+// NewRegisterKubernetesMonitorResponse creates a new RegisterKubernetesMonitorResponse
+func NewRegisterKubernetesMonitorResponse(resource *KubernetesMonitorResource, authenticationToken string, certificateThumbprint string) *RegisterKubernetesMonitorResponse {
+	return &RegisterKubernetesMonitorResponse{
+		Resource:              resource,
+		AuthenticationToken:   authenticationToken,
+		CertificateThumbprint: certificateThumbprint,
+	}
+}
+
+// NewKubernetesMonitorResource creates a new KubernetesMonitorResource
+func NewKubernetesMonitorResource(id KubernetesMonitorId, spaceID string, installationID KubernetesMonitorInstallationId, machineID string) *KubernetesMonitorResource {
+	return &KubernetesMonitorResource{
+		ID:             id,
+		SpaceID:        spaceID,
+		InstallationID: installationID,
+		MachineID:      machineID,
+	}
+}
+
+// Validate checks the state of the command and returns an error if invalid
+func (c *RegisterKubernetesMonitorCommand) Validate() error {
+	return validator.New().Struct(c)
+}
+
+// Validate checks the state of the response and returns an error if invalid
+func (r *RegisterKubernetesMonitorResponse) Validate() error {
+	return validator.New().Struct(r)
+}
+
+// Validate checks the state of the resource and returns an error if invalid
+func (k *KubernetesMonitorResource) Validate() error {
+	return validator.New().Struct(k)
+}

--- a/pkg/observability/kubernetes_monitor_service.go
+++ b/pkg/observability/kubernetes_monitor_service.go
@@ -1,0 +1,38 @@
+package observability
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+)
+
+const (
+	kubernetesMonitorsTemplate = "/api/{spaceId}/observability/kubernetes-monitors"
+)
+
+// RegisterKubernetesMonitorWithClient registers a new Kubernetes Monitor using the new client implementation
+func RegisterKubernetesMonitorWithClient(client newclient.Client, command *RegisterKubernetesMonitorCommand) (*RegisterKubernetesMonitorResponse, error) {
+	if command == nil {
+		return nil, internal.CreateInvalidParameterError("RegisterKubernetesMonitor", "command")
+	}
+
+	spaceID, err := internal.GetSpaceID(command.SpaceID, client.GetSpaceID())
+	if err != nil {
+		return nil, err
+	}
+
+	pathVars := map[string]interface{}{
+		"spaceId": spaceID,
+	}
+
+	expandedUri, err := client.URITemplateCache().Expand(kubernetesMonitorsTemplate, pathVars)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := newclient.Post[RegisterKubernetesMonitorResponse](client.HttpSession(), expandedUri, command)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/pkg/observability/kubernetes_monitor_test.go
+++ b/pkg/observability/kubernetes_monitor_test.go
@@ -1,0 +1,131 @@
+package observability
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegisterKubernetesMonitorCommand_Validate(t *testing.T) {
+	// Test valid command
+	command := &RegisterKubernetesMonitorCommand{
+		InstallationID: KubernetesMonitorInstallationId("install-123"),
+		SpaceID:        "Spaces-1",
+		MachineID:      "Machines-1",
+	}
+	err := command.Validate()
+	assert.NoError(t, err)
+
+	// Test invalid command (missing InstallationID)
+	command2 := &RegisterKubernetesMonitorCommand{
+		SpaceID:   "Spaces-1",
+		MachineID: "Machines-1",
+	}
+	err = command2.Validate()
+	assert.Error(t, err)
+
+	// Test invalid command (missing SpaceID)
+	command3 := &RegisterKubernetesMonitorCommand{
+		InstallationID: KubernetesMonitorInstallationId("install-123"),
+		MachineID:      "Machines-1",
+	}
+	err = command3.Validate()
+	assert.Error(t, err)
+
+	// Test invalid command (missing MachineID)
+	command4 := &RegisterKubernetesMonitorCommand{
+		InstallationID: KubernetesMonitorInstallationId("install-123"),
+		SpaceID:        "Spaces-1",
+	}
+	err = command4.Validate()
+	assert.Error(t, err)
+}
+
+func TestRegisterKubernetesMonitorResponse_Validate(t *testing.T) {
+	// Test valid response
+	resource := &KubernetesMonitorResource{
+		ID:             KubernetesMonitorId("km-123"),
+		SpaceID:        "Spaces-1",
+		InstallationID: KubernetesMonitorInstallationId("install-123"),
+		MachineID:      "Machines-1",
+	}
+	response := &RegisterKubernetesMonitorResponse{
+		Resource:              resource,
+		AuthenticationToken:   "auth-token-123",
+		CertificateThumbprint: "cert-thumbprint-123",
+	}
+	err := response.Validate()
+	assert.NoError(t, err)
+
+	// Test invalid response (missing Resource)
+	response2 := &RegisterKubernetesMonitorResponse{
+		AuthenticationToken:   "auth-token-123",
+		CertificateThumbprint: "cert-thumbprint-123",
+	}
+	err = response2.Validate()
+	assert.Error(t, err)
+
+	// Test invalid response (missing AuthenticationToken)
+	response3 := &RegisterKubernetesMonitorResponse{
+		Resource:              resource,
+		CertificateThumbprint: "cert-thumbprint-123",
+	}
+	err = response3.Validate()
+	assert.Error(t, err)
+
+	// Test invalid response (missing CertificateThumbprint)  
+	response4 := &RegisterKubernetesMonitorResponse{
+		Resource:            resource,
+		AuthenticationToken: "auth-token-123",
+	}
+	err = response4.Validate()
+	assert.Error(t, err)
+}
+
+func TestKubernetesMonitorResource_Validate(t *testing.T) {
+	// Test valid resource
+	resource := &KubernetesMonitorResource{
+		ID:             KubernetesMonitorId("km-123"),
+		SpaceID:        "Spaces-1",
+		InstallationID: KubernetesMonitorInstallationId("install-123"),
+		MachineID:      "Machines-1",
+	}
+	err := resource.Validate()
+	assert.NoError(t, err)
+
+	// Test invalid resource (missing ID)
+	resource2 := &KubernetesMonitorResource{
+		SpaceID:        "Spaces-1",
+		InstallationID: KubernetesMonitorInstallationId("install-123"),
+		MachineID:      "Machines-1",
+	}
+	err = resource2.Validate()
+	assert.Error(t, err)
+
+	// Test invalid resource (missing SpaceID)
+	resource3 := &KubernetesMonitorResource{
+		ID:             KubernetesMonitorId("km-123"),
+		InstallationID: KubernetesMonitorInstallationId("install-123"),
+		MachineID:      "Machines-1",
+	}
+	err = resource3.Validate()
+	assert.Error(t, err)
+
+	// Test invalid resource (missing InstallationID)
+	resource4 := &KubernetesMonitorResource{
+		ID:        KubernetesMonitorId("km-123"),
+		SpaceID:   "Spaces-1",
+		MachineID: "Machines-1",
+	}
+	err = resource4.Validate()
+	assert.Error(t, err)
+
+	// Test invalid resource (missing MachineID)
+	resource5 := &KubernetesMonitorResource{
+		ID:             KubernetesMonitorId("km-123"),
+		SpaceID:        "Spaces-1",
+		InstallationID: KubernetesMonitorInstallationId("install-123"),
+	}
+	err = resource5.Validate()
+	assert.Error(t, err)
+}


### PR DESCRIPTION
This PR adds support for the RegisterKubernetesMonitor API

Testing evidence:

Local Go client

```
Testing RegisterKubernetesMonitor with Octopus Client...
=======================================================
Connecting to: http://localhost:8065

2. Testing with New Client (RegisterKubernetesMonitorWithClient)...
New client created successfully
Making API call with new client, request: &{InstallationID:98dca12e-eb95-4757-bac9-d54018e75310 SpaceID:Spaces-1 MachineID:Machines-61}
API call succeeded: &{Resource:0x1400018a0c0 AuthenticationToken:QJ9QKY5MV3YZTDF9RQIDW4CRQP5TAHM25VYDP2Y1XPE CertificateThumbprint:BD365B54DDF25D37037390DD89F53247AA5AF14E}
Response - Full object (JSON):
{
  "resource": {
    "id": "KubernetesMonitors-62",
    "spaceId": "Spaces-1",
    "installationId": "98dca12e-eb95-4757-bac9-d54018e75310",
    "machineId": "Machines-61"
  },
  "authenticationToken": "QJ9QKY5MV3YZTDF9RQIDW4CRQP5TAHM25VYDP2Y1XPE",
  "certificateThumbprint": "BD365B54DDF25D37037390DD89F53247AA5AF14E"
}

```