### PR TITLE
fix: parse day and fractional-second components in FromTimeSpan (cherry-pick of #435)

### DIFF
--- a/pkg/machinepolicies/duration_formatter.go
+++ b/pkg/machinepolicies/duration_formatter.go
@@ -3,6 +3,7 @@ package machinepolicies
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -30,20 +31,67 @@ func ToTimeSpan(duration time.Duration) string {
 	return fmt.Sprintf("%02d.%02d:%02d:%02d.%05d", days, hours, minutes, seconds, secondsFraction)
 }
 
+// FromTimeSpan parses a .NET time span, "[d.]hh:mm:ss[.fffffff]", into a duration. The day and
+// fractional-second components are optional, and the server does not pad the day component to a
+// fixed width, so the fields cannot be read at fixed offsets. Input that does not parse yields a
+// zero duration.
 func FromTimeSpan(timeSpan string) time.Duration {
-	if len(timeSpan) == 8 {
-		hours, _ := strconv.ParseInt(timeSpan[0:2], 10, 64)
-		minutes, _ := strconv.ParseInt(timeSpan[3:5], 10, 64)
-		seconds, _ := strconv.ParseInt(timeSpan[6:8], 10, 64)
-		duration, _ := time.ParseDuration(fmt.Sprintf("%dh%dm%ds", hours, minutes, seconds))
-		return duration
+	var days int64
+	remainder := timeSpan
+
+	// Both the day separator and the fractional-second separator are ".", so a leading segment is
+	// only the day component when the rest still holds a complete "hh:mm:ss".
+	if index := strings.Index(remainder, "."); index >= 0 && strings.Count(remainder[index+1:], ":") == 2 {
+		parsedDays, err := strconv.ParseInt(remainder[:index], 10, 64)
+		if err != nil {
+			return 0
+		}
+		days = parsedDays
+		remainder = remainder[index+1:]
 	}
 
-	days, _ := strconv.ParseInt(timeSpan[0:0], 10, 32)
-	hours, _ := strconv.ParseInt(timeSpan[2:4], 10, 64)
-	hours += (days * 24)
-	minutes, _ := strconv.ParseInt(timeSpan[5:7], 10, 64)
-	seconds, _ := strconv.ParseInt(timeSpan[8:10], 10, 64)
-	duration, _ := time.ParseDuration(fmt.Sprintf("%dh%dm%ds", hours, minutes, seconds))
-	return duration
+	var fraction time.Duration
+	if index := strings.Index(remainder, "."); index >= 0 {
+		digits := remainder[index+1:]
+		parsedFraction, err := strconv.ParseInt(digits, 10, 64)
+		if err != nil {
+			return 0
+		}
+		// The digits are a decimal fraction of a second, however many of them there are.
+		scale := pow10(len(digits))
+		fraction = time.Duration(parsedFraction * int64(time.Second) / scale)
+		remainder = remainder[:index]
+	}
+
+	fields := strings.Split(remainder, ":")
+	if len(fields) != 3 {
+		return 0
+	}
+
+	hours, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return 0
+	}
+	minutes, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return 0
+	}
+	seconds, err := strconv.ParseInt(fields[2], 10, 64)
+	if err != nil {
+		return 0
+	}
+
+	return time.Duration(days)*24*time.Hour +
+		time.Duration(hours)*time.Hour +
+		time.Duration(minutes)*time.Minute +
+		time.Duration(seconds)*time.Second +
+		fraction
+}
+
+func pow10(exponent int) int64 {
+	result := int64(1)
+	for i := 0; i < exponent; i++ {
+		result *= 10
+	}
+	return result
 }

