### PR TITLE
fix: refuse to write a sensitive variable that would clear its value

### DIFF
--- a/pkg/variables/sensitive_variable_test.go
+++ b/pkg/variables/sensitive_variable_test.go
@@ -1,0 +1,75 @@
+package variables
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func sensitiveVariable(name string, value string, id string) *Variable {
+	variable := NewVariable(name)
+	variable.IsSensitive = true
+	variable.Type = "Sensitive"
+	variable.Value = value
+	variable.ID = id
+	return variable
+}
+
+func TestValidateSensitiveVariables(t *testing.T) {
+	testCases := []struct {
+		name        string
+		variables   []*Variable
+		expectError bool
+	}{
+		{
+			name:        "sensitive with an ID and no value keeps the stored value",
+			variables:   []*Variable{sensitiveVariable("secret", "", "abc-123")},
+			expectError: false,
+		},
+		{
+			name:        "sensitive with a value and no ID sets it explicitly",
+			variables:   []*Variable{sensitiveVariable("secret", "s3cret", "")},
+			expectError: false,
+		},
+		{
+			name:        "sensitive with neither would clear the stored value",
+			variables:   []*Variable{sensitiveVariable("secret", "", "")},
+			expectError: true,
+		},
+		{
+			name:        "non-sensitive with neither is unaffected",
+			variables:   []*Variable{NewVariable("plain")},
+			expectError: false,
+		},
+		{
+			name:        "reported alongside valid variables",
+			variables:   []*Variable{NewVariable("plain"), sensitiveVariable("secret", "", "")},
+			expectError: true,
+		},
+		{
+			name:        "nil entries are skipped",
+			variables:   []*Variable{nil},
+			expectError: false,
+		},
+		{
+			name:        "empty set",
+			variables:   nil,
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSensitiveVariables(VariableSet{Variables: tc.variables})
+
+			if !tc.expectError {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			require.ErrorAs(t, err, &errSensitiveVariableWouldBeCleared{})
+			require.Contains(t, err.Error(), "secret")
+		})
+	}
+}

--- a/pkg/variables/variable.go
+++ b/pkg/variables/variable.go
@@ -10,8 +10,12 @@ type Variable struct {
 	Prompt      *VariablePromptOptions `json:"Prompt,omitempty"`
 	Scope       VariableScope          `json:"Scope"`
 	Type        string                 `json:"Type"`
-	Value       string                 `json:"Value"`
-	SpaceID     string                 `json:"SpaceId,omitempty"`
+	// Value is never populated for a sensitive variable: the server returns null and it reads
+	// back as an empty string. Preserving an existing secret across an update therefore depends
+	// on sending the variable's ID, not on the value. Writing a sensitive variable with an empty
+	// Value and no ID replaces the stored secret with an empty string.
+	Value   string `json:"Value"`
+	SpaceID string `json:"SpaceId,omitempty"`
 
 	resources.Resource
 }

--- a/pkg/variables/variable_service.go
+++ b/pkg/variables/variable_service.go
@@ -22,6 +22,32 @@ func (e errInvalidVariableServiceParameter) Error() string {
 	return fmt.Sprintf("VariableService: invalid parameter, %s", e.ParameterName)
 }
 
+// errSensitiveVariableWouldBeCleared reports a write that would replace a stored secret with an
+// empty string. The server matches a variable without an ID by name, so an empty value overwrites
+// whatever is already held under that name.
+type errSensitiveVariableWouldBeCleared struct {
+	VariableName string
+}
+
+func (e errSensitiveVariableWouldBeCleared) Error() string {
+	return fmt.Sprintf("VariableService: sensitive variable %s has no value and no ID; writing it would clear the stored value. Send the variable's ID to keep the existing value, or set a value explicitly", e.VariableName)
+}
+
+// validateSensitiveVariables rejects sensitive variables that carry neither a value nor an ID.
+func validateSensitiveVariables(variableSet VariableSet) error {
+	for _, variable := range variableSet.Variables {
+		if variable == nil {
+			continue
+		}
+
+		if variable.IsSensitive && internal.IsEmpty(variable.Value) && internal.IsEmpty(variable.GetID()) {
+			return errSensitiveVariableWouldBeCleared{VariableName: variable.Name}
+		}
+	}
+
+	return nil
+}
+
 type VariableService struct {
 	namesPath   string
 	previewPath string
@@ -233,6 +259,10 @@ func (s *VariableService) Update(ownerID string, variableSet VariableSet) (Varia
 
 	if internal.IsEmpty(ownerID) {
 		return VariableSet{}, errInvalidVariableServiceParameter{ParameterName: "ownerID"}
+	}
+
+	if err := validateSensitiveVariables(variableSet); err != nil {
+		return VariableSet{}, err
 	}
 
 	path := internal.TrimTemplate(s.GetPath())
@@ -505,6 +535,10 @@ func UpdateSingle(client newclient.Client, spaceID string, ownerID string, varia
 func Update(client newclient.Client, spaceID string, ownerID string, variableSet VariableSet) (VariableSet, error) {
 	if internal.IsEmpty(ownerID) {
 		return VariableSet{}, errInvalidVariableServiceParameter{ParameterName: "ownerID"}
+	}
+
+	if err := validateSensitiveVariables(variableSet); err != nil {
+		return VariableSet{}, err
 	}
 
 	spaceID, err := internal.GetSpaceID(spaceID, client.GetSpaceID())


### PR DESCRIPTION
Fixes #449.

A sensitive variable written with an empty `Value` and no `Id` had its stored secret replaced with an empty string. Nothing errored, and the loss was undetectable on read because the server never returns a sensitive value. A caller who rebuilds a variable set instead of round-tripping the objects from `GetAll` produces exactly that payload.

Both `Update` paths now reject it. Everything else is unchanged: sending the `Id` keeps the existing value, and sending an explicit value sets it.

## What the server actually does

Measured against a live 2026.x instance, using a runbook that printed `${#VALUE}` so masking could not hide the result. Starting value 18 characters:

| `Id` sent | `Value` sent | Resulting length |
|---|---|---|
| yes | `""` | 18 — preserved |
| yes | `null` | 18 — preserved |
| yes | `"newvalue123"` | 11 — updated |
| no | `""` | **0 — wiped** |
| no | `null` | **0 — wiped** |
| no | `"newvalue123"` | 11 — updated |

The `Id` is the sole determinant. `null` and `""` are indistinguishable.

That is why this doesn't take #261's approach of changing `Value` to `*string` — rows 4 and 5 show sending `null` wipes the secret just the same, so it would be a breaking change to every caller of `Variable.Value` that fixes nothing. #261 also bundles GitHub credential support that has since landed independently as `credentials.GitHubApp`.

## Verified live

Six flows through the client, before cleanup:

```
1. round-trip untouched (IDs intact)          err=<nil>
2. same set, sensitive variable's ID stripped  err=... would clear the stored value
3. explicit value, no ID                       err=<nil>
4. new sensitive variable with a value         err=<nil>
5. new sensitive variable with no value        err=... would clear the stored value
6. newclient path, ID stripped                 err=... would clear the stored value
```

Case 5 is newly rejected: creating a sensitive variable with no value. That was already a no-op on the server and is indistinguishable from case 2, which is the destructive one.

Test fixtures were removed afterwards. `pkg/variables` has the same failures before and after — `TestLibraryVariableSetServiceDeleteAll` fails on both, being a destructive integration test that cannot delete variable sets in use by projects on the instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)