### PR TITLE
feat: expand the serverstatus API surface

### DIFF
--- a/pkg/serverstatus/document_counts.go
+++ b/pkg/serverstatus/document_counts.go
@@ -1,0 +1,36 @@
+package serverstatus
+
+type DocumentCounts struct {
+	Global         GlobalDocumentCounts         `json:"Global"`
+	Infrastructure InfrastructureDocumentCounts `json:"Infrastructure"`
+	Library        LibraryDocumentCounts        `json:"Library"`
+	Project        ProjectDocumentCounts        `json:"Project"`
+}
+
+type GlobalDocumentCounts struct {
+	Spaces int `json:"Spaces"`
+	Teams  int `json:"Teams"`
+	Users  int `json:"Users"`
+}
+
+type InfrastructureDocumentCounts struct {
+	DeploymentTargets int `json:"DeploymentTargets"`
+	Environments      int `json:"Environments"`
+	Tenants           int `json:"Tenants"`
+	WorkerPools       int `json:"WorkerPools"`
+	Workers           int `json:"Workers"`
+}
+
+type LibraryDocumentCounts struct {
+	Certificates int `json:"Certificates"`
+	Packages     int `json:"Packages"`
+	VariableSets int `json:"VariableSets"`
+}
+
+type ProjectDocumentCounts struct {
+	Deployments int `json:"Deployments"`
+	Projects    int `json:"Projects"`
+	Releases    int `json:"Releases"`
+	RunbookRuns int `json:"RunbookRuns"`
+	Runbooks    int `json:"Runbooks"`
+}

--- a/pkg/serverstatus/log_entry.go
+++ b/pkg/serverstatus/log_entry.go
@@ -1,0 +1,11 @@
+package serverstatus
+
+import "time"
+
+type LogEntry struct {
+	Category    string     `json:"Category,omitempty"`
+	Detail      string     `json:"Detail,omitempty"`
+	MessageText string     `json:"MessageText,omitempty"`
+	Number      int        `json:"Number"`
+	OccurredAt  *time.Time `json:"OccurredAt,omitempty"`
+}

--- a/pkg/serverstatus/logs_query.go
+++ b/pkg/serverstatus/logs_query.go
@@ -1,0 +1,8 @@
+package serverstatus
+
+// LogsQuery represents parameters to query the recent server logs.
+type LogsQuery struct {
+	IncludeDetail bool `uri:"includeDetail,omitempty" url:"includeDetail,omitempty"`
+	Skip          int  `uri:"skip,omitempty" url:"skip,omitempty"`
+	Take          int  `uri:"take,omitempty" url:"take,omitempty"`
+}

--- a/pkg/serverstatus/logs_query_test.go
+++ b/pkg/serverstatus/logs_query_test.go
@@ -1,0 +1,28 @@
+package serverstatus
+
+import (
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/uritemplates"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogsQueryExpandsIntoTheRecentLogsTemplate(t *testing.T) {
+	values, ok := uritemplates.Struct2map(LogsQuery{Skip: 5, Take: 10, IncludeDetail: true})
+	require.True(t, ok)
+
+	uri, err := uritemplates.NewUriTemplateCache().Expand(recentLogsTemplate, values)
+	require.NoError(t, err)
+
+	require.Equal(t, "/api/serverstatus/logs?skip=5&take=10&includeDetail=true", uri)
+}
+
+func TestEmptyLogsQueryExpandsIntoNoParameters(t *testing.T) {
+	values, ok := uritemplates.Struct2map(LogsQuery{})
+	require.True(t, ok)
+
+	uri, err := uritemplates.NewUriTemplateCache().Expand(recentLogsTemplate, values)
+	require.NoError(t, err)
+
+	require.Equal(t, "/api/serverstatus/logs", uri)
+}

--- a/pkg/serverstatus/server_health_status.go
+++ b/pkg/serverstatus/server_health_status.go
@@ -1,0 +1,13 @@
+package serverstatus
+
+import "github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+
+type ServerHealthStatus struct {
+	Description                  string `json:"Description,omitempty"`
+	IsCompliantWithLicense       bool   `json:"IsCompliantWithLicense"`
+	IsEntireClusterDrainingTasks bool   `json:"IsEntireClusterDrainingTasks"`
+	IsEntireClusterReadOnly      bool   `json:"IsEntireClusterReadOnly"`
+	IsOperatingNormally          bool   `json:"IsOperatingNormally"`
+
+	resources.Resource
+}

