### PR TITLE
fix: make rate limiting request limit per minute rather than hour

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -35,6 +35,7 @@ jobs:
           DB_CONNECTION_STRING: 'Server=sqlserver;Database=OctopusDeploy;User Id=sa;Password=${{ env.SA_PASSWORD }};'
           ADMIN_API_KEY: ${{ env.ADMIN_API_KEY }}
           ENABLE_USAGE: N
+          DISABLE_RATE_LIMITING: Y
           OCTOPUS_SERVER_BASE64_LICENSE: ${{ secrets.OCTOPUS_SERVER_BASE64_LICENSE }}
           OCTOPUS__FeatureToggles__EphemeralEnvironmentsManualDeploymentsFeatureToggle: 'true'
           OCTOPUS__FeatureToggles__EphemeralEnvironmentsFeatureToggle: 'true'

--- a/pkg/ratelimitingpolicies/rate_limiting_policy.go
+++ b/pkg/ratelimitingpolicies/rate_limiting_policy.go
@@ -1,14 +1,14 @@
 package ratelimitingpolicies
 
 type RateLimitingPolicy struct {
-	ID              string                      `json:"Id"`
-	IsBuiltIn       bool                        `json:"IsBuiltIn"`
-	Name            string                      `json:"Name"`
-	IsEnabled       bool                        `json:"IsEnabled"`
-	ScopeType       RateLimitingPolicyScopeType `json:"ScopeType"`
-	RequestsPerHour int                         `json:"RequestsPerHour"`
-	BurstLimit      int                         `json:"BurstLimit"`
-	AuditMode       bool                        `json:"AuditMode"`
+	ID                string                      `json:"Id"`
+	IsBuiltIn         bool                        `json:"IsBuiltIn"`
+	Name              string                      `json:"Name"`
+	IsEnabled         bool                        `json:"IsEnabled"`
+	ScopeType         RateLimitingPolicyScopeType `json:"ScopeType"`
+	RequestsPerMinute int                         `json:"RequestsPerMinute"`
+	BurstLimit        int                         `json:"BurstLimit"`
+	AuditMode         bool                        `json:"AuditMode"`
 }
 
 type GetRateLimitingPolicyByIdRequest struct {
@@ -30,11 +30,11 @@ type ListRateLimitingPoliciesResponse struct {
 }
 
 type ModifyRateLimitingPolicyCommand struct {
-	ID              string                      `uri:"id" json:"-"`
-	Name            string                      `json:"Name"`
-	IsEnabled       bool                        `json:"IsEnabled"`
-	ScopeType       RateLimitingPolicyScopeType `json:"ScopeType"`
-	RequestsPerHour int                         `json:"RequestsPerHour"`
-	BurstLimit      int                         `json:"BurstLimit"`
-	AuditMode       bool                        `json:"AuditMode"`
+	ID                string                      `uri:"id" json:"-"`
+	Name              string                      `json:"Name"`
+	IsEnabled         bool                        `json:"IsEnabled"`
+	ScopeType         RateLimitingPolicyScopeType `json:"ScopeType"`
+	RequestsPerMinute int                         `json:"RequestsPerMinute"`
+	BurstLimit        int                         `json:"BurstLimit"`
+	AuditMode         bool                        `json:"AuditMode"`
 }

--- a/pkg/ratelimitingpolicies/rate_limiting_policy_test.go
+++ b/pkg/ratelimitingpolicies/rate_limiting_policy_test.go
@@ -31,14 +31,14 @@ func TestRateLimitingPolicyScopeTypeJsonUnmarshalInvalid(t *testing.T) {
 
 func TestRateLimitingPolicyMarshalRoundTrip(t *testing.T) {
 	policy := RateLimitingPolicy{
-		ID:              "RateLimitingPolicies-2",
-		IsBuiltIn:       true,
-		Name:            "Authenticated requests",
-		IsEnabled:       true,
-		ScopeType:       AuthenticatedHuman,
-		RequestsPerHour: 10_000,
-		BurstLimit:      5_000,
-		AuditMode:       true,
+		ID:                "RateLimitingPolicies-2",
+		IsBuiltIn:         true,
+		Name:              "Authenticated requests",
+		IsEnabled:         true,
+		ScopeType:         AuthenticatedHuman,
+		RequestsPerMinute: 10_000,
+		BurstLimit:        5_000,
+		AuditMode:         true,
 	}
 
 	data, err := json.Marshal(policy)
@@ -50,7 +50,7 @@ func TestRateLimitingPolicyMarshalRoundTrip(t *testing.T) {
 		"Name": "Authenticated requests",
 		"IsEnabled": true,
 		"ScopeType": "AuthenticatedHuman",
-		"RequestsPerHour": 10000,
+		"RequestsPerMinute": 10000,
 		"BurstLimit": 5000,
 		"AuditMode": true
 	}`
@@ -63,13 +63,13 @@ func TestRateLimitingPolicyMarshalRoundTrip(t *testing.T) {
 
 func TestModifyRateLimitingPolicyCommandMarshal(t *testing.T) {
 	command := ModifyRateLimitingPolicyCommand{
-		ID:              "RateLimitingPolicies-1",
-		Name:            "Changed",
-		IsEnabled:       true,
-		ScopeType:       Unauthenticated,
-		RequestsPerHour: 123,
-		BurstLimit:      456,
-		AuditMode:       true,
+		ID:                "RateLimitingPolicies-1",
+		Name:              "Changed",
+		IsEnabled:         true,
+		ScopeType:         Unauthenticated,
+		RequestsPerMinute: 123,
+		BurstLimit:        456,
+		AuditMode:         true,
 	}
 
 	data, err := json.Marshal(command)
@@ -78,7 +78,7 @@ func TestModifyRateLimitingPolicyCommandMarshal(t *testing.T) {
 		"Name": "Changed",
 		"IsEnabled": true,
 		"ScopeType": "Unauthenticated",
-		"RequestsPerHour": 123,
+		"RequestsPerMinute": 123,
 		"BurstLimit": 456,
 		"AuditMode": true
 	}`, string(data))
@@ -98,7 +98,7 @@ func TestListRateLimitingPoliciesResponseUnmarshal(t *testing.T) {
 				"IsBuiltIn": true,
 				"ScopeType": "AuthenticatedHuman",
 				"IsEnabled": true,
-				"RequestsPerHour": 1000,
+				"RequestsPerMinute": 1000,
 				"BurstLimit": 50,
 				"AuditMode": true
 			},
@@ -108,7 +108,7 @@ func TestListRateLimitingPoliciesResponseUnmarshal(t *testing.T) {
 				"IsBuiltIn": true,
 				"ScopeType": "AuthenticatedAgent",
 				"IsEnabled": false,
-				"RequestsPerHour": 500,
+				"RequestsPerMinute": 500,
 				"BurstLimit": 25,
 				"AuditMode": false
 			}

--- a/test/e2e/rate_limiting_policy_service_test.go
+++ b/test/e2e/rate_limiting_policy_service_test.go
@@ -104,7 +104,7 @@ func TestModifyRateLimitingPolicy(t *testing.T) {
 	assert.Len(t, listResponse.Items, 1)
 	policy := listResponse.Items[0]
 
-	testModify := func(isEnabled bool, requestsPerHour int, burstLimit int, auditMode bool) {
+	testModify := func(isEnabled bool, requestsPerMinute int, burstLimit int, auditMode bool) {
 		modifyResponse, modifyError := ratelimitingpolicies.Modify(
 			client,
 			ratelimitingpolicies.ModifyRateLimitingPolicyCommand{
@@ -112,10 +112,10 @@ func TestModifyRateLimitingPolicy(t *testing.T) {
 				Name:      policy.Name,
 				ScopeType: policy.ScopeType,
 
-				IsEnabled:       isEnabled,
-				RequestsPerHour: requestsPerHour,
-				BurstLimit:      burstLimit,
-				AuditMode:       auditMode,
+				IsEnabled:         isEnabled,
+				RequestsPerMinute: requestsPerMinute,
+				BurstLimit:        burstLimit,
+				AuditMode:         auditMode,
 			})
 		assert.NoError(t, modifyError)
 		assert.NotNil(t, modifyResponse)
@@ -123,7 +123,7 @@ func TestModifyRateLimitingPolicy(t *testing.T) {
 		assert.Equal(t, policy.Name, modifyResponse.Name)
 		assert.Equal(t, policy.ScopeType, modifyResponse.ScopeType)
 		assert.Equal(t, isEnabled, modifyResponse.IsEnabled)
-		assert.Equal(t, requestsPerHour, modifyResponse.RequestsPerHour)
+		assert.Equal(t, requestsPerMinute, modifyResponse.RequestsPerMinute)
 		assert.Equal(t, burstLimit, modifyResponse.BurstLimit)
 		assert.Equal(t, auditMode, modifyResponse.AuditMode)
 
@@ -140,14 +140,14 @@ func TestModifyRateLimitingPolicy(t *testing.T) {
 		assert.Equal(t, policy.Name, getResponse.Name)
 		assert.Equal(t, policy.ScopeType, getResponse.ScopeType)
 		assert.Equal(t, isEnabled, getResponse.IsEnabled)
-		assert.Equal(t, requestsPerHour, getResponse.RequestsPerHour)
+		assert.Equal(t, requestsPerMinute, getResponse.RequestsPerMinute)
 		assert.Equal(t, burstLimit, getResponse.BurstLimit)
 		assert.Equal(t, auditMode, getResponse.AuditMode)
 	}
 
 	// Modify twice in case the properties were already set to what we modified them to
-	testModify(false, 12, 34, true)
-	testModify(true, 56, 78, false)
+	testModify(true, 12, 34, true)
+	testModify(false, 56, 78, false)
 }
 
 func TestModifyRateLimitingPolicyError(t *testing.T) {
@@ -174,10 +174,10 @@ func TestModifyRateLimitingPolicyError(t *testing.T) {
 			Name:      "New name", // Not allowed to change built-in policy names
 			ScopeType: policy.ScopeType,
 
-			IsEnabled:       policy.IsEnabled,
-			RequestsPerHour: policy.RequestsPerHour,
-			BurstLimit:      policy.BurstLimit,
-			AuditMode:       policy.AuditMode,
+			IsEnabled:         policy.IsEnabled,
+			RequestsPerMinute: policy.RequestsPerMinute,
+			BurstLimit:        policy.BurstLimit,
+			AuditMode:         policy.AuditMode,
 		})
 	assert.Nil(t, modifyResponse)
 	assert.Error(t, modifyError)


### PR DESCRIPTION
On the server side, we've changed requests per hour to requests per minute, so this PR makes the corresponding changes to the API client. This feature hasn't been released to production yet (it's behind a feature toggle that is currently off) so this isn't a breaking change.