### PR TITLE
feat: add approval policies and server-task approvals support

### DIFF
--- a/pkg/approvalpolicies/approval_policies_service.go
+++ b/pkg/approvalpolicies/approval_policies_service.go
@@ -1,6 +1,8 @@
 package approvalpolicies
 
 import (
+	"math"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
@@ -18,9 +20,16 @@ func Get(client newclient.Client, spaceID string, query ApprovalPoliciesQuery) (
 	return newclient.GetByQuery[ApprovalPolicy](client, template, spaceID, query)
 }
 
-// GetAll returns all approval policies in the space, following pagination links.
+// GetAll returns all approval policies in the space. The list endpoint requires
+// the skip and take query parameters, so this issues a single request with the
+// maximum take rather than relying on the generic paginated helper (which omits
+// them and would be rejected by the server).
 func GetAll(client newclient.Client, spaceID string) ([]*ApprovalPolicy, error) {
-	return newclient.GetAll[ApprovalPolicy](client, template, spaceID)
+	res, err := Get(client, spaceID, ApprovalPoliciesQuery{Skip: 0, Take: math.MaxInt32})
+	if err != nil {
+		return nil, err
+	}
+	return res.Items, nil
 }
 
 // Add creates a new approval policy.

--- a/pkg/approvalpolicies/approval_policies_service.go
+++ b/pkg/approvalpolicies/approval_policies_service.go
@@ -1,0 +1,45 @@
+package approvalpolicies
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+)
+
+const template = "/api/{spaceId}/approvalpolicies{/id}{?skip,take,partialName}"
+
+// GetByID returns the approval policy that matches the input ID.
+func GetByID(client newclient.Client, spaceID string, ID string) (*ApprovalPolicy, error) {
+	return newclient.GetByID[ApprovalPolicy](client, template, spaceID, ID)
+}
+
+// Get returns a paginated collection of approval policies matching the query.
+func Get(client newclient.Client, spaceID string, query ApprovalPoliciesQuery) (*resources.Resources[*ApprovalPolicy], error) {
+	return newclient.GetByQuery[ApprovalPolicy](client, template, spaceID, query)
+}
+
+// GetAll returns all approval policies in the space, following pagination links.
+func GetAll(client newclient.Client, spaceID string) ([]*ApprovalPolicy, error) {
+	return newclient.GetAll[ApprovalPolicy](client, template, spaceID)
+}
+
+// Add creates a new approval policy.
+func Add(client newclient.Client, spaceID string, policy *ApprovalPolicy) (*ApprovalPolicy, error) {
+	if policy == nil {
+		return nil, internal.CreateRequiredParameterIsEmptyOrNilError("policy")
+	}
+	return newclient.Add[ApprovalPolicy](client, template, spaceID, policy)
+}
+
+// Update modifies an existing approval policy.
+func Update(client newclient.Client, spaceID string, policy *ApprovalPolicy) (*ApprovalPolicy, error) {
+	if policy == nil {
+		return nil, internal.CreateRequiredParameterIsEmptyOrNilError("policy")
+	}
+	return newclient.Update[ApprovalPolicy](client, template, spaceID, policy.GetID(), policy)
+}
+
+// DeleteByID deletes the approval policy that matches the input ID.
+func DeleteByID(client newclient.Client, spaceID string, ID string) error {
+	return newclient.DeleteByID(client, template, spaceID, ID)
+}

--- a/pkg/approvalpolicies/approval_policies_service_test.go
+++ b/pkg/approvalpolicies/approval_policies_service_test.go
@@ -1,0 +1,24 @@
+package approvalpolicies
+
+import (
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+	"github.com/stretchr/testify/require"
+)
+
+func createClient() newclient.Client {
+	return newclient.NewClient(&newclient.HttpSession{})
+}
+
+func TestAddParameterValidation(t *testing.T) {
+	client := createClient()
+	_, err := Add(client, "Spaces-1", nil)
+	require.Error(t, err)
+}
+
+func TestUpdateParameterValidation(t *testing.T) {
+	client := createClient()
+	_, err := Update(client, "Spaces-1", nil)
+	require.Error(t, err)
+}

