### PR TITLE
Fix empty GitDependencyName being cleared in Channel DeploymentActionGitDependency

### DIFF
--- a/pkg/channels/channel.go
+++ b/pkg/channels/channel.go
@@ -24,7 +24,7 @@ type Channel struct {
 	TenantTags                               []string                       `json:"TenantTags,omitempty"`
 	Type                                     ChannelType                    `json:"Type,omitempty"`
 	GitReferenceRules                        []string                       `json:"GitReferenceRules,omitempty"`
-	GitResourceRules                         []ChannelGitResourceRule       `json:"GitResourceRules,omitempty"`
+	GitResourceRules                         []ChannelGitResourceRule       `json:"GitResourceRules,omitempty" validate:"dive"`
 
 	resources.Resource
 }

--- a/pkg/channels/channel_git_resource_rule.go
+++ b/pkg/channels/channel_git_resource_rule.go
@@ -4,6 +4,6 @@ import "github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/gitdependencies"
 
 type ChannelGitResourceRule struct {
 	Id                   string                                          `json:"Id,omitempty"`
-	GitDependencyActions []gitdependencies.DeploymentActionGitDependency `json:"GitDependencyActions,omitempty"`
+	GitDependencyActions []gitdependencies.DeploymentActionGitDependency `json:"GitDependencyActions,omitempty" validate:"dive"`
 	Rules                []string                                        `json:"Rules,omitempty"`
 }

--- a/pkg/channels/channel_git_resource_rule_test.go
+++ b/pkg/channels/channel_git_resource_rule_test.go
@@ -1,0 +1,42 @@
+package channels
+
+import (
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/gitdependencies"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChannelValidateDivesIntoGitResourceRules(t *testing.T) {
+	newChannelWithGitDependency := func(dep gitdependencies.DeploymentActionGitDependency) *Channel {
+		channel := NewChannel("my-channel", "Projects-1")
+		channel.GitResourceRules = []ChannelGitResourceRule{
+			{GitDependencyActions: []gitdependencies.DeploymentActionGitDependency{dep}},
+		}
+		return channel
+	}
+
+	t.Run("valid nested git dependency passes", func(t *testing.T) {
+		channel := newChannelWithGitDependency(gitdependencies.DeploymentActionGitDependency{
+			DeploymentActionSlug: "deploy-action",
+			GitDependencyName:    "",
+		})
+		require.NoError(t, channel.Validate())
+	})
+
+	t.Run("empty deployment action slug fails", func(t *testing.T) {
+		channel := newChannelWithGitDependency(gitdependencies.DeploymentActionGitDependency{
+			DeploymentActionSlug: "",
+			GitDependencyName:    "my-dependency",
+		})
+		require.Error(t, channel.Validate())
+	})
+
+	t.Run("whitespace-only deployment action slug fails", func(t *testing.T) {
+		channel := newChannelWithGitDependency(gitdependencies.DeploymentActionGitDependency{
+			DeploymentActionSlug: "   ",
+			GitDependencyName:    "my-dependency",
+		})
+		require.Error(t, channel.Validate())
+	})
+}

--- a/pkg/gitdependencies/deployment_action_git_dependency.go
+++ b/pkg/gitdependencies/deployment_action_git_dependency.go
@@ -1,6 +1,20 @@
 package gitdependencies
 
+import (
+	"github.com/go-playground/validator/v10"
+	"github.com/go-playground/validator/v10/non-standard/validators"
+)
+
 type DeploymentActionGitDependency struct {
-	DeploymentActionSlug string `json:"DeploymentActionSlug,omitempty"`
-	GitDependencyName    string `json:"GitDependencyName,omitempty"`
+	DeploymentActionSlug string `json:"DeploymentActionSlug" validate:"required,notblank"`
+	GitDependencyName    string `json:"GitDependencyName"`
+}
+
+// Validate checks the state of the deployment action git dependency and returns an error if invalid.
+func (d DeploymentActionGitDependency) Validate() error {
+	v := validator.New()
+	if err := v.RegisterValidation("notblank", validators.NotBlank); err != nil {
+		return err
+	}
+	return v.Struct(d)
 }

--- a/pkg/gitdependencies/deployment_action_git_dependency_test.go
+++ b/pkg/gitdependencies/deployment_action_git_dependency_test.go
@@ -1,0 +1,66 @@
+package gitdependencies
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeploymentActionGitDependencyValidate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		dependency  DeploymentActionGitDependency
+		expectError bool
+	}{
+		{
+			name:        "valid - both fields populated",
+			dependency:  DeploymentActionGitDependency{DeploymentActionSlug: "deploy-action", GitDependencyName: "my-dependency"},
+			expectError: false,
+		},
+		{
+			name:        "valid - empty git dependency name is allowed",
+			dependency:  DeploymentActionGitDependency{DeploymentActionSlug: "deploy-action", GitDependencyName: ""},
+			expectError: false,
+		},
+		{
+			name:        "valid - whitespace git dependency name is allowed",
+			dependency:  DeploymentActionGitDependency{DeploymentActionSlug: "deploy-action", GitDependencyName: "   "},
+			expectError: false,
+		},
+		{
+			name:        "invalid - empty deployment action slug",
+			dependency:  DeploymentActionGitDependency{DeploymentActionSlug: "", GitDependencyName: "my-dependency"},
+			expectError: true,
+		},
+		{
+			name:        "invalid - whitespace-only deployment action slug",
+			dependency:  DeploymentActionGitDependency{DeploymentActionSlug: "   ", GitDependencyName: "my-dependency"},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.dependency.Validate()
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Checks both fields are always present in the payload as these are required properties in Octopus
+// and an empty Git dependency name is valid
+func TestDeploymentActionGitDependencyMarshalJSON(t *testing.T) {
+	data, err := json.Marshal(DeploymentActionGitDependency{})
+	require.NoError(t, err)
+
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &fields))
+
+	require.Contains(t, fields, "DeploymentActionSlug")
+	require.Contains(t, fields, "GitDependencyName")
+}


### PR DESCRIPTION
This property is `Required(AllowEmptyStrings = true)` in Octopus, meaning empty strings are an accepted value. `omitempty` caused this value to be cleared when an empty string was used as the value, leading to the following error from Octopus (example usage from the Terraform provider):
> Octopus API error: There was a problem with your request. [The GitDependencyName field is required.]

This PR also updates `DeploymentActionSlug` to be required as this is also a required property in Octopus (however this one can't be empty).