### PR TITLE
feat: Add function to retrieve all ephemeral environments

### DIFF
--- a/pkg/environments/environment_v2_query.go
+++ b/pkg/environments/environment_v2_query.go
@@ -1,0 +1,7 @@
+package environments
+
+type EnvironmentV2Query struct {
+	Skip int    `uri:"skip" url:"skip"`
+	Take int    `uri:"take" url:"take"`
+	Type string `uri:"type,omitempty" url:"type,omitempty"`
+}

--- a/pkg/environments/ephemeralenvironments/ephemeral_environment.go
+++ b/pkg/environments/ephemeralenvironments/ephemeral_environment.go
@@ -1,0 +1,26 @@
+package ephemeralenvironments
+
+type EphemeralEnvironment struct {
+	ID                  string `json:"Id"`
+	Name                string `json:"Name"`
+	SpaceID             string `json:"SpaceId"`
+	Slug                string `json:"Slug"`
+	Description         string `json:"Description"`
+	Type                string `json:"Type"`
+	SortOrder           int    `json:"SortOrder"`
+	UseGuidedFailure    bool   `json:"UseGuidedFailure"`
+	ParentEnvironmentId string `json:"ParentEnvironmentId"`
+}
+
+type EphemeralEnvironmentV2Response struct {
+	Environments *EphemeralEnvironmentResponse `json:Environments`
+}
+
+type EphemeralEnvironmentResponse struct {
+	ItemType       string                  `json:"ItemType"`
+	TotalResults   int                     `json:"TotalResults"`
+	ItemsPerPage   int                     `json:"ItemsPerPage"`
+	NumberOfPages  int                     `json:"NumberOfPages"`
+	LastPageNumber int                     `json:"LastPageNumber"`
+	Items          []*EphemeralEnvironment `json:"Items"`
+}


### PR DESCRIPTION
In order to be able to select an ephemeral environment to deploy to, we have to have the ability to find all ephemeral environments. This code review adds a function that will retrieve all ephemeral environments to the user.