--- a/pkg/approvalpolicies/approval_policy.go
+++ b/pkg/approvalpolicies/approval_policy.go
@@ -1,0 +1,71 @@
+package approvalpolicies
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+)
+
+// ApprovalPolicyScopingStrategy selects whether a policy is scoped by tags or by ids.
+type ApprovalPolicyScopingStrategy string
+
+const (
+	ApprovalPolicyScopingStrategyTag ApprovalPolicyScopingStrategy = "Tag"
+	ApprovalPolicyScopingStrategyId  ApprovalPolicyScopingStrategy = "Id"
+)
+
+// ApprovalPolicyTagScope scopes a policy by project/environment tags (ScopingStrategy = "Tag").
+type ApprovalPolicyTagScope struct {
+	Id              string   `json:"Id,omitempty"`
+	ProjectTags     []string `json:"ProjectTags"`
+	EnvironmentTags []string `json:"EnvironmentTags"`
+}
+
+// ApprovalPolicyIdScope scopes a policy by a project + specific environments (ScopingStrategy = "Id").
+type ApprovalPolicyIdScope struct {
+	Id             string   `json:"Id,omitempty"`
+	ProjectId      string   `json:"ProjectId"`
+	EnvironmentIds []string `json:"EnvironmentIds"`
+}
+
+// ApprovalPolicy is the reusable approval configuration applied to a set of
+// projects/environments (by tag or by id).
+type ApprovalPolicy struct {
+	SpaceID     string `json:"SpaceId,omitempty"`
+	Name        string `json:"Name" validate:"required"`
+	Description string `json:"Description,omitempty"`
+
+	ScopingStrategy ApprovalPolicyScopingStrategy `json:"ScopingStrategy"`
+	TagScopes       []ApprovalPolicyTagScope      `json:"TagScopes"`
+	IdScopes        []ApprovalPolicyIdScope       `json:"IdScopes"`
+
+	MinimumApproversRequired int `json:"MinimumApproversRequired"`
+
+	// AllowSelfApproval controls whether the deployment creator may approve their own
+	// deployment. There is no separate "block by creator" field — this is it, inverted.
+	AllowSelfApproval bool `json:"AllowSelfApproval"`
+
+	// IsDisabled disables the policy. There is no "Enabled" field — this is it, inverted.
+	IsDisabled bool `json:"IsDisabled"`
+
+	ApprovingUserIds []string `json:"ApprovingUserIds"`
+	ApprovingTeamIds []string `json:"ApprovingTeamIds"`
+
+	resources.Resource
+}
+
+// NewApprovalPolicy creates an ApprovalPolicy with server-friendly defaults
+// (Tag scoping, 2 minimum approvers, empty scope/approver slices).
+func NewApprovalPolicy(name string) *ApprovalPolicy {
+	return &ApprovalPolicy{
+		Name:                     name,
+		ScopingStrategy:          ApprovalPolicyScopingStrategyTag,
+		TagScopes:                []ApprovalPolicyTagScope{},
+		IdScopes:                 []ApprovalPolicyIdScope{},
+		MinimumApproversRequired: 2,
+		ApprovingUserIds:         []string{},
+		ApprovingTeamIds:         []string{},
+		Resource:                 *resources.NewResource(),
+	}
+}
+
+func (p *ApprovalPolicy) GetName() string     { return p.Name }
+func (p *ApprovalPolicy) SetName(name string) { p.Name = name }

--- a/pkg/approvalpolicies/approval_policy_query.go
+++ b/pkg/approvalpolicies/approval_policy_query.go
@@ -1,0 +1,8 @@
+package approvalpolicies
+
+// ApprovalPoliciesQuery is the query for the paginated approval-policies list endpoint.
+type ApprovalPoliciesQuery struct {
+	PartialName string `uri:"partialName,omitempty" url:"partialName,omitempty"`
+	Skip        int    `uri:"skip" url:"skip"`
+	Take        int    `uri:"take,omitempty" url:"take,omitempty"`
+}

