### PR TITLE
feat: add runbooks.Get for space-wide runbook queries (cherry-pick of #433)

### DIFF
--- a/pkg/runbooks/queries_test.go
+++ b/pkg/runbooks/queries_test.go
@@ -1,0 +1,59 @@
+package runbooks
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/uritemplates"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunbooksQueryExpandsIntoTemplate covers the path Get relies on: RunbooksQuery is
+// converted by uritemplates.Struct2map and expanded against the space-wide runbooks
+// template. A field present on the struct but absent from the template is silently
+// dropped, so assert each filter survives the round trip.
+func TestRunbooksQueryExpandsIntoTemplate(t *testing.T) {
+	parsedTemplate, err := uritemplates.Parse(template)
+	require.NoError(t, err)
+
+	query := RunbooksQuery{
+		IDs:         []string{"Runbooks-1", "Runbooks-2"},
+		IsClone:     true,
+		PartialName: "Deploy Database",
+		ProjectIDs:  []string{"Projects-1"},
+		Skip:        10,
+		Take:        20,
+	}
+
+	values, ok := uritemplates.Struct2map(query)
+	require.True(t, ok)
+	require.NotNil(t, values)
+	values["spaceId"] = "Spaces-1"
+
+	expanded, err := parsedTemplate.Expand(values)
+	require.NoError(t, err)
+
+	expandedURL, err := url.Parse(expanded)
+	require.NoError(t, err)
+	require.Equal(t, "/api/Spaces-1/runbooks", expandedURL.Path)
+
+	parameters := expandedURL.Query()
+	require.Equal(t, "Runbooks-1,Runbooks-2", parameters.Get("ids"))
+	require.Equal(t, "Deploy Database", parameters.Get("partialName"))
+	require.Equal(t, "Projects-1", parameters.Get("projectIds"))
+	require.Equal(t, "10", parameters.Get("skip"))
+	require.Equal(t, "20", parameters.Get("take"))
+}
+
+func TestRunbooksQueryOmitsEmptyFilters(t *testing.T) {
+	parsedTemplate, err := uritemplates.Parse(template)
+	require.NoError(t, err)
+
+	values, ok := uritemplates.Struct2map(RunbooksQuery{})
+	require.True(t, ok)
+	values["spaceId"] = "Spaces-1"
+
+	expanded, err := parsedTemplate.Expand(values)
+	require.NoError(t, err)
+	require.Equal(t, "/api/Spaces-1/runbooks", expanded)
+}

--- a/pkg/runbooks/runbook_service.go
+++ b/pkg/runbooks/runbook_service.go
@@ -140,6 +140,13 @@ func DeleteByID(client newclient.Client, spaceID string, ID string) error {
 	return newclient.DeleteByID(client, template, spaceID, ID)
 }
 
+// Get returns runbooks across a space, in a standard Octopus paginated result structure.
+// Use RunbooksQuery to filter by project, name, or ID. To list the runbooks of a single
+// project, List is a convenience wrapper over the project-scoped endpoint.
+func Get(client newclient.Client, spaceID string, runbooksQuery RunbooksQuery) (*resources.Resources[*Runbook], error) {
+	return newclient.GetByQuery[Runbook](client, template, spaceID, runbooksQuery)
+}
+
 // List returns a list of runbooks from the server, in a standard Octopus paginated result structure.
 // If you don't specify --limit the server will use a default limit (typically 30)
 func List(client newclient.Client, spaceID string, projectID string, filter string, limit int) (*resources.Resources[*Runbook], error) {


### PR DESCRIPTION
Cherry-pick of #433 by @Scott-Emberson, re-hosted on a branch in this repo **solely so CI can run**. Authorship is preserved on the commit — this is a mechanical move, not a rewrite.

Fork PRs cannot satisfy the required `test` check: `integration-tests.yml` needs `secrets.DB_IMAGE_SA_PASSWORD`, `OD_IMAGE_ADMIN_API_KEY` and `OCTOPUS_SERVER_BASE64_LICENSE`, and GitHub withholds secrets from `pull_request` runs originating on a fork, so the job dies at *Initialize containers* before any Go executes. #433 is red for that reason and no other.

## What it does

Six lines of production code plus a test file. The space-wide runbooks URI template and the `RunbooksQuery` filter struct both already exist in the package — nothing connected them, so `RunbooksQuery` is currently unreferenced. This adds `Get`, using the same `newclient.GetByQuery` one-liner that `tenants.Get` and the other resources on this template already use:

```go
func Get(client newclient.Client, spaceID string, runbooksQuery RunbooksQuery) (*resources.Resources[*Runbook], error) {
	return newclient.GetByQuery[Runbook](client, template, spaceID, runbooksQuery)
}
```

Purely additive — no existing signature changes. Callers could previously only reach runbooks through the project-scoped `List`.

Unblocks a runbooks data source in the Terraform provider (OctopusDeploy/terraform-provider-octopusdeploy#209).

## Once this merges

Close #433 pointing here, so Scott gets the credit and knows it wasn't rejected.
