### PR TITLE
fix: Set required property SpaceManagersTeamMembers when creating new space

### DIFF
--- a/pkg/spaces/space.go
+++ b/pkg/spaces/space.go
@@ -20,9 +20,10 @@ type Space struct {
 // NewSpace initializes a Space with a name.
 func NewSpace(name string) *Space {
 	return &Space{
-		Name:               name,
-		Resource:           *resources.NewResource(),
-		SpaceManagersTeams: []string{}, // ensure required field is always present
+		Name:                     name,
+		Resource:                 *resources.NewResource(),
+		SpaceManagersTeams:       []string{}, // ensure required field is always present
+		SpaceManagersTeamMembers: []string{}, // ensure required field is always present
 	}
 }
 


### PR DESCRIPTION
We've had some failing [integration tests in the cli](https://github.com/OctopusDeploy/cli/actions/runs/17956240014/job/51068174273#step:7:21) creating a new space because a required property `SpaceManagersTeamMembers` isn't being set. We'll take a look at this within Octopus Server itself but in the meantime this PR sets the property to an empty array so that spaces can be created successfully.