--- a/pkg/approvalpolicies/approval_policy_test.go
+++ b/pkg/approvalpolicies/approval_policy_test.go
@@ -1,0 +1,71 @@
+package approvalpolicies
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApprovalPolicyTagScopeMarshalRoundTrip(t *testing.T) {
+	policy := NewApprovalPolicy("Production approvals")
+	policy.ID = "ApprovalPolicies-1"
+	policy.SpaceID = "Spaces-1"
+	policy.Description = "Requires two approvers"
+	policy.ScopingStrategy = ApprovalPolicyScopingStrategyTag
+	policy.MinimumApproversRequired = 2
+	policy.AllowSelfApproval = false
+	policy.IsDisabled = false
+	policy.TagScopes = []ApprovalPolicyTagScope{
+		{ProjectTags: []string{"tenant/prod"}, EnvironmentTags: []string{"env/prod"}},
+	}
+	policy.IdScopes = []ApprovalPolicyIdScope{}
+	policy.ApprovingUserIds = []string{"Users-1"}
+	policy.ApprovingTeamIds = []string{"Teams-1"}
+
+	data, err := json.Marshal(policy)
+	require.NoError(t, err)
+
+	expected := `{
+		"Id": "ApprovalPolicies-1",
+		"SpaceId": "Spaces-1",
+		"Name": "Production approvals",
+		"Description": "Requires two approvers",
+		"ScopingStrategy": "Tag",
+		"TagScopes": [{"ProjectTags":["tenant/prod"],"EnvironmentTags":["env/prod"]}],
+		"IdScopes": [],
+		"MinimumApproversRequired": 2,
+		"AllowSelfApproval": false,
+		"IsDisabled": false,
+		"ApprovingUserIds": ["Users-1"],
+		"ApprovingTeamIds": ["Teams-1"]
+	}`
+	require.JSONEq(t, expected, string(data))
+}
+
+func TestApprovalPolicyIdScopeUnmarshal(t *testing.T) {
+	payload := `{
+		"Id": "ApprovalPolicies-2",
+		"SpaceId": "Spaces-1",
+		"Name": "Id scoped",
+		"ScopingStrategy": "Id",
+		"TagScopes": [],
+		"IdScopes": [{"Id":"scope-1","ProjectId":"Projects-1","EnvironmentIds":["Environments-1","Environments-2"]}],
+		"MinimumApproversRequired": 1,
+		"AllowSelfApproval": true,
+		"IsDisabled": true,
+		"ApprovingUserIds": [],
+		"ApprovingTeamIds": ["Teams-9"]
+	}`
+	var policy ApprovalPolicy
+	require.NoError(t, json.Unmarshal([]byte(payload), &policy))
+
+	require.Equal(t, "ApprovalPolicies-2", policy.GetID())
+	require.Equal(t, ApprovalPolicyScopingStrategyId, policy.ScopingStrategy)
+	require.Len(t, policy.IdScopes, 1)
+	require.Equal(t, "Projects-1", policy.IdScopes[0].ProjectId)
+	require.Equal(t, []string{"Environments-1", "Environments-2"}, policy.IdScopes[0].EnvironmentIds)
+	require.True(t, policy.AllowSelfApproval)
+	require.True(t, policy.IsDisabled)
+	require.Equal(t, "Id scoped", policy.GetName())
+}

--- a/pkg/approvals/approval.go
+++ b/pkg/approvals/approval.go
@@ -1,0 +1,20 @@
+package approvals
+
+// ApprovalStatus is an individual approver's decision.
+type ApprovalStatus string
+
+const (
+	ApprovalStatusApproved ApprovalStatus = "Approved"
+	ApprovalStatusRejected ApprovalStatus = "Rejected"
+)
+
+// Approval is a single person's decision recorded against a ServerTaskApproval.
+type Approval struct {
+	Id                   string         `json:"Id,omitempty"`
+	SpaceId              string         `json:"SpaceId,omitempty"`
+	Name                 string         `json:"Name,omitempty"`
+	ServerTaskApprovalId string         `json:"ServerTaskApprovalId"`
+	UserId               string         `json:"UserId,omitempty"`
+	Status               ApprovalStatus `json:"Status"`
+	Notes                string         `json:"Notes"`
+}

