### PR TITLE
fix: Add Block as a KubernetesAgentUpdateBehaviour

### DIFF
--- a/pkg/machines/machine_update_policy.go
+++ b/pkg/machines/machine_update_policy.go
@@ -4,7 +4,7 @@ type MachineUpdatePolicy struct {
 	CalamariUpdateBehavior        string `json:"CalamariUpdateBehavior" validate:"required,oneof=UpdateAlways UpdateOnDeployment UpdateOnNewMachine"`
 	TentacleUpdateAccountID       string `json:"TentacleUpdateAccountId,omitempty"`
 	TentacleUpdateBehavior        string `json:"TentacleUpdateBehavior" validate:"required,oneof=NeverUpdate Update"`
-	KubernetesAgentUpdateBehavior string `json:"KubernetesAgentUpdateBehavior" validate:"required,oneof=NeverUpdate Update"`
+	KubernetesAgentUpdateBehavior string `json:"KubernetesAgentUpdateBehavior" validate:"required,oneof=NeverUpdate Update Block"`
 }
 
 func NewMachineUpdatePolicy() *MachineUpdatePolicy {


### PR DESCRIPTION
This was added in late 2025 and not added here. Will be needed for the terraform client bug

https://github.com/OctopusDeploy/terraform-provider-octopusdeploy/issues/260