### PR TITLE
feat: Add Ephemeral Environment Fields to Channel

### DIFF
--- a/pkg/channels/channel.go
+++ b/pkg/channels/channel.go
@@ -10,17 +10,20 @@ import (
 )
 
 type Channel struct {
-	Description            string                         `json:"Description,omitempty"`
-	IsDefault              bool                           `json:"IsDefault"`
-	LifecycleID            string                         `json:"LifecycleId,omitempty"`
-	Name                   string                         `json:"Name" validate:"required,notblank,notall"`
-	ProjectID              string                         `json:"ProjectId" validate:"required,notblank"`
-	Rules                  []ChannelRule                  `json:"Rules,omitempty"`
-	SpaceID                string                         `json:"SpaceId,omitempty"`
-	TenantTags             []string                       `json:"TenantTags,omitempty"`
-	GitReferenceRules      []string                       `json:"GitReferenceRules,omitempty"`
-	GitResourceRules       []ChannelGitResourceRule       `json:"GitResourceRules,omitempty"`
-	CustomFieldDefinitions []ChannelCustomFieldDefinition `json:"CustomFieldDefinitions,omitempty"`
+	CustomFieldDefinitions           []ChannelCustomFieldDefinition `json:"CustomFieldDefinitions,omitempty"`
+	Description                      string                         `json:"Description,omitempty"`
+	EphemeralEnvironmentNameTemplate string                         `json:"EphemeralEnvironmentNameTemplate,omitempty"`
+	IsDefault                        bool                           `json:"IsDefault"`
+	LifecycleID                      string                         `json:"LifecycleId,omitempty"`
+	Name                             string                         `json:"Name" validate:"required,notblank,notall"`
+	ParentEnvironmentID              string                         `json:"ParentEnvironmentId,omitempty"`
+	ProjectID                        string                         `json:"ProjectId" validate:"required,notblank"`
+	Rules                            []ChannelRule                  `json:"Rules,omitempty"`
+	SpaceID                          string                         `json:"SpaceId,omitempty"`
+	TenantTags                       []string                       `json:"TenantTags,omitempty"`
+	Type                             ChannelType                    `json:"Type,omitempty"`
+	GitReferenceRules                []string                       `json:"GitReferenceRules,omitempty"`
+	GitResourceRules                 []ChannelGitResourceRule       `json:"GitResourceRules,omitempty"`
 
 	resources.Resource
 }

--- a/pkg/channels/channel_service_test.go
+++ b/pkg/channels/channel_service_test.go
@@ -29,6 +29,12 @@ func TestChannelServiceAdd(t *testing.T) {
 	resource, err = service.Add(invalidResource)
 	assert.Equal(t, internal.CreateValidationFailureError(constants.OperationAdd, invalidResource.Validate()), err)
 	assert.Nil(t, resource)
+
+	invalidResource = NewChannel("test-channel", "Projects-1")
+	invalidResource.Type = "invalid"
+	resource, err = service.Add(invalidResource)
+	assert.Error(t, err)
+	assert.Nil(t, resource)
 }
 
 func TestChannelServiceGetByID(t *testing.T) {

--- a/pkg/channels/channel_type.go
+++ b/pkg/channels/channel_type.go
@@ -1,0 +1,9 @@
+package channels
+
+// ChannelType is the type of channel.
+type ChannelType string
+
+const (
+	ChannelTypeEphemeral ChannelType = "EphemeralEnvironment"
+	ChannelTypeLifecycle ChannelType = "Lifecycle"
+)

--- a/test/e2e/channel_service_test.go
+++ b/test/e2e/channel_service_test.go
@@ -35,6 +35,9 @@ func AssertEqualChannels(t *testing.T, expected *channels.Channel, actual *chann
 	assert.Equal(t, expected.Name, actual.Name)
 	assert.Equal(t, expected.ProjectID, actual.ProjectID)
 	assert.True(t, reflect.DeepEqual(expected.Rules, actual.Rules))
+	assert.Equal(t, expected.ParentEnvironmentID, actual.ParentEnvironmentID)
+	assert.Equal(t, expected.Type, actual.Type)
+	assert.Equal(t, expected.EphemeralEnvironmentNameTemplate, actual.EphemeralEnvironmentNameTemplate)
 	assert.True(t, reflect.DeepEqual(expected.TenantTags, actual.TenantTags))
 	assert.True(t, reflect.DeepEqual(expected.GitReferenceRules, actual.GitReferenceRules))
 	assert.True(t, reflect.DeepEqual(expected.GitResourceRules, actual.GitResourceRules))
@@ -50,6 +53,7 @@ func CreateTestChannel(t *testing.T, client *client.Client, project *projects.Pr
 	name := internal.GetRandomName()
 
 	channel := channels.NewChannel(name, project.GetID())
+	channel.Type = channels.ChannelTypeLifecycle
 	require.NotNil(t, channel)
 	require.NoError(t, channel.Validate())
 
@@ -299,6 +303,7 @@ func CreateTestChannel_NewClient(t *testing.T, client *client.Client, project *p
 	name := internal.GetRandomName()
 
 	channel := channels.NewChannel(name, project.GetID())
+	channel.Type = channels.ChannelTypeLifecycle
 	require.NotNil(t, channel)
 	require.NoError(t, channel.Validate())
 


### PR DESCRIPTION
Ephemeral Environments has introduced a new type of channel called an Ephemeral Environment Channel. This change adds this new channel type, along with its new fields (EphemeralEnvironmentNameTemplate and ParentEnvironmentID) to the channel.

[sc-122355]