### PR TITLE
Add Parent Environment

### DIFF
--- a/pkg/environments/parentenvironments/parent_environment.go
+++ b/pkg/environments/parentenvironments/parent_environment.go
@@ -1,0 +1,37 @@
+package parentenvironments
+
+import (
+	"github.com/go-playground/validator/v10"
+)
+
+// AutomaticDeprovisioningRule defines the rule for automatic deprovisioning.
+type AutomaticDeprovisioningRule struct {
+	ExpiryDays  int `json:"ExpiryDays,omitempty"`
+	ExpiryHours int `json:"ExpiryHours,omitempty"`
+}
+
+// ParentEnvironment represents a parent environment in Octopus Deploy.
+type ParentEnvironment struct {
+	Name                        string                       `json:"Name" validate:"required"`
+	SpaceID                     string                       `json:"SpaceId" validate:"required"`
+	Description                 string                       `json:"Description,omitempty"`
+	Slug                        string                       `json:"Slug,omitempty"`
+	UseGuidedFailure            bool                         `json:"UseGuidedFailure"`
+	AutomaticDeprovisioningRule *AutomaticDeprovisioningRule `json:"AutomaticDeprovisioningRule,omitempty"`
+	ID                          string                       `json:"Id,omitempty"`
+	SortOrder                   int                          `json:"SortOrder"`
+}
+
+// NewParentEnvironment creates and initializes a parent environment.
+func NewParentEnvironment(name string, spaceID string) *ParentEnvironment {
+	return &ParentEnvironment{
+		Name:    name,
+		SpaceID: spaceID,
+	}
+}
+
+// Validate checks the state of the parent environment and returns an error if
+// invalid.
+func (p *ParentEnvironment) Validate() error {
+	return validator.New().Struct(p)
+}

--- a/pkg/environments/parentenvironments/parent_environment_service.go
+++ b/pkg/environments/parentenvironments/parent_environment_service.go
@@ -1,0 +1,28 @@
+package parentenvironments
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+)
+
+const template = "/api/spaces/{spaceId}/parentEnvironments{/id}"
+
+// Add creates a new parent environment.
+func Add(client newclient.Client, parentEnvironment *ParentEnvironment) (*ParentEnvironment, error) {
+	return newclient.Add[ParentEnvironment](client, template, parentEnvironment.SpaceID, parentEnvironment)
+}
+
+// DeleteByID deletes the parent environment based on the ID provided as input.
+func DeleteByID(client newclient.Client, spaceID string, ID string) error {
+	return newclient.DeleteByID(client, template, spaceID, ID)
+}
+
+// GetByID returns the parent environment that matches the input ID. If one cannot be
+// found, it returns nil and an error.
+func GetByID(client newclient.Client, spaceID string, ID string) (*ParentEnvironment, error) {
+	return newclient.GetByID[ParentEnvironment](client, template, spaceID, ID)
+}
+
+// Update updates an existing parent environment.
+func Update(client newclient.Client, parentEnvironment *ParentEnvironment) (*ParentEnvironment, error) {
+	return newclient.Update[ParentEnvironment](client, template, parentEnvironment.SpaceID, parentEnvironment.ID, parentEnvironment)
+}


### PR DESCRIPTION
Ephemeral environments have introduced the concept of a parent environment. This environment will be linked to an ephemeral environment so that it can be used to set for example, variables on the parent environment to be used for the ephemeral environment.

This change adds the parent environment model.

[sc-122355]