--- a/pkg/serverstatus/server_status.go
+++ b/pkg/serverstatus/server_status.go
@@ -6,6 +6,7 @@ type ServerStatus struct {
 	IsDatabaseEncrypted                     bool   `json:"IsDatabaseEncrypted"`
 	IsMajorMinorUpgrade                     bool   `json:"IsMajorMinorUpgrade"`
 	IsInMaintenanceMode                     bool   `json:"IsInMaintenanceMode"`
+	IsPotentialClone                        bool   `json:"IsPotentialClone"`
 	IsUpgradeAvailable                      bool   `json:"IsUpgradeAvailable"`
 	MaintenanceExpires                      string `json:"MaintenanceExpires,omitempty"`
 	MaximumAvailableVersion                 string `json:"MaximumAvailableVersion,omitempty"`

--- a/pkg/serverstatus/server_status_service.go
+++ b/pkg/serverstatus/server_status_service.go
@@ -1,10 +1,18 @@
 package serverstatus
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/constants"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/services"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/services/api"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/uritemplates"
 	"github.com/dghubble/sling"
 )
 
@@ -47,6 +55,9 @@ const (
 	healthStatusTemplate   = "/api/serverstatus/health"
 	timezonesTemplate      = "/api/serverstatus/timezones"
 	documentCountsTemplate = "/api/serverstatus/counts"
+	systemInfoTemplate     = "/api/serverstatus/system-info"
+	systemReportTemplate   = "/api/serverstatus/system-report"
+	recentLogsTemplate     = "/api/serverstatus/logs{?skip,take,includeDetail}"
 )
 
 // GetServerStatus returns the status of the server.
