### PR TITLE
feat: allow a machine health check schedule of Never

### DIFF
--- a/pkg/machinepolicies/duration_formatter.go
+++ b/pkg/machinepolicies/duration_formatter.go
@@ -3,6 +3,7 @@ package machinepolicies
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -30,20 +31,67 @@ func ToTimeSpan(duration time.Duration) string {
 	return fmt.Sprintf("%02d.%02d:%02d:%02d.%05d", days, hours, minutes, seconds, secondsFraction)
 }
 
+// FromTimeSpan parses a .NET time span, "[d.]hh:mm:ss[.fffffff]", into a duration. The day and
+// fractional-second components are optional, and the server does not pad the day component to a
+// fixed width, so the fields cannot be read at fixed offsets. Input that does not parse yields a
+// zero duration.
 func FromTimeSpan(timeSpan string) time.Duration {
-	if len(timeSpan) == 8 {
-		hours, _ := strconv.ParseInt(timeSpan[0:2], 10, 64)
-		minutes, _ := strconv.ParseInt(timeSpan[3:5], 10, 64)
-		seconds, _ := strconv.ParseInt(timeSpan[6:8], 10, 64)
-		duration, _ := time.ParseDuration(fmt.Sprintf("%dh%dm%ds", hours, minutes, seconds))
-		return duration
+	var days int64
+	remainder := timeSpan
+
+	// Both the day separator and the fractional-second separator are ".", so a leading segment is
+	// only the day component when the rest still holds a complete "hh:mm:ss".
+	if index := strings.Index(remainder, "."); index >= 0 && strings.Count(remainder[index+1:], ":") == 2 {
+		parsedDays, err := strconv.ParseInt(remainder[:index], 10, 64)
+		if err != nil {
+			return 0
+		}
+		days = parsedDays
+		remainder = remainder[index+1:]
 	}
 
-	days, _ := strconv.ParseInt(timeSpan[0:0], 10, 32)
-	hours, _ := strconv.ParseInt(timeSpan[2:4], 10, 64)
-	hours += (days * 24)
-	minutes, _ := strconv.ParseInt(timeSpan[5:7], 10, 64)
-	seconds, _ := strconv.ParseInt(timeSpan[8:10], 10, 64)
-	duration, _ := time.ParseDuration(fmt.Sprintf("%dh%dm%ds", hours, minutes, seconds))
-	return duration
+	var fraction time.Duration
+	if index := strings.Index(remainder, "."); index >= 0 {
+		digits := remainder[index+1:]
+		parsedFraction, err := strconv.ParseInt(digits, 10, 64)
+		if err != nil {
+			return 0
+		}
+		// The digits are a decimal fraction of a second, however many of them there are.
+		scale := pow10(len(digits))
+		fraction = time.Duration(parsedFraction * int64(time.Second) / scale)
+		remainder = remainder[:index]
+	}
+
+	fields := strings.Split(remainder, ":")
+	if len(fields) != 3 {
+		return 0
+	}
+
+	hours, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return 0
+	}
+	minutes, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return 0
+	}
+	seconds, err := strconv.ParseInt(fields[2], 10, 64)
+	if err != nil {
+		return 0
+	}
+
+	return time.Duration(days)*24*time.Hour +
+		time.Duration(hours)*time.Hour +
+		time.Duration(minutes)*time.Minute +
+		time.Duration(seconds)*time.Second +
+		fraction
+}
+
+func pow10(exponent int) int64 {
+	result := int64(1)
+	for i := 0; i < exponent; i++ {
+		result *= 10
+	}
+	return result
 }

