### PR TITLE
feat: add GetDashboard and assert every query field carries a uri tag

### DIFF
--- a/pkg/dashboard/dashboard_query.go
+++ b/pkg/dashboard/dashboard_query.go
@@ -1,7 +1,7 @@
 package dashboard
 
 type DashboardQuery struct {
-	IncludeLatest   bool     `url:"highestLatestVersionPerProjectAndEnvironment"`
+	IncludeLatest   bool     `uri:"highestLatestVersionPerProjectAndEnvironment,omitempty" url:"highestLatestVersionPerProjectAndEnvironment,omitempty"`
 	ProjectID       string   `uri:"projectId,omitempty" url:"projectId,omitempty"`
 	SelectedTags    []string `uri:"selectedTags,omitempty" url:"selectedTags,omitempty"`
 	SelectedTenants []string `uri:"selectedTenants,omitempty" url:"selectedTenants,omitempty"`

--- a/pkg/dashboard/dashboard_service.go
+++ b/pkg/dashboard/dashboard_service.go
@@ -22,6 +22,24 @@ func NewDashboardService(sling *sling.Sling, uriTemplate string, dashboardDynami
 	}
 }
 
+// GetDashboard returns the dashboard, optionally narrowed to a project or
+// release and to the given tenants and tenant tags.
+//
+// Like GetDynamicDashboard, the query filters on IDs rather than names.
+func (s *DashboardService) GetDashboard(query DashboardQuery) (*Dashboard, error) {
+	path, err := s.GetURITemplate().Expand(query)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := api.ApiGet(s.GetClient(), new(Dashboard), path)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.(*Dashboard), nil
+}
+
 // GetDynamicDashboard returns the release currently deployed to each
 // environment, optionally narrowed to the given projects and environments, and
 // optionally including the deployment preceding the current one.

--- a/pkg/dashboard/dashboard_service_httptest_test.go
+++ b/pkg/dashboard/dashboard_service_httptest_test.go
@@ -1,0 +1,63 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/constants"
+	"github.com/dghubble/sling"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The path tests expand the template without calling the method; this covers
+// the URL GetDashboard actually requests, and the response deserialising.
+func TestDashboardServiceGetDashboardRoundTrip(t *testing.T) {
+	const payload = `{
+	  "Projects": [{ "Id": "Projects-81", "Name": "NJ Todo List K8s" }],
+	  "Environments": [{ "Id": "Environments-2", "Name": "Production" }],
+	  "Items": [
+	    {
+	      "Id": "Deployments-387",
+	      "ProjectId": "Projects-81",
+	      "EnvironmentId": "Environments-2",
+	      "ReleaseVersion": "2.16.0",
+	      "State": "Success",
+	      "IsCurrent": true,
+	      "Links": { "Self": "/api/Spaces-1/deployments/Deployments-387" }
+	    }
+	  ],
+	  "ProjectLimit": null,
+	  "IsFiltered": true
+	}`
+
+	var requested string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = r.URL.RequestURI()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer server.Close()
+
+	base := sling.New().Client(server.Client()).Base(server.URL+"/").Set("Accept", "application/json")
+	service := NewDashboardService(base, constants.TestURIDashboard, constants.TestURIDashboardDynamic)
+
+	board, err := service.GetDashboard(DashboardQuery{ProjectID: "Projects-81", IncludeLatest: true})
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(requested)
+	require.NoError(t, err)
+	assert.Equal(t, "/api/Spaces-1/dashboard", parsed.Path)
+	assert.Equal(t, url.Values{
+		"projectId": {"Projects-81"},
+		"highestLatestVersionPerProjectAndEnvironment": {"true"},
+	}, parsed.Query())
+
+	require.Len(t, board.Items, 1)
+	assert.Equal(t, "Deployments-387", board.Items[0].GetID())
+	assert.Equal(t, "Projects-81", board.Items[0].ProjectID)
+	assert.Equal(t, "/api/Spaces-1/deployments/Deployments-387", board.Items[0].Links["Self"])
+	assert.True(t, board.IsFiltered)
+}

--- a/pkg/dashboard/dashboard_service_test.go
+++ b/pkg/dashboard/dashboard_service_test.go
@@ -25,6 +25,71 @@ func TestNewDashboardService(t *testing.T) {
 	require.Equal(t, constants.TestURIDashboardDynamic, service.dashboardDynamicPath)
 }
 
