### PR TITLE
Add step template Get function

### DIFF
--- a/pkg/actiontemplates/action_template_service.go
+++ b/pkg/actiontemplates/action_template_service.go
@@ -237,3 +237,9 @@ func GetVersionByID(client newclient.Client, spaceID string, actionTemplateID st
 
 	return newclient.Get[ActionTemplate](client.HttpSession(), uri)
 }
+
+// Get returns a collection of action templates based on the criteria defined by its
+// input query parameter.
+func Get(client newclient.Client, spaceID string, actionsQuery ActionTemplateSearch) (*resources.Resources[*ActionTemplate], error) {
+	return newclient.GetByQuery[ActionTemplate](client, template, spaceID, actionsQuery)
+}

--- a/pkg/actiontemplates/action_template_service.go
+++ b/pkg/actiontemplates/action_template_service.go
@@ -159,21 +159,6 @@ func (s *ActionTemplateService) Search(searchQuery string) ([]ActionTemplateSear
 	return searchResults, err
 }
 
-// GetByPartialName performs a lookup and returns action templates with a matching
-// partial name.
-func (s *ActionTemplateService) GetByPartialName(partialName string) ([]*ActionTemplateSearch, error) {
-	if internal.IsEmpty(partialName) {
-		return []*ActionTemplateSearch{}, internal.CreateInvalidParameterError(constants.OperationGetByPartialName, constants.ParameterPartialName)
-	}
-
-	path, err := services.GetByPartialNamePath(s, partialName)
-	if err != nil {
-		return []*ActionTemplateSearch{}, err
-	}
-
-	return services.GetPagedResponse[ActionTemplateSearch](s, path)
-}
-
 // Update modifies an ActionTemplate based on the one provided as input.
 //
 // Deprecated: use actiontemplates.Update

--- a/pkg/actiontemplates/action_template_service.go
+++ b/pkg/actiontemplates/action_template_service.go
@@ -159,6 +159,21 @@ func (s *ActionTemplateService) Search(searchQuery string) ([]ActionTemplateSear
 	return searchResults, err
 }
 
+// GetByPartialName performs a lookup and returns action templates with a matching
+// partial name.
+func (s *ActionTemplateService) GetByPartialName(partialName string) ([]*ActionTemplateSearch, error) {
+	if internal.IsEmpty(partialName) {
+		return []*ActionTemplateSearch{}, internal.CreateInvalidParameterError(constants.OperationGetByPartialName, constants.ParameterPartialName)
+	}
+
+	path, err := services.GetByPartialNamePath(s, partialName)
+	if err != nil {
+		return []*ActionTemplateSearch{}, err
+	}
+
+	return services.GetPagedResponse[ActionTemplateSearch](s, path)
+}
+
 // Update modifies an ActionTemplate based on the one provided as input.
 //
 // Deprecated: use actiontemplates.Update


### PR DESCRIPTION
This PR adds a `Get` function to the step template service to allow templates to be searched. This is required to implement a proper data source in the Terraform provider to look up existing step templates.