--- a/pkg/machinepolicies/duration_formatter_test.go
+++ b/pkg/machinepolicies/duration_formatter_test.go
@@ -1,4 +1,4 @@
-package machines
+package machinepolicies
 
 import (
 	"testing"

--- a/pkg/machinepolicies/machine_health_check_policy.go
+++ b/pkg/machinepolicies/machine_health_check_policy.go
@@ -28,6 +28,14 @@ func NewMachineHealthCheckPolicy() *MachineHealthCheckPolicy {
 
 // MarshalJSON returns a machine health check policy as its JSON encoding.
 func (m *MachineHealthCheckPolicy) MarshalJSON() ([]byte, error) {
+	// A health check schedule of "Never" is the absence of both an interval and a cron
+	// expression, so a zero interval has to be left out of the payload entirely. Writing
+	// "00:00:00" is read back as an interval of zero rather than as "Never".
+	healthCheckInterval := ""
+	if m.HealthCheckInterval != 0 {
+		healthCheckInterval = ToTimeSpan(m.HealthCheckInterval)
+	}
+
 	machineHealthCheckPolicy := struct {
 		BashHealthCheckPolicy       *MachineScriptPolicy `json:"BashHealthCheckPolicy,omitempty"`
 		HealthCheckCron             string               `json:"HealthCheckCron,omitempty"`
@@ -39,7 +47,7 @@ func (m *MachineHealthCheckPolicy) MarshalJSON() ([]byte, error) {
 		BashHealthCheckPolicy:       m.BashHealthCheckPolicy,
 		HealthCheckCron:             m.HealthCheckCron,
 		HealthCheckCronTimezone:     m.HealthCheckCronTimezone,
-		HealthCheckInterval:         ToTimeSpan(m.HealthCheckInterval),
+		HealthCheckInterval:         healthCheckInterval,
 		HealthCheckType:             m.HealthCheckType,
 		PowerShellHealthCheckPolicy: m.PowerShellHealthCheckPolicy,
 	}

--- a/pkg/machinepolicies/machine_health_check_policy_test.go
+++ b/pkg/machinepolicies/machine_health_check_policy_test.go
@@ -1,0 +1,67 @@
+package machinepolicies
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMachineHealthCheckPolicyMarshalJSON(t *testing.T) {
+	testCases := []struct {
+		name     string
+		interval time.Duration
+		expected string
+	}{
+		{"interval is written as a time span", 24 * time.Hour, `"HealthCheckInterval":"01.00:00:00"`},
+		{"sub-day interval is written as a time span", time.Hour, `"HealthCheckInterval":"01:00:00"`},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			policy := NewMachineHealthCheckPolicy()
+			policy.HealthCheckInterval = testCase.interval
+
+			data, err := json.Marshal(policy)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(string(data), testCase.expected) {
+				t.Errorf("marshalled policy %s does not contain %s", data, testCase.expected)
+			}
+		})
+	}
+}
+
+// A zero interval means the health check schedule is "Never", which the server represents by the
+// absence of both HealthCheckInterval and HealthCheckCron. Writing "00:00:00" instead is read back
+// as an interval of zero minutes, not as Never.
+func TestMachineHealthCheckPolicyMarshalJSONOmitsZeroInterval(t *testing.T) {
+	policy := NewMachineHealthCheckPolicy()
+	policy.HealthCheckInterval = 0
+
+	data, err := json.Marshal(policy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(string(data), "HealthCheckInterval") {
+		t.Errorf("marshalled policy %s should not contain HealthCheckInterval", data)
+	}
+}
+
+func TestMachineHealthCheckPolicyUnmarshalJSONWithoutInterval(t *testing.T) {
+	data := `{
+		"PowerShellHealthCheckPolicy": {"RunType": "Inline", "ScriptBody": ""},
+		"BashHealthCheckPolicy": {"RunType": "Inline", "ScriptBody": ""},
+		"HealthCheckCronTimezone": "UTC",
+		"HealthCheckType": "RunScript"
+	}`
+
+	policy := &MachineHealthCheckPolicy{}
+	if err := json.Unmarshal([]byte(data), policy); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if policy.HealthCheckInterval != 0 {
+		t.Errorf("HealthCheckInterval = %s, want 0", policy.HealthCheckInterval)
+	}
+}

--- a/pkg/machines/duration_formatter.go
+++ b/pkg/machines/duration_formatter.go
@@ -3,6 +3,7 @@ package machines
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -30,20 +31,67 @@ func ToTimeSpan(duration time.Duration) string {
 	return fmt.Sprintf("%02d.%02d:%02d:%02d.%05d", days, hours, minutes, seconds, secondsFraction)
 }
 
+// FromTimeSpan parses a .NET time span, "[d.]hh:mm:ss[.fffffff]", into a duration. The day and
+// fractional-second components are optional, and the server does not pad the day component to a
+// fixed width, so the fields cannot be read at fixed offsets. Input that does not parse yields a
+// zero duration.
 func FromTimeSpan(timeSpan string) time.Duration {
-	if len(timeSpan) == 8 {
-		hours, _ := strconv.ParseInt(timeSpan[0:2], 10, 64)
-		minutes, _ := strconv.ParseInt(timeSpan[3:5], 10, 64)
-		seconds, _ := strconv.ParseInt(timeSpan[6:8], 10, 64)
-		duration, _ := time.ParseDuration(fmt.Sprintf("%dh%dm%ds", hours, minutes, seconds))
-		return duration
+	var days int64
+	remainder := timeSpan
+
+	// Both the day separator and the fractional-second separator are ".", so a leading segment is
+	// only the day component when the rest still holds a complete "hh:mm:ss".
+	if index := strings.Index(remainder, "."); index >= 0 && strings.Count(remainder[index+1:], ":") == 2 {
+		parsedDays, err := strconv.ParseInt(remainder[:index], 10, 64)
+		if err != nil {
+			return 0
+		}
+		days = parsedDays
+		remainder = remainder[index+1:]
 	}
 
-	days, _ := strconv.ParseInt(timeSpan[0:0], 10, 32)
-	hours, _ := strconv.ParseInt(timeSpan[2:4], 10, 64)
-	hours += (days * 24)
-	minutes, _ := strconv.ParseInt(timeSpan[5:7], 10, 64)
-	seconds, _ := strconv.ParseInt(timeSpan[8:10], 10, 64)
-	duration, _ := time.ParseDuration(fmt.Sprintf("%dh%dm%ds", hours, minutes, seconds))
-	return duration
+	var fraction time.Duration
+	if index := strings.Index(remainder, "."); index >= 0 {
+		digits := remainder[index+1:]
+		parsedFraction, err := strconv.ParseInt(digits, 10, 64)
+		if err != nil {
+			return 0
+		}
+		// The digits are a decimal fraction of a second, however many of them there are.
+		scale := pow10(len(digits))
+		fraction = time.Duration(parsedFraction * int64(time.Second) / scale)
+		remainder = remainder[:index]
+	}
+
+	fields := strings.Split(remainder, ":")
+	if len(fields) != 3 {
+		return 0
+	}
+
+	hours, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return 0
+	}
+	minutes, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return 0
+	}
+	seconds, err := strconv.ParseInt(fields[2], 10, 64)
+	if err != nil {
+		return 0
+	}
+
+	return time.Duration(days)*24*time.Hour +
+		time.Duration(hours)*time.Hour +
+		time.Duration(minutes)*time.Minute +
+		time.Duration(seconds)*time.Second +
+		fraction
+}
+
+func pow10(exponent int) int64 {
+	result := int64(1)
+	for i := 0; i < exponent; i++ {
+		result *= 10
+	}
+	return result
 }

--- a/pkg/machines/machine_health_check_policy.go
+++ b/pkg/machines/machine_health_check_policy.go
@@ -28,6 +28,14 @@ func NewMachineHealthCheckPolicy() *MachineHealthCheckPolicy {
 
 // MarshalJSON returns a machine health check policy as its JSON encoding.
 func (m *MachineHealthCheckPolicy) MarshalJSON() ([]byte, error) {
+	// A health check schedule of "Never" is the absence of both an interval and a cron
+	// expression, so a zero interval has to be left out of the payload entirely. Writing
+	// "00:00:00" is read back as an interval of zero rather than as "Never".
+	healthCheckInterval := ""
+	if m.HealthCheckInterval != 0 {
+		healthCheckInterval = ToTimeSpan(m.HealthCheckInterval)
+	}
+
 	machineHealthCheckPolicy := struct {
 		BashHealthCheckPolicy       *MachineScriptPolicy `json:"BashHealthCheckPolicy,omitempty"`
 		HealthCheckCron             string               `json:"HealthCheckCron,omitempty"`
@@ -39,7 +47,7 @@ func (m *MachineHealthCheckPolicy) MarshalJSON() ([]byte, error) {
 		BashHealthCheckPolicy:       m.BashHealthCheckPolicy,
 		HealthCheckCron:             m.HealthCheckCron,
 		HealthCheckCronTimezone:     m.HealthCheckCronTimezone,
-		HealthCheckInterval:         ToTimeSpan(m.HealthCheckInterval),
+		HealthCheckInterval:         healthCheckInterval,
 		HealthCheckType:             m.HealthCheckType,
 		PowerShellHealthCheckPolicy: m.PowerShellHealthCheckPolicy,
 	}

--- a/pkg/machines/machine_health_check_policy_test.go
+++ b/pkg/machines/machine_health_check_policy_test.go
@@ -1,0 +1,67 @@
+package machines
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMachineHealthCheckPolicyMarshalJSON(t *testing.T) {
+	testCases := []struct {
+		name     string
+		interval time.Duration
+		expected string
+	}{
+		{"interval is written as a time span", 24 * time.Hour, `"HealthCheckInterval":"01.00:00:00"`},
+		{"sub-day interval is written as a time span", time.Hour, `"HealthCheckInterval":"01:00:00"`},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			policy := NewMachineHealthCheckPolicy()
+			policy.HealthCheckInterval = testCase.interval
+
+			data, err := json.Marshal(policy)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(string(data), testCase.expected) {
+				t.Errorf("marshalled policy %s does not contain %s", data, testCase.expected)
+			}
+		})
+	}
+}
+
+// A zero interval means the health check schedule is "Never", which the server represents by the
+// absence of both HealthCheckInterval and HealthCheckCron. Writing "00:00:00" instead is read back
+// as an interval of zero minutes, not as Never.
+func TestMachineHealthCheckPolicyMarshalJSONOmitsZeroInterval(t *testing.T) {
+	policy := NewMachineHealthCheckPolicy()
+	policy.HealthCheckInterval = 0
+
+	data, err := json.Marshal(policy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(string(data), "HealthCheckInterval") {
+		t.Errorf("marshalled policy %s should not contain HealthCheckInterval", data)
+	}
+}
+
+func TestMachineHealthCheckPolicyUnmarshalJSONWithoutInterval(t *testing.T) {
+	data := `{
+		"PowerShellHealthCheckPolicy": {"RunType": "Inline", "ScriptBody": ""},
+		"BashHealthCheckPolicy": {"RunType": "Inline", "ScriptBody": ""},
+		"HealthCheckCronTimezone": "UTC",
+		"HealthCheckType": "RunScript"
+	}`
+
+	policy := &MachineHealthCheckPolicy{}
+	if err := json.Unmarshal([]byte(data), policy); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if policy.HealthCheckInterval != 0 {
+		t.Errorf("HealthCheckInterval = %s, want 0", policy.HealthCheckInterval)
+	}
+}


### PR DESCRIPTION
Unblocks OctopusDeploy/terraform-provider-octopusdeploy#225.

**Stacked on #435, which needs to merge first.** GitHub will not let me base a pull request from a fork on another fork branch, so the diff here shows both commits. Only the second one, `feat: allow a machine health check schedule of Never`, is new.

## The problem

A health check schedule of "Never" is the absence of both `HealthCheckInterval` and `HealthCheckCron`. There is no schedule type on the wire; the portal derives it:

```js
scheduleType = MachineHealthCheckPolicy.HealthCheckInterval ? Interval
             : MachineHealthCheckPolicy.HealthCheckCron     ? Cron
             : None
```

`MarshalJSON` always populated the interval through `ToTimeSpan`, and `ToTimeSpan(0)` returns `"00:00:00"`. That is not an empty string, so the `omitempty` tag on the wire struct never fired. No value of `HealthCheckInterval` could produce a payload without the field, which left "Never" unreachable through this SDK, and `"00:00:00"` reads back as an interval of zero rather than as Never.

## The change

Write the interval only when it is non-zero. `UnmarshalJSON` already guards with `if len(fields.HealthCheckInterval) > 0`, so a null from the server leaves the field at zero and the round trip is symmetric.

`HealthCheckInterval` stays a `time.Duration`. Making it a pointer would express the same thing but break every caller that assigns to it.

Applied to `pkg/machinepolicies/` and `pkg/machines/`, which each carry their own copy.

## Why it depends on the other commit

Before the `FromTimeSpan` fix, a policy whose interval carries a day component reads back as zero. Landing this change on its own would mean those policies get written back with the interval omitted, which switches them to Never. `"1.00:00:00"` is the default machine policy's interval, so that would be most of them.

## Tests

Unit tests covering the omission at zero, the interval still being written when non-zero, and an absent interval deserialising to zero.

Verified against a 2026.x server through `machinepolicies.Add` and `machinepolicies.Update`: creating a policy with a zero interval stores `HealthCheckInterval: null`, re-reading gives `0s`, and updating a seven day policy to zero also lands as null. Reading the raw payload back confirms the field is absent rather than `"00:00:00"`, so the portal shows the schedule as Never.
