### PR TITLE
fix: correct GitCredentialId JSON tag on ReleaseTemplateGitResource

### DIFF
--- a/pkg/releases/release_template_git_resource.go
+++ b/pkg/releases/release_template_git_resource.go
@@ -9,6 +9,7 @@ type ReleaseTemplateGitResource struct {
 	IsResolvable                   bool                            `json:"IsResolvable"`
 	Name                           string                          `json:"Name,omitempty"`
 	FilePathFilters                []string                        `json:"FilePathFilters,omitempty"`
-	GitCredentialId                string                          `json:"NuGetPackageId,omitempty"`
+	GitCredentialId                string                          `json:"GitCredentialId,omitempty"`
+	GitHubConnectionId             string                          `json:"GitHubConnectionId,omitempty"`
 	GitResourceSelectedLastRelease actions.VersionControlReference `json:"GitResourceSelectedLastRelease,omitempty"`
 }

--- a/pkg/releases/release_template_git_resource_test.go
+++ b/pkg/releases/release_template_git_resource_test.go
@@ -1,0 +1,56 @@
+package releases
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReleaseTemplateGitResourceUnmarshalJSON(t *testing.T) {
+	payload := `{
+		"ActionName": "Update Argo Manifests",
+		"RepositoryUri": "https://github.com/OctopusDeploy/manifests.git",
+		"DefaultBranch": "main",
+		"IsResolvable": true,
+		"Name": "",
+		"FilePathFilters": ["deployment.yaml"],
+		"GitCredentialId": "GitCredentials-1",
+		"GitHubConnectionId": "GitHubConnections-1",
+		"GitResourceSelectedLastRelease": {
+			"GitRef": "refs/heads/main",
+			"GitCommit": "d65a219f86d95cc193050efa2e7a0cd2d314e9a2"
+		}
+	}`
+
+	var gitResource ReleaseTemplateGitResource
+	require.NoError(t, json.Unmarshal([]byte(payload), &gitResource))
+
+	require.Equal(t, "Update Argo Manifests", gitResource.ActionName)
+	require.Equal(t, "https://github.com/OctopusDeploy/manifests.git", gitResource.RepositoryUri)
+	require.Equal(t, "main", gitResource.DefaultBranch)
+	require.True(t, gitResource.IsResolvable)
+	require.Equal(t, []string{"deployment.yaml"}, gitResource.FilePathFilters)
+	require.Equal(t, "GitCredentials-1", gitResource.GitCredentialId)
+	require.Equal(t, "GitHubConnections-1", gitResource.GitHubConnectionId)
+	require.Equal(t, "refs/heads/main", gitResource.GitResourceSelectedLastRelease.GitRef)
+	require.Equal(t, "d65a219f86d95cc193050efa2e7a0cd2d314e9a2", gitResource.GitResourceSelectedLastRelease.GitCommit)
+}
+
+func TestReleaseTemplateGitResourceMarshalJSON(t *testing.T) {
+	gitResource := ReleaseTemplateGitResource{
+		ActionName:         "Update Argo Manifests",
+		GitCredentialId:    "GitCredentials-1",
+		GitHubConnectionId: "GitHubConnections-1",
+	}
+
+	data, err := json.Marshal(gitResource)
+	require.NoError(t, err)
+
+	var roundTripped map[string]any
+	require.NoError(t, json.Unmarshal(data, &roundTripped))
+
+	require.Equal(t, "GitCredentials-1", roundTripped["GitCredentialId"])
+	require.Equal(t, "GitHubConnections-1", roundTripped["GitHubConnectionId"])
+	require.NotContains(t, roundTripped, "NuGetPackageId")
+}


### PR DESCRIPTION
`GitCredentialId` was tagged `json:"NuGetPackageId,omitempty"`, so it never deserialised and always read as `""`. `GitHubConnectionId`, which the server also sends, was missing from the struct.

Tags now match `pkg/gitdependencies/git_dependency.go`, which had them right.

Verified against a live instance — the same `GetTemplate` call that returned `GitCredentialId = ""` now returns `"GitCredentials-1"`. Added unmarshal/marshal tests; `pkg/releases` previously had none.

Fixes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)