### PR TITLE
fix: add actiontemplates.GetByQuery so collection filters reach the server

### DIFF
--- a/pkg/actiontemplates/action_template_search.go
+++ b/pkg/actiontemplates/action_template_search.go
@@ -1,6 +1,6 @@
 package actiontemplates
 
-// ActionTemplateSearch is a result returned by ActionTemplateService.Search, not a query type.
+// ActionTemplateSearch is a result returned by ActionTemplateService.Search.
 type ActionTemplateSearch struct {
 	Author                    string            `json:"Author,omitempty"`
 	Categories                []string          `json:"Categories"`

--- a/pkg/actiontemplates/action_template_search.go
+++ b/pkg/actiontemplates/action_template_search.go
@@ -1,6 +1,6 @@
 package actiontemplates
 
-// ActionTemplateSearch represents an action template search.
+// ActionTemplateSearch is a result returned by ActionTemplateService.Search, not a query type.
 type ActionTemplateSearch struct {
 	Author                    string            `json:"Author,omitempty"`
 	Categories                []string          `json:"Categories"`

--- a/pkg/actiontemplates/action_template_service.go
+++ b/pkg/actiontemplates/action_template_service.go
@@ -225,6 +225,14 @@ func GetVersionByID(client newclient.Client, spaceID string, actionTemplateID st
 
 // Get returns a collection of action templates based on the criteria defined by its
 // input query parameter.
+//
+// Deprecated: use actiontemplates.GetByQuery; ActionTemplateSearch has no uri tags, so its fields never reach the server.
 func Get(client newclient.Client, spaceID string, actionsQuery ActionTemplateSearch) (*resources.Resources[*ActionTemplate], error) {
 	return newclient.GetByQuery[ActionTemplate](client, template, spaceID, actionsQuery)
+}
+
+// GetByQuery returns a collection of action templates based on the criteria defined by its
+// input query parameter.
+func GetByQuery(client newclient.Client, spaceID string, actionTemplatesQuery Query) (*resources.Resources[*ActionTemplate], error) {
+	return newclient.GetByQuery[ActionTemplate](client, template, spaceID, actionTemplatesQuery)
 }

--- a/pkg/actiontemplates/action_template_service.go
+++ b/pkg/actiontemplates/action_template_service.go
@@ -226,7 +226,7 @@ func GetVersionByID(client newclient.Client, spaceID string, actionTemplateID st
 // Get returns a collection of action templates based on the criteria defined by its
 // input query parameter.
 //
-// Deprecated: use actiontemplates.GetByQuery; ActionTemplateSearch has no uri tags, so its fields never reach the server.
+// Deprecated: use actiontemplates.GetByQuery.
 func Get(client newclient.Client, spaceID string, actionsQuery ActionTemplateSearch) (*resources.Resources[*ActionTemplate], error) {
 	return newclient.GetByQuery[ActionTemplate](client, template, spaceID, actionsQuery)
 }

--- a/pkg/actiontemplates/query_test.go
+++ b/pkg/actiontemplates/query_test.go
@@ -1,0 +1,44 @@
+package actiontemplates
+
+import (
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/uritemplates"
+	"github.com/stretchr/testify/require"
+)
+
+func expandCollectionTemplate(t *testing.T, query any) string {
+	values, ok := uritemplates.Struct2map(query)
+	require.True(t, ok)
+	values["spaceId"] = "Spaces-1"
+
+	uri, err := uritemplates.NewUriTemplateCache().Expand(template, values)
+	require.NoError(t, err)
+
+	return uri
+}
+
+func TestQueryExpandsIntoTheCollectionTemplate(t *testing.T) {
+	uri := expandCollectionTemplate(t, Query{
+		IDs:         []string{"ActionTemplates-1", "ActionTemplates-2"},
+		PartialName: "Hello World",
+		Skip:        10,
+		Take:        100,
+	})
+
+	require.Equal(
+		t,
+		"/api/Spaces-1/actiontemplates?skip=10&take=100&ids=ActionTemplates-1%2CActionTemplates-2&partialName=Hello%20World",
+		uri,
+	)
+}
+
+// ActionTemplateSearch has no uri tags, so its fields expand to nothing.
+func TestActionTemplateSearchExpandsIntoNothing(t *testing.T) {
+	uri := expandCollectionTemplate(t, ActionTemplateSearch{
+		ID:   "ActionTemplates-1",
+		Name: "Hello World",
+	})
+
+	require.Equal(t, "/api/Spaces-1/actiontemplates", uri)
+}


### PR DESCRIPTION
Fixes #437.

`ActionTemplateSearch` is the response shape of `Search` and carries no `uri` tags, so the fields passed to `Get` never reached the server — every call returned the default first page.

- adds `GetByQuery`, taking the existing `Query` (which has the correct tags)
- deprecates `Get`, left in place and unchanged
- tests pin both behaviours against the collection template