--- a/pkg/machinepolicies/duration_formatter_test.go
+++ b/pkg/machinepolicies/duration_formatter_test.go
@@ -1,4 +1,4 @@
-package machines
+package machinepolicies
 
 import (
 	"testing"

--- a/pkg/machines/duration_formatter.go
+++ b/pkg/machines/duration_formatter.go
@@ -3,6 +3,7 @@ package machines
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -30,20 +31,67 @@ func ToTimeSpan(duration time.Duration) string {
 	return fmt.Sprintf("%02d.%02d:%02d:%02d.%05d", days, hours, minutes, seconds, secondsFraction)
 }
 
+// FromTimeSpan parses a .NET time span, "[d.]hh:mm:ss[.fffffff]", into a duration. The day and
+// fractional-second components are optional, and the server does not pad the day component to a
+// fixed width, so the fields cannot be read at fixed offsets. Input that does not parse yields a
+// zero duration.
 func FromTimeSpan(timeSpan string) time.Duration {
-	if len(timeSpan) == 8 {
-		hours, _ := strconv.ParseInt(timeSpan[0:2], 10, 64)
-		minutes, _ := strconv.ParseInt(timeSpan[3:5], 10, 64)
-		seconds, _ := strconv.ParseInt(timeSpan[6:8], 10, 64)
-		duration, _ := time.ParseDuration(fmt.Sprintf("%dh%dm%ds", hours, minutes, seconds))
-		return duration
+	var days int64
+	remainder := timeSpan
+
+	// Both the day separator and the fractional-second separator are ".", so a leading segment is
+	// only the day component when the rest still holds a complete "hh:mm:ss".
+	if index := strings.Index(remainder, "."); index >= 0 && strings.Count(remainder[index+1:], ":") == 2 {
+		parsedDays, err := strconv.ParseInt(remainder[:index], 10, 64)
+		if err != nil {
+			return 0
+		}
+		days = parsedDays
+		remainder = remainder[index+1:]
 	}
 
-	days, _ := strconv.ParseInt(timeSpan[0:0], 10, 32)
-	hours, _ := strconv.ParseInt(timeSpan[2:4], 10, 64)
-	hours += (days * 24)
-	minutes, _ := strconv.ParseInt(timeSpan[5:7], 10, 64)
-	seconds, _ := strconv.ParseInt(timeSpan[8:10], 10, 64)
-	duration, _ := time.ParseDuration(fmt.Sprintf("%dh%dm%ds", hours, minutes, seconds))
-	return duration
+	var fraction time.Duration
+	if index := strings.Index(remainder, "."); index >= 0 {
+		digits := remainder[index+1:]
+		parsedFraction, err := strconv.ParseInt(digits, 10, 64)
+		if err != nil {
+			return 0
+		}
+		// The digits are a decimal fraction of a second, however many of them there are.
+		scale := pow10(len(digits))
+		fraction = time.Duration(parsedFraction * int64(time.Second) / scale)
+		remainder = remainder[:index]
+	}
+
+	fields := strings.Split(remainder, ":")
+	if len(fields) != 3 {
+		return 0
+	}
+
+	hours, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return 0
+	}
+	minutes, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return 0
+	}
+	seconds, err := strconv.ParseInt(fields[2], 10, 64)
+	if err != nil {
+		return 0
+	}
+
+	return time.Duration(days)*24*time.Hour +
+		time.Duration(hours)*time.Hour +
+		time.Duration(minutes)*time.Minute +
+		time.Duration(seconds)*time.Second +
+		fraction
+}
+
+func pow10(exponent int) int64 {
+	result := int64(1)
+	for i := 0; i < exponent; i++ {
+		result *= 10
+	}
+	return result
 }


### PR DESCRIPTION
Cherry-pick of #435 by @Scott-Emberson, re-hosted on a branch in this repo **solely so CI can run**. Authorship is preserved on the commit — this is a mechanical move, not a rewrite, and the work and the analysis are entirely Scott's.

Fork PRs cannot satisfy the required `test` check: `integration-tests.yml` needs `secrets.DB_IMAGE_SA_PASSWORD`, `OD_IMAGE_ADMIN_API_KEY` and `OCTOPUS_SERVER_BASE64_LICENSE`, and GitHub withholds secrets from `pull_request` runs originating on a fork, so the job dies at *Initialize containers* before any Go executes. #435 is red for that reason and no other.

## The bug

`FromTimeSpan` read the day component from `timeSpan[0:0]` — always the empty string — so every value carrying days parsed to zero. Fixed offsets also assumed a single-digit day, fractional seconds were dropped, and an empty string panicked on a slice bound. It is duplicated verbatim in `pkg/machines` and `pkg/machinepolicies`; this fixes both.

Running main's parser against this one on the same inputs:

| input | correct | `main` today | this PR |
|---|---|---|---|
| `00:05:00` | 5m0s | 5m0s | 5m0s |
| `01:30:00` | 1h30m0s | 1h30m0s | 1h30m0s |
| `1.00:00:00` | 24h0m0s | **0s** | 24h0m0s |
| `7.12:30:00` | 180h30m0s | **12h30m0s** | 180h30m0s |
| `07.12:30:00` | 180h30m0s | **0s** | 180h30m0s |
| `10.00:00:00` | 240h0m0s | **0s** | 240h0m0s |
| `00:00:00.5000000` | 500ms | **0s** | 500ms |
| `1.02:03:04.5000000` | 26h3m4.5s | **2h3m4s** | 26h3m4.5s |
| `""` | 0s | **panic** | 0s |

Every day-bearing value was silently wrong rather than failing loudly. Plain `hh:mm:ss` is identical before and after, so nothing that works today regresses.

## Blast radius

Read path only. `ToTimeSpan`, which produces what gets sent to the server, is untouched. All 14 in-repo callers of `FromTimeSpan` sit inside `UnmarshalJSON` on machine policy, cleanup policy and health check policy. It also closes a quiet data-loss path: today you can read a policy, write it back unchanged, and send a day-scale interval out as zero.

## Two notes for the release

1. **Negative time spans remain wrong, in both directions** — pre-existing, not touched here, and arguably never supported:
   ```
   FromTimeSpan("-1.02:03:04") = -21h56m56s   // .NET means -26h3m4s
   FromTimeSpan("-00:05:00")   = 5m0s         // sign dropped entirely
   ToTimeSpan(-26h3m4s)        = "-1.-2:-3:-4"
   ```
2. **This changes values consumers already read.** Anyone getting `0s` for these fields starts getting the true duration, which may surface as a one-off Terraform plan on machine policy timeouts. There is no `CHANGELOG.md` and goreleaser builds notes from commit subjects only, so this needs a note pasted onto the GitHub Release at tag time. Wording is in a comment on #435.

## Once this merges

Close #435 pointing here, so Scott gets the credit and knows it wasn't rejected.
