### PR TITLE
Add GitUrl and Dockerfile fields to DeploymentActionContainer

### DIFF
--- a/pkg/deployments/deployment_action_container.go
+++ b/pkg/deployments/deployment_action_container.go
@@ -1,12 +1,14 @@
 package deployments
 
 type DeploymentActionContainer struct {
-	FeedID string `json:"FeedId,omitempty"`
-	Image  string `json:"Image,omitempty"`
+	FeedID     string `json:"FeedId,omitempty"`
+	Image      string `json:"Image,omitempty"`
+	GitUrl     string `json:"GitUrl,omitempty"`
+	Dockerfile string `json:"Dockerfile,omitempty"`
 }
 
 // NewDeploymentActionContainer creates and initializes a new Kubernetes endpoint.
-func NewDeploymentActionContainer(feedID *string, image *string) *DeploymentActionContainer {
+func NewDeploymentActionContainer(feedID *string, image *string, gitUrl *string, dockerfile *string) *DeploymentActionContainer {
 	deploymentActionContainer := &DeploymentActionContainer{}
 
 	if feedID != nil && len(*feedID) > 0 {
@@ -15,6 +17,14 @@ func NewDeploymentActionContainer(feedID *string, image *string) *DeploymentActi
 
 	if image != nil && len(*image) > 0 {
 		deploymentActionContainer.Image = *image
+	}
+
+	if gitUrl != nil && len(*gitUrl) > 0 {
+		deploymentActionContainer.GitUrl = *gitUrl
+	}
+
+	if dockerfile != nil && len(*dockerfile) > 0 {
+		deploymentActionContainer.Dockerfile = *dockerfile
 	}
 
 	return deploymentActionContainer

--- a/pkg/machines/kubernetes_endpoint_test.go
+++ b/pkg/machines/kubernetes_endpoint_test.go
@@ -69,7 +69,7 @@ func TestKubernetesEndpointMarshalJSON(t *testing.T) {
 	resource := NewKubernetesEndpoint(url)
 	resource.Authentication = kubernetesCertificateAuthentication
 	resource.ClusterCertificate = "cluster-certificate"
-	resource.Container = deployments.NewDeploymentActionContainer(&feedID, nil)
+	resource.Container = deployments.NewDeploymentActionContainer(&feedID, nil, nil, nil)
 	resource.ContainerOptions = "foobar"
 	resource.DefaultWorkerPoolID = "default-worker-pool-id"
 	resource.ID = id


### PR DESCRIPTION
This PR adds the new GitUrl and Dockerfile fields to the DeploymentActionContainer struct.