### PR TITLE
fix: parse day and fractional-second components in FromTimeSpan (changes parsed values)

### DIFF
--- a/pkg/machinepolicies/duration_formatter.go
+++ b/pkg/machinepolicies/duration_formatter.go
@@ -3,6 +3,7 @@ package machinepolicies
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -30,20 +31,67 @@ func ToTimeSpan(duration time.Duration) string {
 	return fmt.Sprintf("%02d.%02d:%02d:%02d.%05d", days, hours, minutes, seconds, secondsFraction)
 }
 
+// FromTimeSpan parses a .NET time span, "[d.]hh:mm:ss[.fffffff]", into a duration. The day and
+// fractional-second components are optional, and the server does not pad the day component to a
+// fixed width, so the fields cannot be read at fixed offsets. Input that does not parse yields a
+// zero duration.
 func FromTimeSpan(timeSpan string) time.Duration {
-	if len(timeSpan) == 8 {
-		hours, _ := strconv.ParseInt(timeSpan[0:2], 10, 64)
-		minutes, _ := strconv.ParseInt(timeSpan[3:5], 10, 64)
-		seconds, _ := strconv.ParseInt(timeSpan[6:8], 10, 64)
-		duration, _ := time.ParseDuration(fmt.Sprintf("%dh%dm%ds", hours, minutes, seconds))
-		return duration
+	var days int64
+	remainder := timeSpan
+
+	// Both the day separator and the fractional-second separator are ".", so a leading segment is
+	// only the day component when the rest still holds a complete "hh:mm:ss".
+	if index := strings.Index(remainder, "."); index >= 0 && strings.Count(remainder[index+1:], ":") == 2 {
+		parsedDays, err := strconv.ParseInt(remainder[:index], 10, 64)
+		if err != nil {
+			return 0
+		}
+		days = parsedDays
+		remainder = remainder[index+1:]
 	}
 
-	days, _ := strconv.ParseInt(timeSpan[0:0], 10, 32)
-	hours, _ := strconv.ParseInt(timeSpan[2:4], 10, 64)
-	hours += (days * 24)
-	minutes, _ := strconv.ParseInt(timeSpan[5:7], 10, 64)
-	seconds, _ := strconv.ParseInt(timeSpan[8:10], 10, 64)
-	duration, _ := time.ParseDuration(fmt.Sprintf("%dh%dm%ds", hours, minutes, seconds))
-	return duration
+	var fraction time.Duration
+	if index := strings.Index(remainder, "."); index >= 0 {
+		digits := remainder[index+1:]
+		parsedFraction, err := strconv.ParseInt(digits, 10, 64)
+		if err != nil {
+			return 0
+		}
+		// The digits are a decimal fraction of a second, however many of them there are.
+		scale := pow10(len(digits))
+		fraction = time.Duration(parsedFraction * int64(time.Second) / scale)
+		remainder = remainder[:index]
+	}
+
+	fields := strings.Split(remainder, ":")
+	if len(fields) != 3 {
+		return 0
+	}
+
+	hours, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return 0
+	}
+	minutes, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return 0
+	}
+	seconds, err := strconv.ParseInt(fields[2], 10, 64)
+	if err != nil {
+		return 0
+	}
+
+	return time.Duration(days)*24*time.Hour +
+		time.Duration(hours)*time.Hour +
+		time.Duration(minutes)*time.Minute +
+		time.Duration(seconds)*time.Second +
+		fraction
+}
+
+func pow10(exponent int) int64 {
+	result := int64(1)
+	for i := 0; i < exponent; i++ {
+		result *= 10
+	}
+	return result
 }

--- a/pkg/machinepolicies/duration_formatter_test.go
+++ b/pkg/machinepolicies/duration_formatter_test.go
@@ -1,4 +1,4 @@
-package machines
+package machinepolicies
 
 import (
 	"testing"

--- a/pkg/machines/duration_formatter.go
+++ b/pkg/machines/duration_formatter.go
@@ -3,6 +3,7 @@ package machines
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -30,20 +31,67 @@ func ToTimeSpan(duration time.Duration) string {
 	return fmt.Sprintf("%02d.%02d:%02d:%02d.%05d", days, hours, minutes, seconds, secondsFraction)
 }
 
+// FromTimeSpan parses a .NET time span, "[d.]hh:mm:ss[.fffffff]", into a duration. The day and
+// fractional-second components are optional, and the server does not pad the day component to a
+// fixed width, so the fields cannot be read at fixed offsets. Input that does not parse yields a
+// zero duration.
 func FromTimeSpan(timeSpan string) time.Duration {
-	if len(timeSpan) == 8 {
-		hours, _ := strconv.ParseInt(timeSpan[0:2], 10, 64)
-		minutes, _ := strconv.ParseInt(timeSpan[3:5], 10, 64)
-		seconds, _ := strconv.ParseInt(timeSpan[6:8], 10, 64)
-		duration, _ := time.ParseDuration(fmt.Sprintf("%dh%dm%ds", hours, minutes, seconds))
-		return duration
+	var days int64
+	remainder := timeSpan
+
+	// Both the day separator and the fractional-second separator are ".", so a leading segment is
+	// only the day component when the rest still holds a complete "hh:mm:ss".
+	if index := strings.Index(remainder, "."); index >= 0 && strings.Count(remainder[index+1:], ":") == 2 {
+		parsedDays, err := strconv.ParseInt(remainder[:index], 10, 64)
+		if err != nil {
+			return 0
+		}
+		days = parsedDays
+		remainder = remainder[index+1:]
 	}
 
-	days, _ := strconv.ParseInt(timeSpan[0:0], 10, 32)
-	hours, _ := strconv.ParseInt(timeSpan[2:4], 10, 64)
-	hours += (days * 24)
-	minutes, _ := strconv.ParseInt(timeSpan[5:7], 10, 64)
-	seconds, _ := strconv.ParseInt(timeSpan[8:10], 10, 64)
-	duration, _ := time.ParseDuration(fmt.Sprintf("%dh%dm%ds", hours, minutes, seconds))
-	return duration
+	var fraction time.Duration
+	if index := strings.Index(remainder, "."); index >= 0 {
+		digits := remainder[index+1:]
+		parsedFraction, err := strconv.ParseInt(digits, 10, 64)
+		if err != nil {
+			return 0
+		}
+		// The digits are a decimal fraction of a second, however many of them there are.
+		scale := pow10(len(digits))
+		fraction = time.Duration(parsedFraction * int64(time.Second) / scale)
+		remainder = remainder[:index]
+	}
+
+	fields := strings.Split(remainder, ":")
+	if len(fields) != 3 {
+		return 0
+	}
+
+	hours, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return 0
+	}
+	minutes, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return 0
+	}
+	seconds, err := strconv.ParseInt(fields[2], 10, 64)
+	if err != nil {
+		return 0
+	}
+
+	return time.Duration(days)*24*time.Hour +
+		time.Duration(hours)*time.Hour +
+		time.Duration(minutes)*time.Minute +
+		time.Duration(seconds)*time.Second +
+		fraction
+}
+
+func pow10(exponent int) int64 {
+	result := int64(1)
+	for i := 0; i < exponent; i++ {
+		result *= 10
+	}
+	return result
 }


