### PR TITLE
Omit empty space ID

### DIFF
--- a/pkg/userroles/scoped_user_role.go
+++ b/pkg/userroles/scoped_user_role.go
@@ -11,7 +11,7 @@ type ScopedUserRole struct {
 	ProjectGroupIDs []string `json:"ProjectGroupIds,omitempty"`
 	TeamID          string   `json:"TeamId" validate:"required"`
 	TenantIDs       []string `json:"TenantIds,omitempty"`
-	SpaceID         string   `json:"SpaceId"`
+	SpaceID         string   `json:"SpaceId,omitempty"`
 	UserRoleID      string   `json:"UserRoleId" validate:"required"`
 
 	resources.Resource


### PR DESCRIPTION
[SC-120030]
Provides support for optional space ID in the terraform scoped user role resource. Related PR: https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/pull/85