--- a/pkg/approvals/approval_resources_test.go
+++ b/pkg/approvals/approval_resources_test.go
@@ -1,0 +1,70 @@
+package approvals
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerTaskApprovalUnmarshal(t *testing.T) {
+	payload := `{
+		"Id": "ServerTaskApprovals-1",
+		"ServerTaskId": "ServerTasks-1",
+		"SpaceId": "Spaces-1",
+		"ApprovalProviderId": "octopus",
+		"Name": "Deploy to Prod",
+		"ChangeRequest": {
+			"Id": "CR-1",
+			"Number": "CHG001",
+			"Description": "Deploy release 1.0",
+			"Active": true,
+			"Type": "normal",
+			"ChangeRequestApprovalState": "PreApproval",
+			"Self": "https://example/cr/1"
+		}
+	}`
+	var sta ServerTaskApproval
+	require.NoError(t, json.Unmarshal([]byte(payload), &sta))
+	require.Equal(t, "ServerTaskApprovals-1", sta.Id)
+	require.Equal(t, "octopus", sta.ApprovalProviderId)
+	require.Equal(t, ChangeRequestApprovalStatePreApproval, sta.ChangeRequest.ChangeRequestApprovalState)
+	require.Equal(t, "CHG001", sta.ChangeRequest.Number)
+}
+
+func TestServerTaskApprovalDetailUnmarshal(t *testing.T) {
+	payload := `{
+		"Id": "ServerTaskApprovals-1",
+		"SpaceId": "Spaces-1",
+		"Approvals": [
+			{"Id":"Approvals-1","SpaceId":"Spaces-1","Name":"a","ServerTaskApprovalId":"ServerTaskApprovals-1","UserId":"Users-1","Status":"Approved","Notes":"lgtm"}
+		],
+		"ApprovalState": "Approved",
+		"ApprovingUsers": [{"Id":"Users-1","DisplayName":"Alice","DisplayIdAndName":false}],
+		"ApprovalsCount": 1,
+		"MinimumApproversRequired": 2
+	}`
+	var detail ServerTaskApprovalDetail
+	require.NoError(t, json.Unmarshal([]byte(payload), &detail))
+	require.Equal(t, 1, detail.ApprovalsCount)
+	require.Equal(t, 2, detail.MinimumApproversRequired)
+	require.Len(t, detail.Approvals, 1)
+	require.Equal(t, ApprovalStatusApproved, detail.Approvals[0].Status)
+	require.Equal(t, "Alice", detail.ApprovingUsers[0].DisplayName)
+}
+
+func TestApprovalMarshal(t *testing.T) {
+	approval := &Approval{
+		ServerTaskApprovalId: "ServerTaskApprovals-1",
+		Status:               ApprovalStatusRejected,
+		Notes:                "needs change window",
+	}
+	data, err := json.Marshal(approval)
+	require.NoError(t, err)
+	expected := `{
+		"ServerTaskApprovalId": "ServerTaskApprovals-1",
+		"Status": "Rejected",
+		"Notes": "needs change window"
+	}`
+	require.JSONEq(t, expected, string(data))
+}

