### PR TITLE
Allow empty fields on channel custom field definitions

### DIFF
--- a/pkg/channels/channel.go
+++ b/pkg/channels/channel.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Channel struct {
-	CustomFieldDefinitions                   []ChannelCustomFieldDefinition `json:"CustomFieldDefinitions,omitempty"`
+	CustomFieldDefinitions                   []ChannelCustomFieldDefinition `json:"CustomFieldDefinitions"`
 	Description                              string                         `json:"Description,omitempty"`
 	EphemeralEnvironmentNameTemplate         string                         `json:"EphemeralEnvironmentNameTemplate,omitempty"`
 	IsDefault                                bool                           `json:"IsDefault"`

--- a/pkg/channels/channel.go
+++ b/pkg/channels/channel.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Channel struct {
-	CustomFieldDefinitions                   []ChannelCustomFieldDefinition `json:"CustomFieldDefinitions"`
+	CustomFieldDefinitions                   *[]ChannelCustomFieldDefinition `json:"CustomFieldDefinitions,omitempty"`
 	Description                              string                         `json:"Description,omitempty"`
 	EphemeralEnvironmentNameTemplate         string                         `json:"EphemeralEnvironmentNameTemplate,omitempty"`
 	IsDefault                                bool                           `json:"IsDefault"`
@@ -37,7 +37,7 @@ func NewChannel(name string, projectID string) *Channel {
 		TenantTags:             []string{},
 		GitReferenceRules:      []string{},
 		GitResourceRules:       []ChannelGitResourceRule{},
-		CustomFieldDefinitions: []ChannelCustomFieldDefinition{},
+		CustomFieldDefinitions: &[]ChannelCustomFieldDefinition{},
 		Resource:               *resources.NewResource(),
 	}
 }

--- a/pkg/channels/channel.go
+++ b/pkg/channels/channel.go
@@ -31,14 +31,13 @@ type Channel struct {
 
 func NewChannel(name string, projectID string) *Channel {
 	return &Channel{
-		Name:                   strings.TrimSpace(name),
-		ProjectID:              projectID,
-		Rules:                  []ChannelRule{},
-		TenantTags:             []string{},
-		GitReferenceRules:      []string{},
-		GitResourceRules:       []ChannelGitResourceRule{},
-		CustomFieldDefinitions: &[]ChannelCustomFieldDefinition{},
-		Resource:               *resources.NewResource(),
+		Name:              strings.TrimSpace(name),
+		ProjectID:         projectID,
+		Rules:             []ChannelRule{},
+		TenantTags:        []string{},
+		GitReferenceRules: []string{},
+		GitResourceRules:  []ChannelGitResourceRule{},
+		Resource:          *resources.NewResource(),
 	}
 }
 

--- a/pkg/channels/channel_custom_field_definition.go
+++ b/pkg/channels/channel_custom_field_definition.go
@@ -1,6 +1,6 @@
 package channels
 
 type ChannelCustomFieldDefinition struct {
-	FieldName   string `json:"FieldName"`
-	Description string `json:"Description"`
+	FieldName   string `json:"FieldName,omitempty"`
+	Description string `json:"Description,omitempty"`
 }

--- a/pkg/channels/channel_custom_field_definition.go
+++ b/pkg/channels/channel_custom_field_definition.go
@@ -1,6 +1,6 @@
 package channels
 
 type ChannelCustomFieldDefinition struct {
-	FieldName   string `json:"FieldName,omitempty"`
-	Description string `json:"Description,omitempty"`
+	FieldName   string `json:"FieldName"`
+	Description string `json:"Description"`
 }


### PR DESCRIPTION
## Pending advice from MAS. Please hold off on reviewing for now 🛑 

## Background 🌇 

We are currently making a [change to the Octopus Terraform provider](https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/pull/193) to enable the creation and removal of custom field definitions on a channel. In order to completely clear custom fields from the channel we need to be able to send an empty array of custom field definitions to the API. 

Currently, when the `CustomFieldDefinitions` field is empty, the go client would omit it entirely. This is because we have marked this field as `omitempty`. This makes it impossible to signal to the API that all definitions should be removed.

## What's this? 🌵 

This change introduces a pointer to the `CustomFieldDefinitions` field in order to distinguish between cases where it contains an empty list and cases where the field not provided.  

🚩🚩🚩 The proposed change would be a breaking one in that: 
- Anyone who was sending an empty slice in an API request and expecting it to be ignored, will now have their custom field definitions cleared instead!
- The type of `CustomFieldDefinitions` has changed. This could cause compile errors for anyone who is referring directly to the type (e.g., [like us](https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/pull/193/changes#diff-9d5e67c6396176540e92171ab47fccb761797e737354bdba051f2de3cfc822f1R339)). 

## How to review 🔍 
☑️ Carefully. This is my first time making changes in this repository.
🚩 See my red flags above! I'm putting this up as a draft for now to get some advice on the approach.

Part of DEVEX-147