### PR TITLE
Add omitempty to Audience

### DIFF
--- a/pkg/serviceaccounts/oidc_identities.go
+++ b/pkg/serviceaccounts/oidc_identities.go
@@ -15,7 +15,7 @@ type OIDCIdentityQuery struct {
 }
 
 type OIDCIdentity struct {
-	Audience         string `json:"Audience"`
+	Audience         string `json:"Audience,omitempty"`
 	Issuer           string `json:"Issuer"`
 	Name             string `json:"Name"`
 	ServiceAccountID string `json:"ServiceAccountId"`

--- a/pkg/serviceaccounts/oidc_identities_test.go
+++ b/pkg/serviceaccounts/oidc_identities_test.go
@@ -1,0 +1,36 @@
+package serviceaccounts
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOIDCIdentity_MarshalJSON_OmitsEmptyAudience(t *testing.T) {
+	identity := NewOIDCIdentity("ServiceAccounts-1", "name", "issuer", "subject")
+
+	data, err := json.Marshal(identity)
+	assert.NoError(t, err)
+
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+
+	_, hasAudience := result["Audience"]
+	assert.False(t, hasAudience, "Audience must be omitted from JSON when unset")
+}
+
+func TestOIDCIdentity_MarshalJSON_IncludesAudienceWhenSet(t *testing.T) {
+	identity := NewOIDCIdentity("ServiceAccounts-1", "name", "issuer", "subject")
+	identity.Audience = "api://custom"
+
+	data, err := json.Marshal(identity)
+	assert.NoError(t, err)
+
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "api://custom", result["Audience"])
+}


### PR DESCRIPTION
Audience is being initialized in the TFP as an empty string rather than `null` when no value is provided. This leads to it being attempted to be used in Octopus which can result in the following error:
```
Error: Error: Could not find matching identity for presented assertions. Assertions - Issuer: 'https://token.actions.githubusercontent.com/', Subject: 'repo:', Audience: ''
```

Fixes https://github.com/OctopusDeploy/go-octopusdeploy/issues/338