+func TestDashboardServiceGetDashboardPath(t *testing.T) {
+	service := createDashboardService(t)
+
+	tests := []struct {
+		name     string
+		query    DashboardQuery
+		expected map[string][]string
+	}{
+		{
+			name:     "empty query returns the unfiltered dashboard",
+			query:    DashboardQuery{},
+			expected: map[string][]string{},
+		},
+		{
+			name:     "project",
+			query:    DashboardQuery{ProjectID: "Projects-1"},
+			expected: map[string][]string{"projectId": {"Projects-1"}},
+		},
+		{
+			name:     "release",
+			query:    DashboardQuery{ReleaseID: "Releases-1"},
+			expected: map[string][]string{"releaseId": {"Releases-1"}},
+		},
+		{
+			name:     "include latest",
+			query:    DashboardQuery{IncludeLatest: true},
+			expected: map[string][]string{"highestLatestVersionPerProjectAndEnvironment": {"true"}},
+		},
+		{
+			name:     "show all",
+			query:    DashboardQuery{ShowAll: true},
+			expected: map[string][]string{"showAll": {"true"}},
+		},
+		{
+			// Both bools default to false server side, so false must not be sent.
+			name:     "false bools are omitted",
+			query:    DashboardQuery{IncludeLatest: false, ShowAll: false},
+			expected: map[string][]string{},
+		},
+		{
+			name: "tenants and tags",
+			query: DashboardQuery{
+				SelectedTenants: []string{"Tenants-1", "Tenants-2"},
+				SelectedTags:    []string{"Region/Aus-East"},
+			},
+			expected: map[string][]string{
+				"selectedTenants": {"Tenants-1,Tenants-2"},
+				"selectedTags":    {"Region/Aus-East"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path, err := service.GetURITemplate().Expand(test.query)
+			require.NoError(t, err)
+
+			parsed, err := url.Parse(path)
+			require.NoError(t, err)
+			assert.Equal(t, "/api/Spaces-1/dashboard", parsed.Path)
+			assert.Equal(t, url.Values(test.expected), parsed.Query())
+		})
+	}
+}
+
 func TestDashboardServiceGetDynamicDashboardPath(t *testing.T) {
 	service := createDashboardService(t)
 

--- a/test/conventions/query_tags_test.go
+++ b/test/conventions/query_tags_test.go
@@ -1,0 +1,92 @@
+// Package conventions holds tests that assert repository-wide conventions
+// rather than the behaviour of any one package.
+package conventions
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestQueryStructFieldsHaveURITags asserts that every field of every *Query
+// struct under pkg/ carries a uri tag.
+//
+// Query structs reach the server two ways: the newclient functions expand them
+// through uritemplates, which reads the uri tag, and the older services encode
+// them with go-querystring, which reads url. A field with only a url tag is
+// silently dropped by the newclient path — the request succeeds and the filter
+// does not apply. That is how actiontemplates.Get shipped broken (#437), and how
+// DashboardQuery.IncludeLatest sat unusable for four years.
+func TestQueryStructFieldsHaveURITags(t *testing.T) {
+	var files []string
+	err := filepath.WalkDir(filepath.Join("..", "..", "pkg"), func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() && strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, files, "found no Go files under pkg/")
+
+	fset := token.NewFileSet()
+	structsChecked := 0
+
+	for _, path := range files {
+		parsed, err := parser.ParseFile(fset, path, nil, 0)
+		require.NoErrorf(t, err, "parsing %s", path)
+
+		ast.Inspect(parsed, func(node ast.Node) bool {
+			typeSpec, ok := node.(*ast.TypeSpec)
+			if !ok || !strings.HasSuffix(typeSpec.Name.Name, "Query") {
+				return true
+			}
+			structType, ok := typeSpec.Type.(*ast.StructType)
+			if !ok {
+				return true
+			}
+
+			structsChecked++
+			for _, field := range structType.Fields.List {
+				if len(field.Names) == 0 {
+					continue // embedded
+				}
+
+				var tag reflect.StructTag
+				if field.Tag != nil {
+					unquoted, err := strconv.Unquote(field.Tag.Value)
+					require.NoError(t, err)
+					tag = reflect.StructTag(unquoted)
+				}
+
+				if _, hasURI := tag.Lookup("uri"); hasURI {
+					continue
+				}
+
+				reason := "has no struct tag"
+				if _, hasURL := tag.Lookup("url"); hasURL {
+					reason = "has a url tag but no uri tag, so the newclient path drops it"
+				}
+
+				for _, name := range field.Names {
+					t.Errorf("%s: %s.%s %s", path, typeSpec.Name.Name, name.Name, reason)
+				}
+			}
+
+			return true
+		})
+	}
+
+	require.NotZero(t, structsChecked, "found no *Query structs to check")
+	t.Logf("checked %d *Query structs across %d files", structsChecked, len(files))
+}

--- a/test/e2e/dashboard_service_test.go
+++ b/test/e2e/dashboard_service_test.go
@@ -205,3 +205,85 @@ func TestDashboardGetDynamicDashboardFiltersByEnvironmentID(t *testing.T) {
 		require.Equal(t, environmentID, item.EnvironmentID)
 	}
 }
+
+func TestDashboardGetDashboardUnfiltered(t *testing.T) {
+	client := getOctopusClient()
+	require.NotNil(t, client)
+
+	board, err := client.Dashboards.GetDashboard(dashboard.DashboardQuery{})
+	require.NoError(t, err)
+	require.NotNil(t, board)
+	require.False(t, board.IsFiltered)
+	skipWithoutItems(t, board)
+
+	projectIDs := map[string]bool{}
+	for _, project := range board.Projects {
+		projectIDs[project.GetID()] = true
+	}
+
+	for _, item := range board.Items {
+		require.True(t, projectIDs[item.ProjectID], "item project %s missing from reference data", item.ProjectID)
+		require.NotEmpty(t, item.GetID())
+		require.NotEmpty(t, item.Links["Self"])
+	}
+}
+
+func TestDashboardGetDashboardFiltersByProjectID(t *testing.T) {
+	client := getOctopusClient()
+	require.NotNil(t, client)
+
+	board, err := client.Dashboards.GetDashboard(dashboard.DashboardQuery{})
+	require.NoError(t, err)
+	projectID, projectName := projectWithItems(t, board)
+
+	filtered, err := client.Dashboards.GetDashboard(dashboard.DashboardQuery{ProjectID: projectID})
+	require.NoError(t, err)
+	require.True(t, filtered.IsFiltered)
+	require.NotEmpty(t, filtered.Items)
+	for _, item := range filtered.Items {
+		require.Equal(t, projectID, item.ProjectID)
+	}
+
+	// As with the dynamic dashboard, the server matches IDs only.
+	byName, err := client.Dashboards.GetDashboard(dashboard.DashboardQuery{ProjectID: projectName})
+	require.NoError(t, err)
+	require.Empty(t, byName.Items, "a project name matched items; the server contract may have changed")
+}
+
+// TestDashboardGetDashboardIncludeLatest exercises the parameter that carried
+// only a url tag before #442 and so never reached the server.
+func TestDashboardGetDashboardIncludeLatest(t *testing.T) {
+	client := getOctopusClient()
+	require.NotNil(t, client)
+
+	board, err := client.Dashboards.GetDashboard(dashboard.DashboardQuery{IncludeLatest: true, ShowAll: true})
+	require.NoError(t, err)
+	require.NotNil(t, board)
+}
+
+func TestDashboardGetDashboardFiltersByTenant(t *testing.T) {
+	client := getOctopusClient()
+	require.NotNil(t, client)
+
+	board, err := client.Dashboards.GetDashboard(dashboard.DashboardQuery{})
+	require.NoError(t, err)
+
+	tenantID := ""
+	for _, item := range board.Items {
+		if item.TenantID != "" {
+			tenantID = item.TenantID
+			break
+		}
+	}
+	if tenantID == "" {
+		t.Skip("no tenanted deployment on the dashboard")
+	}
+
+	filtered, err := client.Dashboards.GetDashboard(dashboard.DashboardQuery{SelectedTenants: []string{tenantID}})
+	require.NoError(t, err)
+	require.True(t, filtered.IsFiltered)
+	require.NotEmpty(t, filtered.Items)
+	for _, item := range filtered.Items {
+		require.Equal(t, tenantID, item.TenantID)
+	}
+}

--- a/test/e2e/dashboard_service_test.go
+++ b/test/e2e/dashboard_service_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -251,7 +252,9 @@ func TestDashboardGetDashboardFiltersByProjectID(t *testing.T) {
 }
 
 // TestDashboardGetDashboardIncludeLatest exercises the parameter that carried
-// only a url tag before #442 and so never reached the server.
+// only a url tag before #442 and so never reached the server. Neither parameter
+// narrows the result, so what is assertable is the shape the name promises: the
+// highest version per project and environment, meaning one item per cell.
 func TestDashboardGetDashboardIncludeLatest(t *testing.T) {
 	client := getOctopusClient()
 	require.NotNil(t, client)
@@ -259,6 +262,51 @@ func TestDashboardGetDashboardIncludeLatest(t *testing.T) {
 	board, err := client.Dashboards.GetDashboard(dashboard.DashboardQuery{IncludeLatest: true, ShowAll: true})
 	require.NoError(t, err)
 	require.NotNil(t, board)
+	require.False(t, board.IsFiltered)
+	skipWithoutItems(t, board)
+
+	projectIDs := map[string]bool{}
+	for _, project := range board.Projects {
+		projectIDs[project.GetID()] = true
+	}
+	environmentIDs := map[string]bool{}
+	for _, environment := range board.Environments {
+		environmentIDs[environment.GetID()] = true
+	}
+	tenantIDs := map[string]bool{}
+	for _, tenant := range board.Tenants {
+		tenantIDs[tenant.GetID()] = true
+	}
+
+	cells := map[string]bool{}
+	for _, item := range board.Items {
+		require.True(t, projectIDs[item.ProjectID], "item project %s missing from reference data", item.ProjectID)
+		require.True(t, environmentIDs[item.EnvironmentID], "item environment %s missing from reference data", item.EnvironmentID)
+		if item.TenantID != "" {
+			require.True(t, tenantIDs[item.TenantID], "item tenant %s missing from reference data", item.TenantID)
+		}
+
+		// Enough of a cell to render: which release is deployed, how it went,
+		// and a link to the deployment behind it.
+		require.NotEmpty(t, item.ReleaseVersion)
+		require.NotEmpty(t, item.State)
+		require.NotEmpty(t, item.TaskID)
+		require.NotEmpty(t, item.Links["Self"])
+		if item.IsCompleted {
+			require.NotNil(t, item.CompletedTime)
+		}
+
+		// This endpoint reports what is deployed now; previous deployments are
+		// only reachable through the dynamic dashboard's IncludePrevious.
+		require.True(t, item.IsCurrent)
+		require.False(t, item.IsPrevious)
+
+		// highestLatestVersionPerProjectAndEnvironment resolves each cell to one
+		// release, so a repeated cell means it did not do what its name says.
+		cell := fmt.Sprintf("%s/%s/%s", item.ProjectID, item.EnvironmentID, item.TenantID)
+		require.False(t, cells[cell], "two items for cell %s", cell)
+		cells[cell] = true
+	}
 }
 
 func TestDashboardGetDashboardFiltersByTenant(t *testing.T) {


### PR DESCRIPTION
Closes #442.

## `GetDashboard`

`DashboardService` implements the non-dynamic endpoint, reusing the existing `DashboardQuery` and the `Dashboard` type from #441. Expanded via the service's own URI template, as its siblings do.

Verified against a live server, counts from that instance:

| Request | Items | IsFiltered |
|---|---|---|
| no parameters | 10 | false |
| `projectId=<id>` | 3 | true |
| `projectId=<name>` | **0** | true |
| `releaseId=<id>` | 2 | true |
| `selectedTenants=<id>` | 1 | true |
| `selectedTags=Region/Aus-East` | 1 | true |
| `showAll=true` | 10 | false |
| `highestLatestVersionPerProjectAndEnvironment=true` | 10 | false |

Filters on IDs only, same as the dynamic endpoint: a name matches nothing and returns an empty dashboard rather than an error. `showAll` and `highestLatestVersion...` are accepted but had no observable effect on this dataset, so their behaviour is untested beyond the parameter reaching the server.

## `DashboardQuery.IncludeLatest`

It carried only a `url` tag. `uritemplates` reads `uri`, so it expanded to nothing:

```
DashboardQuery{ProjectID: "Projects-1", IncludeLatest: true, ShowAll: true}
  -> /api//dashboard?projectId=Projects-1&showAll=true
```

`highestLatestVersionPerProjectAndEnvironment` never reached the server. Adds the `uri` tag with `omitempty`, which is right because both bools are non-nullable and default to `false` server side.

## Audit test

`test/conventions` walks every `*Query` struct under `pkg/` and fails on any field without a `uri` tag, calling out `url`-only fields specifically. 98 structs across 626 files; `IncludeLatest` was the only violation. Confirmed it fails when the tag is removed.

It does not catch a `uri` tag whose name is absent from the template, nor a response type used as a query — which is what #437 was.