--- a/pkg/approvals/approval_resources_test.go
+++ b/pkg/approvals/approval_resources_test.go
@@ -68,3 +68,17 @@ func TestApprovalMarshal(t *testing.T) {
 	}`
 	require.JSONEq(t, expected, string(data))
 }
+
+func TestChangeRequestApprovalStateValues(t *testing.T) {
+	cases := map[ChangeRequestApprovalState]string{
+		ChangeRequestApprovalStatePreApproval:  "PreApproval",
+		ChangeRequestApprovalStateApproved:     "Approved",
+		ChangeRequestApprovalStatePostApproval: "PostApproval",
+	}
+	for state, want := range cases {
+		cr := ChangeRequest{ChangeRequestApprovalState: state}
+		data, err := json.Marshal(cr)
+		require.NoError(t, err)
+		require.Contains(t, string(data), `"ChangeRequestApprovalState":"`+want+`"`)
+	}
+}

--- a/pkg/approvals/approvals_service.go
+++ b/pkg/approvals/approvals_service.go
@@ -54,6 +54,7 @@ func GetByTaskID(client newclient.Client, spaceID string, serverTaskID string) (
 }
 
 // GetByID returns the server-task approval that matches the input ID.
+// It returns (nil, nil) if the response contains no server-task approval.
 func GetByID(client newclient.Client, spaceID string, ID string) (*ServerTaskApproval, error) {
 	if ID == "" {
 		return nil, internal.CreateRequiredParameterIsEmptyError("ID")

--- a/pkg/approvals/approvals_service.go
+++ b/pkg/approvals/approvals_service.go
@@ -1,0 +1,179 @@
+package approvals
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+)
+
+const serverTaskApprovalsTemplate = "/api/{spaceId}/servertaskapprovals{/id}{?skip,take,providerId,state}"
+const serverTaskApprovalByTaskTemplate = "/api/{spaceId}/tasks/{taskId}/servertaskapproval"
+const approvalsTemplate = "/api/{spaceId}/servertaskapprovals/{serverTaskApprovalId}/approvals{/id}"
+
+// ServerTaskApprovalsQuery is the query for the paginated server-task approvals list endpoint.
+type ServerTaskApprovalsQuery struct {
+	ProviderId string `uri:"providerId,omitempty" url:"providerId,omitempty"`
+	State      string `uri:"state,omitempty" url:"state,omitempty"`
+	Skip       int    `uri:"skip" url:"skip"`
+	Take       int    `uri:"take,omitempty" url:"take,omitempty"`
+}
+
+// getServerTaskApprovalByTaskIdResponse is the nullable envelope for the by-task endpoint.
+type getServerTaskApprovalByTaskIdResponse struct {
+	Resource *ServerTaskApprovalDetail `json:"Resource,omitempty"`
+}
+
+// getServerTaskApprovalByIdResponse unwraps the nested resource for get-by-id.
+type getServerTaskApprovalByIdResponse struct {
+	ServerTaskApproval *ServerTaskApproval `json:"ServerTaskApproval,omitempty"`
+}
+
+// GetByTaskID returns the approval detail for a server task. Returns (nil, nil)
+// when the task has no approval requirement (feature off, not a deployment/runbook,
+// or no policy applies).
+func GetByTaskID(client newclient.Client, spaceID string, serverTaskID string) (*ServerTaskApprovalDetail, error) {
+	if serverTaskID == "" {
+		return nil, internal.CreateRequiredParameterIsEmptyError("serverTaskID")
+	}
+	spaceID, err := internal.GetSpaceID(spaceID, client.GetSpaceID())
+	if err != nil {
+		return nil, err
+	}
+	path, err := client.URITemplateCache().Expand(serverTaskApprovalByTaskTemplate, map[string]any{
+		"spaceId": spaceID,
+		"taskId":  serverTaskID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	res, err := newclient.Get[getServerTaskApprovalByTaskIdResponse](client.HttpSession(), path)
+	if err != nil {
+		return nil, err
+	}
+	return res.Resource, nil
+}
+
+// GetByID returns the server-task approval that matches the input ID.
+func GetByID(client newclient.Client, spaceID string, ID string) (*ServerTaskApproval, error) {
+	if ID == "" {
+		return nil, internal.CreateRequiredParameterIsEmptyError("ID")
+	}
+	spaceID, err := internal.GetSpaceID(spaceID, client.GetSpaceID())
+	if err != nil {
+		return nil, err
+	}
+	path, err := client.URITemplateCache().Expand(serverTaskApprovalsTemplate, map[string]any{
+		"spaceId": spaceID,
+		"id":      ID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	res, err := newclient.Get[getServerTaskApprovalByIdResponse](client.HttpSession(), path)
+	if err != nil {
+		return nil, err
+	}
+	return res.ServerTaskApproval, nil
+}
+
+// Get returns a paginated collection of server-task approvals matching the query.
+func Get(client newclient.Client, spaceID string, query ServerTaskApprovalsQuery) (*resources.Resources[*ServerTaskApproval], error) {
+	return newclient.GetByQuery[ServerTaskApproval](client, serverTaskApprovalsTemplate, spaceID, query)
+}
+
+// GetAll returns all server-task approvals in the space, following pagination links.
+func GetAll(client newclient.Client, spaceID string) ([]*ServerTaskApproval, error) {
+	return newclient.GetAll[ServerTaskApproval](client, serverTaskApprovalsTemplate, spaceID)
+}
+
+// ListApprovals returns the individual decisions recorded against a server-task approval.
+// The server returns a bare array (not a paginated collection).
+func ListApprovals(client newclient.Client, spaceID string, serverTaskApprovalID string) ([]*Approval, error) {
+	if serverTaskApprovalID == "" {
+		return nil, internal.CreateRequiredParameterIsEmptyError("serverTaskApprovalID")
+	}
+	spaceID, err := internal.GetSpaceID(spaceID, client.GetSpaceID())
+	if err != nil {
+		return nil, err
+	}
+	path, err := client.URITemplateCache().Expand(approvalsTemplate, map[string]any{
+		"spaceId":              spaceID,
+		"serverTaskApprovalId": serverTaskApprovalID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	res, err := newclient.Get[[]*Approval](client.HttpSession(), path)
+	if err != nil {
+		return nil, err
+	}
+	return *res, nil
+}
+
+// GetApprovalByID returns a single decision by ID.
+func GetApprovalByID(client newclient.Client, spaceID string, serverTaskApprovalID string, ID string) (*Approval, error) {
+	if serverTaskApprovalID == "" {
+		return nil, internal.CreateRequiredParameterIsEmptyError("serverTaskApprovalID")
+	}
+	if ID == "" {
+		return nil, internal.CreateRequiredParameterIsEmptyError("ID")
+	}
+	spaceID, err := internal.GetSpaceID(spaceID, client.GetSpaceID())
+	if err != nil {
+		return nil, err
+	}
+	path, err := client.URITemplateCache().Expand(approvalsTemplate, map[string]any{
+		"spaceId":              spaceID,
+		"serverTaskApprovalId": serverTaskApprovalID,
+		"id":                   ID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return newclient.Get[Approval](client.HttpSession(), path)
+}
+
+// AddApproval records a new decision (approve/reject) against a server-task approval.
+func AddApproval(client newclient.Client, spaceID string, serverTaskApprovalID string, approval *Approval) (*Approval, error) {
+	if approval == nil {
+		return nil, internal.CreateRequiredParameterIsEmptyOrNilError("approval")
+	}
+	if serverTaskApprovalID == "" {
+		return nil, internal.CreateRequiredParameterIsEmptyError("serverTaskApprovalID")
+	}
+	spaceID, err := internal.GetSpaceID(spaceID, client.GetSpaceID())
+	if err != nil {
+		return nil, err
+	}
+	path, err := client.URITemplateCache().Expand(approvalsTemplate, map[string]any{
+		"spaceId":              spaceID,
+		"serverTaskApprovalId": serverTaskApprovalID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return newclient.Post[Approval](client.HttpSession(), path, approval)
+}
+
+// UpdateApproval modifies an existing decision.
+func UpdateApproval(client newclient.Client, spaceID string, serverTaskApprovalID string, approval *Approval) (*Approval, error) {
+	if approval == nil {
+		return nil, internal.CreateRequiredParameterIsEmptyOrNilError("approval")
+	}
+	if serverTaskApprovalID == "" {
+		return nil, internal.CreateRequiredParameterIsEmptyError("serverTaskApprovalID")
+	}
+	spaceID, err := internal.GetSpaceID(spaceID, client.GetSpaceID())
+	if err != nil {
+		return nil, err
+	}
+	path, err := client.URITemplateCache().Expand(approvalsTemplate, map[string]any{
+		"spaceId":              spaceID,
+		"serverTaskApprovalId": serverTaskApprovalID,
+		"id":                   approval.Id,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return newclient.Put[Approval](client.HttpSession(), path, approval)
+}

--- a/pkg/approvals/approvals_service_test.go
+++ b/pkg/approvals/approvals_service_test.go
@@ -1,0 +1,24 @@
+package approvals
+
+import (
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+	"github.com/stretchr/testify/require"
+)
+
+func createClient() newclient.Client {
+	return newclient.NewClient(&newclient.HttpSession{})
+}
+
+func TestAddApprovalParameterValidation(t *testing.T) {
+	client := createClient()
+	_, err := AddApproval(client, "Spaces-1", "ServerTaskApprovals-1", nil)
+	require.Error(t, err)
+}
+
+func TestUpdateApprovalParameterValidation(t *testing.T) {
+	client := createClient()
+	_, err := UpdateApproval(client, "Spaces-1", "ServerTaskApprovals-1", nil)
+	require.Error(t, err)
+}

--- a/pkg/approvals/server_task_approval.go
+++ b/pkg/approvals/server_task_approval.go
@@ -1,0 +1,51 @@
+package approvals
+
+// ChangeRequestApprovalState is the state of the change carried by a server-task approval.
+type ChangeRequestApprovalState string
+
+const (
+	ChangeRequestApprovalStatePreApproval  ChangeRequestApprovalState = "PreApproval"
+	ChangeRequestApprovalStateApproved     ChangeRequestApprovalState = "Approved"
+	ChangeRequestApprovalStatePostApproval ChangeRequestApprovalState = "PostApproval"
+)
+
+// ChangeRequest is the (optionally ITSM-backed) change associated with a server-task approval.
+type ChangeRequest struct {
+	Id                         string                     `json:"Id"`
+	Number                     string                     `json:"Number,omitempty"`
+	Description                string                     `json:"Description"`
+	Active                     bool                       `json:"Active"`
+	Type                       string                     `json:"Type,omitempty"`
+	ChangeRequestApprovalState ChangeRequestApprovalState `json:"ChangeRequestApprovalState"`
+	Self                       string                     `json:"Self,omitempty"`
+}
+
+// ServerTaskApproval is the approval requirement attached to a server task
+// (list / get-by-id representation).
+type ServerTaskApproval struct {
+	Id                 string        `json:"Id"`
+	ServerTaskId       string        `json:"ServerTaskId"`
+	SpaceId            string        `json:"SpaceId"`
+	ApprovalProviderId string        `json:"ApprovalProviderId"`
+	Name               string        `json:"Name"`
+	ChangeRequest      ChangeRequest `json:"ChangeRequest"`
+}
+
+// NamedReferenceItem is a lightweight id/display-name reference used for approving users/teams.
+type NamedReferenceItem struct {
+	Id               string `json:"Id"`
+	DisplayName      string `json:"DisplayName"`
+	DisplayIdAndName bool   `json:"DisplayIdAndName"`
+}
+
+// ServerTaskApprovalDetail is the richer representation returned by the by-task-id endpoint.
+type ServerTaskApprovalDetail struct {
+	Id                       string               `json:"Id"`
+	SpaceId                  string               `json:"SpaceId"`
+	Approvals                []Approval           `json:"Approvals"`
+	ApprovalState            string               `json:"ApprovalState"`
+	ApprovingUsers           []NamedReferenceItem `json:"ApprovingUsers,omitempty"`
+	ApprovingTeams           []NamedReferenceItem `json:"ApprovingTeams,omitempty"`
+	ApprovalsCount           int                  `json:"ApprovalsCount"`
+	MinimumApproversRequired int                  `json:"MinimumApproversRequired"`
+}


### PR DESCRIPTION
## What & why

Adds Go client support for the **Octopus Approvals** feature (server-side gated by `OctopusApprovalsFeatureToggle`), which was built in the server and TypeScript client but never ported here. Precursor for SI-260 / SI-222 (Terraform provider support) and a planned approvals CLI.

## Changes

**`pkg/approvalpolicies/`** — the reusable approval-policy configuration resource (Settings > Approvals):
- `ApprovalPolicy` resource with `Tag`/`Id` scoping (`ApprovalPolicyTagScope`, `ApprovalPolicyIdScope`), approving users/teams, `MinimumApproversRequired`, `AllowSelfApproval`, `IsDisabled`.
- CRUD: `GetByID`, `Get` (paginated), `GetAll`, `Add`, `Update`, `DeleteByID` — modern `newclient` functional style (no root-document link; routes built from a `{spaceId}` template).

**`pkg/approvals/`** — the runtime side (for reading approval status and submitting decisions, e.g. from a CLI):
- `ServerTaskApproval` + `ChangeRequest`, the richer by-task `ServerTaskApprovalDetail`, and `Approval` (individual `Approved`/`Rejected` + notes) with the `ApprovalStatus` and `ChangeRequestApprovalState` enums.
- `GetByTaskID` (nullable envelope → `(nil,nil)`), `GetByID`, `Get`, `GetAll`, `ListApprovals` (bare array), `GetApprovalByID`, `AddApproval`, `UpdateApproval`.

Faithful to the API contract: `AllowSelfApproval`/`IsDisabled` are exposed directly (no inversion), and no BFF endpoints are included.

## Testing

- Unit tests for parameter validation and JSON (de)serialization in both packages (`go test ./pkg/approvalpolicies/... ./pkg/approvals/...`).
- **Validated end-to-end against a live instance** with the feature toggle enabled, driven through the Terraform provider (SI-222): approval-policy create/read/update/delete all confirmed. The live run surfaced and fixed a bug where `GetAll` omitted the server-required `skip`/`take` query parameters (HTTP 400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)