@@ -72,4 +83,65 @@ func GetTimezones(client newclient.Client) ([]*Timezone, error) {
 // GetDocumentCounts returns the number of documents held by the server, grouped by area.
 func GetDocumentCounts(client newclient.Client) (*DocumentCounts, error) {
 	return newclient.Get[DocumentCounts](client.HttpSession(), documentCountsTemplate)
+}
+
+// GetSystemInfo returns diagnostic information about the running server. Requires the
+// AdministerSystem permission.
+func GetSystemInfo(client newclient.Client) (*SystemInfo, error) {
+	return newclient.Get[SystemInfo](client.HttpSession(), systemInfoTemplate)
+}
+
+// GetRecentLogs returns recent entries from the server log. Requires the AdministerSystem
+// permission.
+func GetRecentLogs(client newclient.Client, logsQuery LogsQuery) ([]*LogEntry, error) {
+	values, ok := uritemplates.Struct2map(logsQuery)
+	if !ok {
+		values = map[string]any{}
+	}
+
+	path, err := client.URITemplateCache().Expand(recentLogsTemplate, values)
+	if err != nil {
+		return nil, err
+	}
+
+	logEntries, err := newclient.Get[[]*LogEntry](client.HttpSession(), path)
+	if err != nil {
+		return nil, err
+	}
+
+	return *logEntries, nil
+}
+
+// GetSystemReport returns the server's diagnostic report, a zip archive. The caller is
+// responsible for closing the returned reader. Requires the AdministerSystem permission.
+func GetSystemReport(client newclient.Client) (io.ReadCloser, error) {
+	path, err := url.Parse(systemReportTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	request := &http.Request{
+		Method: http.MethodGet,
+		URL:    path,
+		Header: make(http.Header),
+	}
+
+	response, err := client.HttpSession().DoRawRequest(request)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.StatusCode != http.StatusOK {
+		defer newclient.CloseResponse(response)
+
+		apiError := new(core.APIError)
+		if err := json.NewDecoder(response.Body).Decode(apiError); err != nil {
+			return nil, fmt.Errorf("cannot get system report from server. response from server %s", response.Status)
+		}
+		apiError.StatusCode = response.StatusCode
+
+		return nil, apiError
+	}
+
+	return response.Body, nil
 }

--- a/pkg/serverstatus/server_status_service.go
+++ b/pkg/serverstatus/server_status_service.go
@@ -2,6 +2,7 @@ package serverstatus
 
 import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/constants"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/services"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/services/api"
 	"github.com/dghubble/sling"
@@ -40,3 +41,35 @@ func (s *ServerStatusService) Get() (*ServerStatus, error) {
 }
 
 var _ services.IService = &ServerStatusService{}
+
+const (
+	serverStatusTemplate   = "/api/serverstatus"
+	healthStatusTemplate   = "/api/serverstatus/health"
+	timezonesTemplate      = "/api/serverstatus/timezones"
+	documentCountsTemplate = "/api/serverstatus/counts"
+)
+
+// GetServerStatus returns the status of the server.
+func GetServerStatus(client newclient.Client) (*ServerStatus, error) {
+	return newclient.Get[ServerStatus](client.HttpSession(), serverStatusTemplate)
+}
+
+// GetHealthStatus returns the health of the server cluster.
+func GetHealthStatus(client newclient.Client) (*ServerHealthStatus, error) {
+	return newclient.Get[ServerHealthStatus](client.HttpSession(), healthStatusTemplate)
+}
+
+// GetTimezones returns the time zones supported by the server.
+func GetTimezones(client newclient.Client) ([]*Timezone, error) {
+	timezones, err := newclient.Get[[]*Timezone](client.HttpSession(), timezonesTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	return *timezones, nil
+}
+
+// GetDocumentCounts returns the number of documents held by the server, grouped by area.
+func GetDocumentCounts(client newclient.Client) (*DocumentCounts, error) {
+	return newclient.Get[DocumentCounts](client.HttpSession(), documentCountsTemplate)
+}

--- a/pkg/serverstatus/system_info.go
+++ b/pkg/serverstatus/system_info.go
@@ -1,0 +1,16 @@
+package serverstatus
+
+import "github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+
+type SystemInfo struct {
+	ClrVersion         string `json:"ClrVersion,omitempty"`
+	MinThreadPoolCount int    `json:"MinThreadPoolCount"`
+	OSVersion          string `json:"OSVersion,omitempty"`
+	ThreadCount        int    `json:"ThreadCount"`
+	// Uptime is a .NET time span, "[d.]hh:mm:ss[.fffffff]", as sent by the server.
+	Uptime          string `json:"Uptime,omitempty"`
+	Version         string `json:"Version,omitempty"`
+	WorkingSetBytes int64  `json:"WorkingSetBytes"`
+
+	resources.Resource
+}

--- a/pkg/serverstatus/timezone.go
+++ b/pkg/serverstatus/timezone.go
@@ -1,0 +1,10 @@
+package serverstatus
+
+import "github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+
+type Timezone struct {
+	IsLocal bool   `json:"IsLocal"`
+	Name    string `json:"Name,omitempty"`
+
+	resources.Resource
+}

--- a/test/e2e/server_status_service_test.go
+++ b/test/e2e/server_status_service_test.go
@@ -1,6 +1,9 @@
 package e2e
 
 import (
+	"archive/zip"
+	"bytes"
+	"io"
 	"testing"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/serverstatus"
@@ -58,4 +61,50 @@ func TestServerStatusGetDocumentCounts(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, documentCounts)
 	require.GreaterOrEqual(t, documentCounts.Global.Spaces, 1)
+}
+
+func TestServerStatusGetSystemInfo(t *testing.T) {
+	client := getOctopusClient()
+	require.NotNil(t, client)
+
+	systemInfo, err := serverstatus.GetSystemInfo(client)
+	require.NoError(t, err)
+	require.NotNil(t, systemInfo)
+	require.NotEmpty(t, systemInfo.Version)
+	require.NotEmpty(t, systemInfo.ClrVersion)
+	require.NotEmpty(t, systemInfo.OSVersion)
+	require.NotEmpty(t, systemInfo.Uptime)
+	require.Greater(t, systemInfo.WorkingSetBytes, int64(0))
+	require.Greater(t, systemInfo.ThreadCount, 0)
+}
+
+func TestServerStatusGetRecentLogs(t *testing.T) {
+	client := getOctopusClient()
+	require.NotNil(t, client)
+
+	logEntries, err := serverstatus.GetRecentLogs(client, serverstatus.LogsQuery{Take: 5, IncludeDetail: true})
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(logEntries), 5)
+
+	for _, logEntry := range logEntries {
+		require.NotEmpty(t, logEntry.Category)
+		require.NotNil(t, logEntry.OccurredAt)
+	}
+}
+
+func TestServerStatusGetSystemReport(t *testing.T) {
+	client := getOctopusClient()
+	require.NotNil(t, client)
+
+	report, err := serverstatus.GetSystemReport(client)
+	require.NoError(t, err)
+	require.NotNil(t, report)
+	defer report.Close()
+
+	contents, err := io.ReadAll(report)
+	require.NoError(t, err)
+	require.NotEmpty(t, contents)
+
+	_, err = zip.NewReader(bytes.NewReader(contents), int64(len(contents)))
+	require.NoError(t, err)
 }

--- a/test/e2e/server_status_service_test.go
+++ b/test/e2e/server_status_service_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"testing"
 
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/serverstatus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,4 +14,48 @@ func TestServerStatusServiceGet(t *testing.T) {
 	serverStatus, err := client.ServerStatus.Get()
 	require.NoError(t, err)
 	require.NotNil(t, serverStatus)
+}
+
+func TestServerStatusGetServerStatus(t *testing.T) {
+	client := getOctopusClient()
+	require.NotNil(t, client)
+
+	serverStatus, err := serverstatus.GetServerStatus(client)
+	require.NoError(t, err)
+	require.NotNil(t, serverStatus)
+	require.NotEmpty(t, serverStatus.Links)
+}
+
+func TestServerStatusGetHealthStatus(t *testing.T) {
+	client := getOctopusClient()
+	require.NotNil(t, client)
+
+	healthStatus, err := serverstatus.GetHealthStatus(client)
+	require.NoError(t, err)
+	require.NotNil(t, healthStatus)
+	require.NotEmpty(t, healthStatus.Description)
+}
+
+func TestServerStatusGetTimezones(t *testing.T) {
+	client := getOctopusClient()
+	require.NotNil(t, client)
+
+	timezones, err := serverstatus.GetTimezones(client)
+	require.NoError(t, err)
+	require.NotEmpty(t, timezones)
+
+	for _, timezone := range timezones {
+		require.NotEmpty(t, timezone.GetID())
+		require.NotEmpty(t, timezone.Name)
+	}
+}
+
+func TestServerStatusGetDocumentCounts(t *testing.T) {
+	client := getOctopusClient()
+	require.NotNil(t, client)
+
+	documentCounts, err := serverstatus.GetDocumentCounts(client)
+	require.NoError(t, err)
+	require.NotNil(t, documentCounts)
+	require.GreaterOrEqual(t, documentCounts.Global.Spaces, 1)
 }


### PR DESCRIPTION
Refs #47.

`ServerStatusService` exposed only `Get`. Adds newclient functions for every endpoint on the `ServerStatus` resource:

| Function | Endpoint |
|---|---|
| `GetServerStatus` | `/api/serverstatus` |
| `GetHealthStatus` | `/api/serverstatus/health` |
| `GetTimezones` | `/api/serverstatus/timezones` |
| `GetDocumentCounts` | `/api/serverstatus/counts` |
| `GetSystemInfo` | `/api/serverstatus/system-info` |
| `GetRecentLogs` | `/api/serverstatus/logs{?skip,take,includeDetail}` |
| `GetSystemReport` | `/api/serverstatus/system-report` |

Also adds the missing `IsPotentialClone` field on `ServerStatus`.

Notes:

- `GetSystemReport` returns an `io.ReadCloser` — the endpoint serves a zip archive, not JSON. The caller closes it.
- `GetSystemInfo`, `GetRecentLogs` and `GetSystemReport` require the `AdministerSystem` permission.
- `SystemInfo.Uptime` is left as the server's time span string; `FromTimeSpan` lives in `machinepolicies`/`machines`, so parsing it here would mean importing one of those.
- `/api/serverstatus/extensions` is not included; it 404s and is not advertised on the resource.

All response shapes verified against a live server. e2e tests cover all seven, and unit tests pin the `LogsQuery` expansion.