### PR TITLE
feat: Add support for custom fields on releases

### DIFF
--- a/pkg/channels/channel.go
+++ b/pkg/channels/channel.go
@@ -27,13 +27,14 @@ type Channel struct {
 
 func NewChannel(name string, projectID string) *Channel {
 	return &Channel{
-		Name:              strings.TrimSpace(name),
-		ProjectID:         projectID,
-		Rules:             []ChannelRule{},
-		TenantTags:        []string{},
-		GitReferenceRules: []string{},
-		GitResourceRules:  []ChannelGitResourceRule{},
-		Resource:          *resources.NewResource(),
+		Name:                   strings.TrimSpace(name),
+		ProjectID:              projectID,
+		Rules:                  []ChannelRule{},
+		TenantTags:             []string{},
+		GitReferenceRules:      []string{},
+		GitResourceRules:       []ChannelGitResourceRule{},
+		CustomFieldDefinitions: []ChannelCustomFieldDefinition{},
+		Resource:               *resources.NewResource(),
 	}
 }
 

--- a/pkg/channels/channel.go
+++ b/pkg/channels/channel.go
@@ -10,16 +10,17 @@ import (
 )
 
 type Channel struct {
-	Description       string                   `json:"Description,omitempty"`
-	IsDefault         bool                     `json:"IsDefault"`
-	LifecycleID       string                   `json:"LifecycleId,omitempty"`
-	Name              string                   `json:"Name" validate:"required,notblank,notall"`
-	ProjectID         string                   `json:"ProjectId" validate:"required,notblank"`
-	Rules             []ChannelRule            `json:"Rules,omitempty"`
-	SpaceID           string                   `json:"SpaceId,omitempty"`
-	TenantTags        []string                 `json:"TenantTags,omitempty"`
-	GitReferenceRules []string                 `json:"GitReferenceRules,omitempty"`
-	GitResourceRules  []ChannelGitResourceRule `json:"GitResourceRules,omitempty"`
+	Description            string                         `json:"Description,omitempty"`
+	IsDefault              bool                           `json:"IsDefault"`
+	LifecycleID            string                         `json:"LifecycleId,omitempty"`
+	Name                   string                         `json:"Name" validate:"required,notblank,notall"`
+	ProjectID              string                         `json:"ProjectId" validate:"required,notblank"`
+	Rules                  []ChannelRule                  `json:"Rules,omitempty"`
+	SpaceID                string                         `json:"SpaceId,omitempty"`
+	TenantTags             []string                       `json:"TenantTags,omitempty"`
+	GitReferenceRules      []string                       `json:"GitReferenceRules,omitempty"`
+	GitResourceRules       []ChannelGitResourceRule       `json:"GitResourceRules,omitempty"`
+	CustomFieldDefinitions []ChannelCustomFieldDefinition `json:"CustomFieldDefinitions,omitempty"`
 
 	resources.Resource
 }

--- a/pkg/channels/channel_custom_field_definition.go
+++ b/pkg/channels/channel_custom_field_definition.go
@@ -1,0 +1,6 @@
+package channels
+
+type ChannelCustomFieldDefinition struct {
+	FieldName   string `json:"FieldName,omitempty"`
+	Description string `json:"Description,omitempty"`
+}

--- a/pkg/releases/create_release_v1.go
+++ b/pkg/releases/create_release_v1.go
@@ -2,6 +2,7 @@ package releases
 
 import (
 	"encoding/json"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/uritemplates"
@@ -12,19 +13,20 @@ type CreateReleaseCommandV1 struct {
 	// payload.
 	// It'd be nice to allow SpaceIDOrName, but the current server implementation requires a SpaceID
 	// (not a name) in the URL route, so we must force the caller to specify an ID only.
-	SpaceID               string   `json:"spaceId"`
-	ProjectIDOrName       string   `json:"projectName"`
-	PackageVersion        string   `json:"packageVersion,omitempty"`
-	GitCommit             string   `json:"gitCommit,omitempty"`
-	GitRef                string   `json:"gitRef,omitempty"`
-	ReleaseVersion        string   `json:"releaseVersion,omitempty"`
-	ChannelIDOrName       string   `json:"channelName,omitempty"`
-	Packages              []string `json:"packages,omitempty"`
-	GitResources          []string `json:"gitResources,omitempty"`
-	ReleaseNotes          string   `json:"releaseNotes,omitempty"`
-	IgnoreIfAlreadyExists bool     `json:"ignoreIfAlreadyExists"`
-	IgnoreChannelRules    bool     `json:"ignoreChannelRules"`
-	PackagePrerelease     string   `json:"packagePrerelease,omitempty"`
+	SpaceID               string            `json:"spaceId"`
+	ProjectIDOrName       string            `json:"projectName"`
+	PackageVersion        string            `json:"packageVersion,omitempty"`
+	GitCommit             string            `json:"gitCommit,omitempty"`
+	GitRef                string            `json:"gitRef,omitempty"`
+	ReleaseVersion        string            `json:"releaseVersion,omitempty"`
+	ChannelIDOrName       string            `json:"channelName,omitempty"`
+	Packages              []string          `json:"packages,omitempty"`
+	GitResources          []string          `json:"gitResources,omitempty"`
+	ReleaseNotes          string            `json:"releaseNotes,omitempty"`
+	IgnoreIfAlreadyExists bool              `json:"ignoreIfAlreadyExists"`
+	IgnoreChannelRules    bool              `json:"ignoreChannelRules"`
+	PackagePrerelease     string            `json:"packagePrerelease,omitempty"`
+	CustomFields          map[string]string `json:"customFields,omitempty"`
 }
 
 type CreateReleaseResponseV1 struct {

--- a/pkg/releases/release.go
+++ b/pkg/releases/release.go
@@ -1,8 +1,9 @@
 package releases
 
 import (
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/gitdependencies"
 	"time"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/gitdependencies"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/packages"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
@@ -22,6 +23,7 @@ type Release struct {
 	SelectedGitResources               []*gitdependencies.SelectedGitResources  `json:"SelectedGitResources,omitempty"`
 	SpaceID                            string                                   `json:"SpaceId,omitempty"`
 	Version                            string                                   `json:"Version"`
+	CustomFields                       map[string]string                        `json:"CustomFields,omitempty"`
 
 	resources.Resource
 }

--- a/test/e2e/channel_service_test.go
+++ b/test/e2e/channel_service_test.go
@@ -38,6 +38,7 @@ func AssertEqualChannels(t *testing.T, expected *channels.Channel, actual *chann
 	assert.True(t, reflect.DeepEqual(expected.TenantTags, actual.TenantTags))
 	assert.True(t, reflect.DeepEqual(expected.GitReferenceRules, actual.GitReferenceRules))
 	assert.True(t, reflect.DeepEqual(expected.GitResourceRules, actual.GitResourceRules))
+	assert.True(t, reflect.DeepEqual(expected.CustomFieldDefinitions, actual.CustomFieldDefinitions))
 }
 
 func CreateTestChannel(t *testing.T, client *client.Client, project *projects.Project) *channels.Channel {


### PR DESCRIPTION
## Context 

We are adding support for Custom Fields on releases as part of the new Ephemeral Environments feature coming to Octopus. This will allow custom key/value data to be stored on a release and used as part of naming automatically created ephemeral environments from releases. Channels can define which custom fields are required for releases created.

## Changes

Adds new properties to channel and release for custom fields.

[sc-113197]