### PR TITLE
chore: fix spelling across comments, identifiers and query tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ vendor
 .env
 
 go-octopusdeploy
+
+# macOS
+.DS_Store

--- a/api/spec.json
+++ b/api/spec.json
@@ -461,7 +461,7 @@
       "enum": [
         "Success",
         "ManualMergeRequired",
-        "DefaultParamterValueMissing",
+        "DefaultParameterValueMissing",
         "RemovedPackageInUse"
       ],
       "type": "string"
@@ -2556,7 +2556,7 @@
         }
       }
     },
-    "DeploymentPromomotionTenant": {
+    "DeploymentPromotionTenant": {
       "type": "object",
       "properties": {
         "Id": {
@@ -3037,7 +3037,7 @@
         "TenantPromotions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DeploymentPromomotionTenant"
+            "$ref": "#/definitions/DeploymentPromotionTenant"
           }
         }
       }
@@ -8127,7 +8127,7 @@
         "TenantPromotions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/DeploymentPromomotionTenant"
+            "$ref": "#/definitions/DeploymentPromotionTenant"
           }
         }
       }

--- a/pkg/accounts/accounts.go
+++ b/pkg/accounts/accounts.go
@@ -148,7 +148,7 @@ func (a *Accounts) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// GetNextPage retrives the next page from the links collection. If no next page
+// GetNextPage retrieves the next page from the links collection. If no next page
 // exists it will return nill
 func (r *Accounts) GetNextPage(client *sling.Sling) (*Accounts, error) {
 	if r.Links.PageNext == "" {
@@ -161,7 +161,7 @@ func (r *Accounts) GetNextPage(client *sling.Sling) (*Accounts, error) {
 	return ToAccounts(response.(*resources.Resources[*AccountResource])), nil
 }
 
-// GetAllPages will retrive all remaining next pages in the link collection
+// GetAllPages will retrieve all remaining next pages in the link collection
 // and return the result as list of concatenated Items; Including the items
 // from the base Resource.
 func (r *Accounts) GetAllPages(client *sling.Sling) ([]IAccount, error) {

--- a/pkg/accounts/ssh_key_account.go
+++ b/pkg/accounts/ssh_key_account.go
@@ -54,7 +54,7 @@ func NewSSHKeyAccount(name string, username string, privateKeyFile *core.Sensiti
 	return &account, nil
 }
 
-// SetPrivateKeyPassphrase sets the private key [assphrase of this SSH key pair account.
+// SetPrivateKeyPassphrase sets the private key passphrase of this SSH key pair account.
 func (s *SSHKeyAccount) SetPrivateKeyPassphrase(privateKeyPassphrase *core.SensitiveValue) {
 	s.PrivateKeyPassphrase = privateKeyPassphrase
 }

--- a/pkg/credentials/resource_test.go
+++ b/pkg/credentials/resource_test.go
@@ -75,9 +75,9 @@ func TestResourceWithAnonymousAsJSON(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, restrictionsAsJSON)
 
-	anonymousdAsJSON, err := json.Marshal(anonymous)
+	anonymousAsJSON, err := json.Marshal(anonymous)
 	require.NoError(t, err)
-	require.NotNil(t, anonymousdAsJSON)
+	require.NotNil(t, anonymousAsJSON)
 
 	resource := credentials.NewResource(name, anonymous)
 	resource.Description = description
@@ -94,7 +94,7 @@ func TestResourceWithAnonymousAsJSON(t *testing.T) {
 		"Links": {
 			"Self": "%s"
 		}
-	}`, description, anonymousdAsJSON, restrictionsAsJSON, id, name, selfLink)
+	}`, description, anonymousAsJSON, restrictionsAsJSON, id, name, selfLink)
 
 	resourceAsJSON, err := json.Marshal(resource)
 	require.NoError(t, err)

--- a/pkg/environments/environment_service.go
+++ b/pkg/environments/environment_service.go
@@ -134,7 +134,7 @@ func (s *EnvironmentService) GetByName(name string) ([]*Environment, error) {
 	return services.GetPagedResponse[Environment](s, path)
 }
 
-// GetByPartialName performs a lookup and returns enironments with a matching
+// GetByPartialName performs a lookup and returns environments with a matching
 // partial name.
 func (s *EnvironmentService) GetByPartialName(partialName string) ([]*Environment, error) {
 	if internal.IsEmpty(partialName) {

--- a/pkg/events/events_query.go
+++ b/pkg/events/events_query.go
@@ -12,7 +12,7 @@ type EventsQuery struct {
 	FromAutoID        string   `uri:"fromAutoId,omitempty" url:"fromAutoId,omitempty"`
 	IDs               []string `uri:"ids,omitempty" url:"ids,omitempty"`
 	IncludeSystem     bool     `uri:"includeSystem,omitempty" url:"includeSystem,omitempty"`
-	Internal          string   `uri:"interal,omitempty" url:"interal,omitempty"`
+	Internal          string   `uri:"internal,omitempty" url:"internal,omitempty"`
 	Name              string   `uri:"name,omitempty" url:"name,omitempty"`
 	PartialName       string   `uri:"partialName,omitempty" url:"partialName,omitempty"`
 	ProjectGroups     []string `uri:"projectGroups,omitempty" url:"projectGroups,omitempty"`

--- a/pkg/interruptions/interruption.go
+++ b/pkg/interruptions/interruption.go
@@ -30,5 +30,8 @@ func NewInterruption() *Interruption {
 	}
 }
 
-const ManualInterverventionApprove = "Proceed"
+const ManualInterventionApprove = "Proceed"
 const ManualInterventionDecline = "Abort"
+
+// Deprecated: use ManualInterventionApprove.
+const ManualInterverventionApprove = ManualInterventionApprove

--- a/pkg/machines/ssh_endpoint.go
+++ b/pkg/machines/ssh_endpoint.go
@@ -75,7 +75,7 @@ func (s *SSHEndpoint) GetProxyID() string {
 func (s *SSHEndpoint) MarshalJSON() ([]byte, error) {
 	sshEndpoint := struct {
 		AccountID          string `json:"AccountId,omitempty"`
-		ComunicationStyle  string `json:"CommunicationStyle" validate:"required,eq=Ssh"`
+		CommunicationStyle string `json:"CommunicationStyle" validate:"required,eq=Ssh"`
 		DotNetCorePlatform string
 		Fingerprint        string
 		Host               string
@@ -85,7 +85,7 @@ func (s *SSHEndpoint) MarshalJSON() ([]byte, error) {
 		resources.Resource
 	}{
 		AccountID:          s.AccountID,
-		ComunicationStyle:  s.CommunicationStyle,
+		CommunicationStyle: s.CommunicationStyle,
 		DotNetCorePlatform: s.DotNetCorePlatform,
 		Fingerprint:        s.Fingerprint,
 		Host:               s.Host,

--- a/pkg/newclient/httpsession.go
+++ b/pkg/newclient/httpsession.go
@@ -87,7 +87,7 @@ func (h *HttpSession) DoRawJsonRequest(req *http.Request, requestBody any, outpu
 	if resp.StatusCode == http.StatusNoContent || resp.ContentLength == 0 {
 		// TODO the ContentLength check is copied from Sling, but it's valid for servers to stream responses
 		// without a known content length. This won't handle such responses, which would be a bug. The octopus server tends not
-		// to do this, so we can defer a fix until it becomes neccessary
+		// to do this, so we can defer a fix until it becomes necessary
 		return resp, nil
 	}
 

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -15,7 +15,7 @@ type Resources[T any] struct {
 	PagedResults
 }
 
-// GetNextPage retrives the next page from the links collection. If no next page
+// GetNextPage retrieves the next page from the links collection. If no next page
 // exists it will return nill
 func (r *Resources[T]) GetNextPage(client *sling.Sling) (*Resources[T], error) {
 	if r.Links.PageNext == "" {
@@ -28,7 +28,7 @@ func (r *Resources[T]) GetNextPage(client *sling.Sling) (*Resources[T], error) {
 	return response.(*Resources[T]), nil
 }
 
-// GetAllPages will retrive all remaining next pages in the link collection
+// GetAllPages will retrieve all remaining next pages in the link collection
 // and return the result as list of concatenated Items; Including the items
 // from the base Resource.
 func (r *Resources[T]) GetAllPages(client *sling.Sling) ([]T, error) {

--- a/pkg/variables/script_module_service.go
+++ b/pkg/variables/script_module_service.go
@@ -210,8 +210,8 @@ func (s *ScriptModuleService) Update(scriptModule *ScriptModule) (*ScriptModule,
 		return nil, err
 	}
 
-	updatedVriableSet := updatedVariablesResponse.(*VariableSet)
-	for _, variable := range updatedVriableSet.Variables {
+	updatedVariableSet := updatedVariablesResponse.(*VariableSet)
+	for _, variable := range updatedVariableSet.Variables {
 		if strings.HasPrefix(variable.Name, "Octopus.Script.Module[") {
 			scriptModuleResponse.ScriptBody = variable.Value
 		}

--- a/test/e2e/interruption_test.go
+++ b/test/e2e/interruption_test.go
@@ -58,7 +58,7 @@ package e2e
 // 	require.NoError(t, err)
 // 	require.NotNil(t, client)
 
-// 	interruption, err := getInterruptonFromJSON(interruptionJSON)
+// 	interruption, err := getInterruptionFromJSON(interruptionJSON)
 // 	require.NoError(t, err)
 // 	require.NotNil(t, interruption)
 
@@ -76,7 +76,7 @@ package e2e
 // 	require.NoError(t, err)
 // 	require.NotNil(t, client)
 
-// 	interruption, err := getInterruptonFromJSON(interruptionJSON)
+// 	interruption, err := getInterruptionFromJSON(interruptionJSON)
 // 	require.NoError(t, err)
 // 	require.NotNil(t, interruption)
 
@@ -95,14 +95,14 @@ package e2e
 // 	require.NoError(t, err)
 // 	require.NotNil(t, client)
 
-// 	interruption, err := getInterruptonFromJSON(interruptionJSON)
+// 	interruption, err := getInterruptionFromJSON(interruptionJSON)
 // 	require.NoError(t, err)
 // 	require.NotNil(t, interruption)
 
 // 	submitRequest := interruptions.InterruptionSubmitRequest{
 // 		Instructions: "Approve The Deployment",
 // 		Notes:        "",
-// 		Result:       interruptions.ManualInterverventionApprove,
+// 		Result:       interruptions.ManualInterventionApprove,
 // 	}
 
 // 	i, err := client.Interruptions.Submit(interruption, &submitRequest)
@@ -298,7 +298,7 @@ package e2e
 // 	}
 // 	`
 
-// func getInterruptonFromJSON(interruptionJSON string) (*interruptions.Interruption, error) {
+// func getInterruptionFromJSON(interruptionJSON string) (*interruptions.Interruption, error) {
 // 	var interruption interruptions.Interruption
 // 	err := json.Unmarshal([]byte(interruptionJSON), &interruption)
 // 	return &interruption, err

--- a/test/testutil.go
+++ b/test/testutil.go
@@ -52,7 +52,7 @@ type MockHttpServer struct {
 	Response chan responseOrError
 
 	// so test code can detect unanswered requests or responses at the end.
-	// Not strictly neccessary as unanswered req/resp results in a channel deadlock
+	// Not strictly necessary as unanswered req/resp results in a channel deadlock
 	// and go panics and kills the process, so we find out about it, but this is a bit
 	// less confusing to troubleshoot
 	pendingMsgCount int32

--- a/tests/Create-ApiKey.ps1
+++ b/tests/Create-ApiKey.ps1
@@ -10,7 +10,7 @@ $LoginObj = New-Object Octopus.Client.Model.LoginCommand
 $LoginObj.Username = "admin"
 $LoginObj.Password = "Password01!"
 
-#Loging in to Octopus
+#Logging in to Octopus
 $repository.Users.SignIn($LoginObj)
 
 #Getting current user logged in

--- a/uritemplates/uritemplates.go
+++ b/uritemplates/uritemplates.go
@@ -185,7 +185,7 @@ func parseTerm(term string) (result templateTerm, err error) {
 		err = errors.New("not a valid name: " + result.name)
 	}
 	if result.explode && result.truncate > 0 {
-		err = errors.New("both explode and prefix modifers on same term")
+		err = errors.New("both explode and prefix modifiers on same term")
 	}
 	return result, err
 }


### PR DESCRIPTION
Replaces #204, which had gone stale and conflicting. Same corrections, rebased onto `main`, with @jsoref credited as co-author.

Mostly comments and local identifiers, but **three are behaviour, not spelling**:

- **`pkg/events/events_query.go`** — `Internal` was tagged `uri:"interal"`. The server's link template is `/api/events{?...,internal,...}`, so the tag never matched and the filter silently expanded to nothing. Confirmed against a live instance. Same class as #442, #443 and #444. Callers that set `Internal` were getting unfiltered results and will now get filtered ones.
- **`pkg/interruptions/interruption.go`** — `ManualInterverventionApprove` is exported, so #204's outright rename would have been breaking. Added `ManualInterventionApprove` and kept the misspelling as a deprecated alias instead.
- **`uritemplates/uritemplates.go:188`** — the `parseTerm` error text changes from `"both explode and prefix modifers on same term"` to `"...modifiers..."`. It's an internal URI-template parse error, but the string is observable to anyone matching on the message, so it belongs in the release notes rather than being filed under comment fixes.

### Not breaking

No compile-level break. `ManualInterverventionApprove` survives as an alias with the same value, and every other renamed identifier is a doc comment, a local variable, a commented-out test, or — in `pkg/machines/ssh_endpoint.go` — a field on the anonymous struct declared inside `MarshalJSON`, whose `json` tag was already correct. Nothing changes on the wire.

### Note on `api/spec.json`

`DeploymentPromomotionTenant` → `DeploymentPromotionTenant` matches how the server actually spells it. The `DefaultParamterValueMissing` → `DefaultParameterValueMissing` hunk is more debatable: that's a wire enum value on `ActionUpdateResultResource`, and a live server still emits the misspelling, so the "fix" makes the checked-in spec diverge from reality. Nothing in this repo reads `spec.json`, so it can't break a build — flagging it for a reviewer to call.

### Omitted

Deliberately left out of #204's set: `pkg/machines/duration_formatter_test.go` (`fourtySevenHours`). #435 rewrites that file, and touching it here would only create a conflict — worth picking up after that merges.

Two stray `.DS_Store` files that had been committed are removed, and `.DS_Store` is now in `.gitignore`.

### Verification

`go build`, `go vet` and `gofmt` clean, and `api/spec.json` still parses. (`uritemplates/uritemplates.go` is unformatted per `gofmt`, but identically so on `main` — a trailing `//` in the package doc comment, untouched here.) The full `pkg/...` suite has the same failures before and after this change — all integration tests against a live instance, and the set varies between consecutive runs on `main` alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