### PR DESCRIPTION
Fixes #434.

`FromTimeSpan` read the time span fields at fixed offsets and took the day component from `timeSpan[0:0]`, which is always the empty string. Every value carrying a day component parsed to zero, fractional seconds were dropped, and an empty string panicked on a slice bound. Only the plain `hh:mm:ss` form worked.

The fixed offsets also assumed a single-digit day, and the server does not pad the day component, so `"7.12:30:00"` and `"07.12:30:00"` could not both be read correctly even with the days segment fixed.

## What it returned before

```
FromTimeSpan("00:00:00")       = 0s          correct
FromTimeSpan("01:00:00")       = 1h0m0s      correct
FromTimeSpan("1.00:00:00")     = 0s          want 24h
FromTimeSpan("02.00:00:00")    = 0s          want 48h
FromTimeSpan("7.12:30:00")     = 12h30m0s    want 180h30m
FromTimeSpan("37500.00:00:00") = 50h0m0s     want 900000h
FromTimeSpan("00:00:00.50000") = 0s          want 500ms
FromTimeSpan("")               = panic: slice bounds out of range [:4] with length 0
```

`"1.00:00:00"` is the health check interval on the default machine policy, so this sits on a common path.

## The change

Split on the separators rather than slicing at fixed offsets. Both uses of `.` are ambiguous (`d.hh:mm:ss` against `hh:mm:ss.fffffff`), so a leading segment is only treated as the day component when what follows still holds a complete `hh:mm:ss`. The fractional part is read as a decimal fraction of a second, which handles both the five-digit form this package writes and the seven-digit form .NET produces. Malformed input returns a zero duration instead of panicking.

Applied to `pkg/machinepolicies/` and `pkg/machines/`, which each carry their own copy of the function. Patching only one would leave consumers of the two packages parsing the same payload differently.

## Tests

`pkg/machines/duration_formatter_test.go` called `FromTimeSpan` seven times and logged each result without asserting anything. All seven returned `0s` and the test passed, which is why this went unnoticed. It now asserts, along with a round trip check over `ToTimeSpan`, and the same file is added to `pkg/machinepolicies/`.

Verified against a 2026.x server: a policy with a seven day interval now reads back as `168h0m0s` instead of `0s`.

`ToTimeSpan` is unchanged. The server accepts its zero-padded day output and normalises it on read.

## Impact

Any `time.Duration` read back through `FromTimeSpan` was affected. In `MachinePolicy` that covers `ConnectionConnectTimeout`, `ConnectionRetrySleepInterval`, `ConnectionRetryTimeLimit`, `PollingRequestQueueTimeout` and `PollingRequestMaximumMessageProcessingTimeout`, plus `MachineHealthCheckPolicy.HealthCheckInterval` and `MachineCleanupPolicy.DeleteMachinesElapsedTimeSpan`.

Callers who were compensating for the zero values will see real durations after this. I could not find any such workaround in this repository.

## Upgrade note (please carry into the release notes)

This changes values consumers already read. Any day-scale duration on the fields above that previously came back as `0s` will start coming back as its true value. In particular, tools that diff read state against stored state (such as the Terraform provider) may show a one-off diff on machine policy timeouts after upgrading. That diff is the correction, not drift, but it will generate questions if the release does not call it out.

For whoever tags the release: goreleaser builds notes from commit subjects only, so this needs a manual note on the GitHub Release. A ready-to-paste version is in https://github.com/OctopusDeploy/go-octopusdeploy/pull/435#issuecomment-5289920337. The PR title already carries the `(changes parsed values)` marker so the default squash subject signals it.

Out of scope, tracked separately: negative time spans are mishandled in both `FromTimeSpan` and `ToTimeSpan` on both sides of this change. See #447 for details.

