### PR TITLE
Add VersioningStrategy and VersionTagRegex to ChannelRule and SearchPackageVersionsQuery

### DIFF
--- a/pkg/channels/channel_rule.go
+++ b/pkg/channels/channel_rule.go
@@ -14,5 +14,15 @@ type ChannelRule struct {
 	//to specify the range of versions to include
 	VersionRange string `json:"VersionRange,omitempty"`
 
+	// VersioningStrategy controls how packages are ordered to determine the latest version.
+	// Set to "MostRecentlyPublished" to use publish date ordering instead of SemVer comparison.
+	// When unset or "SemVer", the existing behaviour applies.
+	VersioningStrategy string `json:"VersioningStrategy,omitempty"`
+
+	// VersionTagRegex is a regex matched against the full version/tag string.
+	// Used with VersioningStrategy "MostRecentlyPublished" as an alternative to
+	// VersionRange and Tag, supporting non-SemVer versioning schemes.
+	VersionTagRegex string `json:"VersionTagRegex,omitempty"`
+
 	resources.Resource
 }

--- a/pkg/feeds/search_package_versions_query.go
+++ b/pkg/feeds/search_package_versions_query.go
@@ -10,4 +10,6 @@ type SearchPackageVersionsQuery struct {
 	Skip                int    `uri:"skip,omitempty"`
 	Take                int    `uri:"take,omitempty"`
 	VersionRange        string `uri:"versionRange,omitempty"`
+	VersioningStrategy  string `uri:"versioningStrategy,omitempty"`
+	VersionTagRegex     string `uri:"versionTagRegex,omitempty"`
 }


### PR DESCRIPTION
## Summary

Additive changes to support the `MostRecentlyPublished` package ordering strategy being introduced in Octopus Server ([server PR #43750](https://github.com/OctopusDeploy/OctopusDeploy/pull/43750)).

**`pkg/channels/channel_rule.go`**
- `VersioningStrategy string` — `"MostRecentlyPublished"` uses publish date ordering instead of SemVer comparison; unset/`"SemVer"` preserves existing behaviour
- `VersionTagRegex string` — regex matched against the full version/tag string, used with `MostRecentlyPublished` as an alternative to `VersionRange` + `Tag`

**`pkg/feeds/search_package_versions_query.go`**
- `VersioningStrategy string` — `uri:"versioningStrategy,omitempty"` query param for `/feeds/{id}/packages`
- `VersionTagRegex string` — `uri:"versionTagRegex,omitempty"` query param

Both changes are purely additive — no existing fields, behaviour, or tests are changed. The CLI ([OctopusDeploy/cli](https://github.com/OctopusDeploy/cli)) will consume these new fields in a follow-up PR to correctly handle `MostRecentlyPublished` channels during `release create`.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./pkg/channels/... ./pkg/feeds/...` pass