### PR TITLE
chore: Update go version to latest patch version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/OctopusDeploy/go-octopusdeploy/v2
 
-go 1.23.0
+go 1.23.12
 
 require (
 	github.com/MakeNowJust/heredoc/v2 v2.0.1


### PR DESCRIPTION
In #358, we updated go to 1.23.0 but this version is missing the patch for CVE-2025-22871.

This PR updates go to the latest patch version.

I've run `go mod tidy` to ensure the dependencies are good to go.

[sc-123351]
