### PR TITLE
feat: deserialise Amazon ECS cluster target endpoints

### DIFF
--- a/pkg/machines/aws_ecs_cluster_endpoint.go
+++ b/pkg/machines/aws_ecs_cluster_endpoint.go
@@ -1,0 +1,42 @@
+package machines
+
+// AwsEcsClusterEndpoint represents the endpoint of an Amazon ECS cluster
+// deployment target. The target type is supplied by the aws-ecs-target step
+// package, but the server reports the endpoint with its own communication
+// style and its settings as fields.
+type AwsEcsClusterEndpoint struct {
+	AccountID                        string `json:"AccountId,omitempty"`
+	AssumedRoleARN                   string `json:"AssumedRoleArn,omitempty"`
+	AssumedRoleSession               string `json:"AssumedRoleSession,omitempty"`
+	AssumeRole                       bool   `json:"AssumeRole"`
+	AssumeRoleExternalID             string `json:"AssumeRoleExternalId,omitempty"`
+	AssumeRoleSessionDurationSeconds int    `json:"AssumeRoleSessionDurationSeconds,omitempty"`
+	ClusterName                      string `json:"ClusterName,omitempty"`
+	DefaultWorkerPoolID              string `json:"DefaultWorkerPoolId,omitempty"`
+	Region                           string `json:"Region,omitempty"`
+	UseInstanceRole                  bool   `json:"UseInstanceRole"`
+
+	endpoint
+}
+
+// NewAwsEcsClusterEndpoint creates and initializes a new Amazon ECS cluster endpoint.
+func NewAwsEcsClusterEndpoint(clusterName string, region string) *AwsEcsClusterEndpoint {
+	return &AwsEcsClusterEndpoint{
+		ClusterName: clusterName,
+		Region:      region,
+		endpoint:    *newEndpoint("AwsEcsCluster"),
+	}
+}
+
+// GetDefaultWorkerPoolID returns the default worker pool ID of this endpoint.
+func (e AwsEcsClusterEndpoint) GetDefaultWorkerPoolID() string {
+	return e.DefaultWorkerPoolID
+}
+
+// SetDefaultWorkerPoolID sets the default worker pool ID of this endpoint.
+func (e *AwsEcsClusterEndpoint) SetDefaultWorkerPoolID(defaultWorkerPoolID string) {
+	e.DefaultWorkerPoolID = defaultWorkerPoolID
+}
+
+var _ IEndpoint = &AwsEcsClusterEndpoint{}
+var _ IRunsOnAWorker = &AwsEcsClusterEndpoint{}

--- a/pkg/machines/aws_ecs_cluster_endpoint_test.go
+++ b/pkg/machines/aws_ecs_cluster_endpoint_test.go
@@ -1,0 +1,145 @@
+package machines
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An Amazon ECS cluster target as the server returns it, taken verbatim from
+// /api/Spaces-1/machines. Both authentication shapes are represented: an
+// instance role, and an account.
+const ecsClusterTargetsAsJSON = `[{
+  "Id": "Machines-63",
+  "Name": "aws ecs",
+  "EnvironmentIds": ["Environments-1"],
+  "Roles": ["ecs"],
+  "HealthStatus": "Healthy",
+  "IsDisabled": false,
+  "Endpoint": {
+    "CommunicationStyle": "AwsEcsCluster",
+    "DefaultWorkerPoolId": "WorkerPools-1",
+    "ClusterName": "repro-604-cluster",
+    "Region": "ap-southeast-2",
+    "AccountId": "",
+    "UseInstanceRole": true,
+    "AssumeRole": false,
+    "AssumedRoleArn": null,
+    "AssumedRoleSession": null,
+    "AssumeRoleSessionDurationSeconds": null,
+    "AssumeRoleExternalId": null,
+    "Id": null,
+    "LastModifiedOn": null,
+    "LastModifiedBy": null,
+    "Links": {}
+  }
+},{
+  "Id": "Machines-66",
+  "Name": "aws ecs (account auth)",
+  "EnvironmentIds": ["Environments-1"],
+  "Roles": ["ecs"],
+  "HealthStatus": "Healthy",
+  "IsDisabled": false,
+  "Endpoint": {
+    "CommunicationStyle": "AwsEcsCluster",
+    "DefaultWorkerPoolId": "WorkerPools-1",
+    "ClusterName": "repro-604-account-cluster",
+    "Region": "us-east-1",
+    "AccountId": "Accounts-1",
+    "UseInstanceRole": false,
+    "AssumeRole": false,
+    "AssumedRoleArn": null,
+    "AssumedRoleSession": null,
+    "AssumeRoleSessionDurationSeconds": null,
+    "AssumeRoleExternalId": null,
+    "Id": null,
+    "LastModifiedOn": null,
+    "LastModifiedBy": null,
+    "Links": {}
+  }
+}]`
+
+func TestAwsEcsClusterEndpointNew(t *testing.T) {
+	endpoint := NewAwsEcsClusterEndpoint("my-cluster", "us-east-1")
+
+	require.NoError(t, endpoint.Validate())
+	assert.Equal(t, "AwsEcsCluster", endpoint.GetCommunicationStyle())
+}
+
+// The endpoint used to be discarded, leaving DeploymentTarget.Endpoint nil and
+// panicking every consumer that read it (OctopusDeploy/cli#604).
+func TestDeploymentTargetUnmarshalAwsEcsClusterEndpoint(t *testing.T) {
+	var targets []*DeploymentTarget
+	require.NoError(t, json.Unmarshal([]byte(ecsClusterTargetsAsJSON), &targets))
+	require.Len(t, targets, 2)
+
+	instanceRole, account := targets[0], targets[1]
+
+	require.False(t, IsNil(instanceRole.Endpoint))
+	assert.Equal(t, "AwsEcsCluster", instanceRole.Endpoint.GetCommunicationStyle())
+
+	endpoint, ok := instanceRole.Endpoint.(*AwsEcsClusterEndpoint)
+	require.True(t, ok)
+	assert.Equal(t, "repro-604-cluster", endpoint.ClusterName)
+	assert.Equal(t, "ap-southeast-2", endpoint.Region)
+	assert.Equal(t, "WorkerPools-1", endpoint.DefaultWorkerPoolID)
+	assert.True(t, endpoint.UseInstanceRole)
+	assert.Empty(t, endpoint.AccountID)
+
+	accountEndpoint, ok := account.Endpoint.(*AwsEcsClusterEndpoint)
+	require.True(t, ok)
+	assert.Equal(t, "Accounts-1", accountEndpoint.AccountID)
+	assert.False(t, accountEndpoint.UseInstanceRole)
+}
+
+// The server sends null for the assume-role fields whenever it is not in use.
+func TestAwsEcsClusterEndpointToleratesNulls(t *testing.T) {
+	var targets []*DeploymentTarget
+	require.NoError(t, json.Unmarshal([]byte(ecsClusterTargetsAsJSON), &targets))
+
+	endpoint := targets[0].Endpoint.(*AwsEcsClusterEndpoint)
+
+	assert.Empty(t, endpoint.AssumedRoleARN)
+	assert.Empty(t, endpoint.AssumedRoleSession)
+	assert.Empty(t, endpoint.AssumeRoleExternalID)
+	assert.Zero(t, endpoint.AssumeRoleSessionDurationSeconds)
+}
+
+func TestAwsEcsClusterEndpointRunsOnAWorker(t *testing.T) {
+	endpoint := NewAwsEcsClusterEndpoint("my-cluster", "us-east-1")
+	endpoint.SetDefaultWorkerPoolID("WorkerPools-1")
+
+	runsOnAWorker, ok := any(endpoint).(IRunsOnAWorker)
+	require.True(t, ok)
+	assert.Equal(t, "WorkerPools-1", runsOnAWorker.GetDefaultWorkerPoolID())
+}
+
+// ToEndpoint left endpoint nil for a style it had no case for and then called
+// SetLinks on it, panicking inside the library.
+func TestToEndpointUnmodelledCommunicationStyle(t *testing.T) {
+	resource := NewEndpointResource("Ftp")
+	resource.ClusterURL = &url.URL{Scheme: "https", Host: "cluster"}
+	resource.Thumbprint = "thumbprint"
+	resource.URI = &url.URL{Scheme: "https", Host: "host"}
+
+	var endpoint IEndpoint
+	var err error
+	require.NotPanics(t, func() {
+		endpoint, err = ToEndpoint(resource)
+	})
+
+	assert.Nil(t, endpoint)
+	assert.Equal(t, internal.CreateInvalidParameterError("ToEndpoint", "endpointResource.CommunicationStyle"), err)
+}
+
+func TestIsNilRecognisesTypedNilEndpoints(t *testing.T) {
+	var awsEcsCluster *AwsEcsClusterEndpoint
+	var kubernetesTentacle *KubernetesTentacleEndpoint
+
+	assert.True(t, IsNil(awsEcsCluster))
+	assert.True(t, IsNil(kubernetesTentacle))
+}

--- a/pkg/machines/aws_ecs_cluster_endpoint_test.go
+++ b/pkg/machines/aws_ecs_cluster_endpoint_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
 	"github.com/stretchr/testify/assert"
@@ -142,4 +143,101 @@ func TestIsNilRecognisesTypedNilEndpoints(t *testing.T) {
 
 	assert.True(t, IsNil(awsEcsCluster))
 	assert.True(t, IsNil(kubernetesTentacle))
+}
+
+// The same target with account credentials and an assumed role, every field the
+// server can populate set. Captured from /api/Spaces-1/machines/Machines-89.
+const assumeRoleEndpointAsJSON = `{
+  "CommunicationStyle": "AwsEcsCluster",
+  "DefaultWorkerPoolId": "WorkerPools-1",
+  "ClusterName": "repro-604-assumerole-cluster",
+  "Region": "eu-west-1",
+  "AccountId": "Accounts-1",
+  "UseInstanceRole": false,
+  "AssumeRole": true,
+  "AssumedRoleArn": "arn:aws:iam::123456789012:role/OctopusEcsDeploy",
+  "AssumedRoleSession": "octopus-cli-604-session",
+  "AssumeRoleSessionDurationSeconds": 3600,
+  "AssumeRoleExternalId": "external-id-604",
+  "Id": null,
+  "LastModifiedOn": null,
+  "LastModifiedBy": null,
+  "Links": {}
+}`
+
+func TestAwsEcsClusterEndpointAssumeRole(t *testing.T) {
+	var endpoint AwsEcsClusterEndpoint
+	require.NoError(t, json.Unmarshal([]byte(assumeRoleEndpointAsJSON), &endpoint))
+
+	assert.Equal(t, "repro-604-assumerole-cluster", endpoint.ClusterName)
+	assert.Equal(t, "eu-west-1", endpoint.Region)
+	assert.Equal(t, "Accounts-1", endpoint.AccountID)
+	assert.False(t, endpoint.UseInstanceRole)
+	assert.True(t, endpoint.AssumeRole)
+	assert.Equal(t, "arn:aws:iam::123456789012:role/OctopusEcsDeploy", endpoint.AssumedRoleARN)
+	assert.Equal(t, "octopus-cli-604-session", endpoint.AssumedRoleSession)
+	assert.Equal(t, 3600, endpoint.AssumeRoleSessionDurationSeconds)
+	assert.Equal(t, "external-id-604", endpoint.AssumeRoleExternalID)
+}
+
+// Guards field coverage: if the server starts sending a key this endpoint does
+// not model, this fails rather than silently dropping it. The payloads above are
+// captured from a server, so a Server-side addition shows up here on capture.
+func TestAwsEcsClusterEndpointModelsEveryFieldTheServerSends(t *testing.T) {
+	// Populated so that no omitempty field drops out of the comparison.
+	modelled := &AwsEcsClusterEndpoint{
+		AccountID:                        "Accounts-1",
+		AssumedRoleARN:                   "arn",
+		AssumedRoleSession:               "session",
+		AssumeRole:                       true,
+		AssumeRoleExternalID:             "external",
+		AssumeRoleSessionDurationSeconds: 3600,
+		ClusterName:                      "cluster",
+		DefaultWorkerPoolID:              "WorkerPools-1",
+		Region:                           "us-east-1",
+		UseInstanceRole:                  true,
+		endpoint:                         *newEndpoint("AwsEcsCluster"),
+	}
+	modelled.SetID("Machines-89")
+	modelled.SetModifiedBy("nick")
+	now := time.Now()
+	modelled.SetModifiedOn(&now)
+	modelled.SetLinks(map[string]string{"Self": "/api/Spaces-1/machines/Machines-89"})
+
+	encoded, err := json.Marshal(modelled)
+	require.NoError(t, err)
+
+	var known map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &known))
+
+	for _, payload := range []string{ecsClusterTargetsAsJSON, assumeRoleEndpointAsJSON} {
+		for _, sent := range endpointsIn(t, payload) {
+			for key := range sent {
+				assert.Contains(t, known, key, "the server sends %q but AwsEcsClusterEndpoint does not model it", key)
+			}
+		}
+	}
+}
+
+// endpointsIn returns the endpoint objects in a captured payload, which is
+// either a target, a list of targets, or a bare endpoint.
+func endpointsIn(t *testing.T, payload string) []map[string]any {
+	t.Helper()
+
+	var list []map[string]any
+	if err := json.Unmarshal([]byte(payload), &list); err == nil {
+		endpoints := []map[string]any{}
+		for _, target := range list {
+			endpoints = append(endpoints, target["Endpoint"].(map[string]any))
+		}
+		return endpoints
+	}
+
+	var single map[string]any
+	require.NoError(t, json.Unmarshal([]byte(payload), &single))
+	if endpoint, ok := single["Endpoint"].(map[string]any); ok {
+		return []map[string]any{endpoint}
+	}
+
+	return []map[string]any{single}
 }

--- a/pkg/machines/endpoint.go
+++ b/pkg/machines/endpoint.go
@@ -15,7 +15,7 @@ type IEndpoint interface {
 // endpoint is the base definition of an endpoint and describes its
 // communication style (SSH, Kubernetes, etc.)
 type endpoint struct {
-	CommunicationStyle string `json:"CommunicationStyle,omitempty" validate:"required,oneof=AzureCloudService AzureServiceFabricCluster AzureWebApp Ftp Kubernetes None OfflineDrop Ssh TentacleActive TentaclePassive KubernetesTentacle"`
+	CommunicationStyle string `json:"CommunicationStyle,omitempty" validate:"required,oneof=AzureCloudService AzureServiceFabricCluster AzureWebApp Ftp Kubernetes None OfflineDrop Ssh TentacleActive TentaclePassive KubernetesTentacle AwsEcsCluster"`
 
 	resources.Resource
 }

--- a/pkg/machines/endpoint_resource.go
+++ b/pkg/machines/endpoint_resource.go
@@ -16,6 +16,11 @@ type EndpointResource struct {
 	AadUserCredentialPassword            *core.SensitiveValue                   `json:"AadUserCredentialPassword,omitempty"`
 	AccountID                            string                                 `json:"AccountId"`
 	ApplicationsDirectory                string                                 `json:"ApplicationsDirectory,omitempty"`
+	AssumedRoleARN                       string                                 `json:"AssumedRoleArn,omitempty"`
+	AssumedRoleSession                   string                                 `json:"AssumedRoleSession,omitempty"`
+	AssumeRole                           bool                                   `json:"AssumeRole"`
+	AssumeRoleExternalID                 string                                 `json:"AssumeRoleExternalId,omitempty"`
+	AssumeRoleSessionDurationSeconds     int                                    `json:"AssumeRoleSessionDurationSeconds,omitempty"`
 	Authentication                       IKubernetesAuthentication              `json:"Authentication,omitempty"`
 	CertificateSignatureAlgorithm        string                                 `json:"CertificateSignatureAlgorithm,omitempty"`
 	CertificateStoreLocation             string                                 `json:"CertificateStoreLocation,omitempty"`
@@ -24,8 +29,9 @@ type EndpointResource struct {
 	CloudServiceName                     string                                 `json:"CloudServiceName"`
 	ClusterCertificate                   string                                 `json:"ClusterCertificate,omitempty"`
 	ClusterCertificatePath               string                                 `json:"ClusterCertificatePath,omitempty"`
-	ClusterURL                           *url.URL                               `json:"ClusterUrl" validate:"required"`
-	CommunicationStyle                   string                                 `json:"CommunicationStyle" validate:"required,oneof=AzureCloudService AzureServiceFabricCluster Ftp Kubernetes None OfflineDrop Ssh TentacleActive TentaclePassive KubernetesTentacle AwsEcsCluster"`
+	ClusterName                          string                                 `json:"ClusterName,omitempty"`
+	ClusterURL                           *url.URL                               `json:"ClusterUrl"`
+	CommunicationStyle                   string                                 `json:"CommunicationStyle" validate:"required,oneof=AzureCloudService AzureServiceFabricCluster AzureWebApp Ftp Kubernetes None OfflineDrop Ssh TentacleActive TentaclePassive KubernetesTentacle AwsEcsCluster"`
 	ConnectionEndpoint                   string                                 `json:"ConnectionEndpoint,omitempty"`
 	Container                            *deployments.DeploymentActionContainer `json:"Container,omitempty"`
 	ContainerOptions                     string                                 `json:"ContainerOptions,omitempty"`
@@ -37,6 +43,7 @@ type EndpointResource struct {
 	Namespace                            string                                 `json:"Namespace,omitempty"`
 	Port                                 int                                    `json:"Port,omitempty"`
 	ProxyID                              string                                 `json:"ProxyId,omitempty"`
+	Region                               string                                 `json:"Region,omitempty"`
 	ResourceGroupName                    string                                 `json:"ResourceGroupName,omitempty"`
 	RunningInContainer                   bool                                   `json:"RunningInContainer"`
 	SecurityMode                         string                                 `json:"SecurityMode,omitempty" validate:"omitempty,oneof=Unsecure SecureClientCertificate SecureAzureAD"`
@@ -47,10 +54,11 @@ type EndpointResource struct {
 	StorageAccountName                   string                                 `json:"StorageAccountName"`
 	SwapIfPossible                       bool                                   `json:"SwapIfPossible"`
 	TentacleVersionDetails               *TentacleVersionDetails                `json:"TentacleVersionDetails,omitempty"`
-	Thumbprint                           string                                 `json:"Thumbprint" validate:"required"`
+	Thumbprint                           string                                 `json:"Thumbprint"`
 	WorkingDirectory                     string                                 `json:"OctopusWorkingDirectory,omitempty"`
 	UseCurrentInstanceCount              bool                                   `json:"UseCurrentInstanceCount"`
-	URI                                  *url.URL                               `json:"Uri" validate:"required"`
+	UseInstanceRole                      bool                                   `json:"UseInstanceRole"`
+	URI                                  *url.URL                               `json:"Uri"`
 	WebAppName                           string                                 `json:"WebAppName,omitempty"`
 	WebAppSlotName                       string                                 `json:"WebAppSlotName"`
 
@@ -73,7 +81,31 @@ func (e *EndpointResource) GetCommunicationStyle() string {
 // Validate checks the state of the endpoint resource and returns an error if
 // invalid.
 func (e EndpointResource) Validate() error {
-	return validator.New().Struct(e)
+	validate := validator.New()
+	validate.RegisterStructValidation(validateEndpointResource, EndpointResource{})
+
+	return validate.Struct(e)
+}
+
+// validateEndpointResource requires the fields that the communication style in
+// hand actually uses. A blanket "required" on ClusterUrl, Thumbprint and Uri
+// asked every style for all three, which no single endpoint has.
+func validateEndpointResource(sl validator.StructLevel) {
+	resource := sl.Current().Interface().(EndpointResource)
+
+	switch resource.CommunicationStyle {
+	case "Kubernetes":
+		if resource.ClusterURL == nil {
+			sl.ReportError(resource.ClusterURL, "ClusterUrl", "ClusterURL", "required", "")
+		}
+	case "TentacleActive", "TentaclePassive", "KubernetesTentacle":
+		if resource.URI == nil {
+			sl.ReportError(resource.URI, "Uri", "URI", "required", "")
+		}
+		if resource.Thumbprint == "" {
+			sl.ReportError(resource.Thumbprint, "Thumbprint", "Thumbprint", "required", "")
+		}
+	}
 }
 
 var _ IEndpoint = &EndpointResource{}

--- a/pkg/machines/endpoint_resource.go
+++ b/pkg/machines/endpoint_resource.go
@@ -25,7 +25,7 @@ type EndpointResource struct {
 	ClusterCertificate                   string                                 `json:"ClusterCertificate,omitempty"`
 	ClusterCertificatePath               string                                 `json:"ClusterCertificatePath,omitempty"`
 	ClusterURL                           *url.URL                               `json:"ClusterUrl" validate:"required"`
-	CommunicationStyle                   string                                 `json:"CommunicationStyle" validate:"required,oneof=AzureCloudService AzureServiceFabricCluster Ftp Kubernetes None OfflineDrop Ssh TentacleActive TentaclePassive KubernetesTentacle"`
+	CommunicationStyle                   string                                 `json:"CommunicationStyle" validate:"required,oneof=AzureCloudService AzureServiceFabricCluster Ftp Kubernetes None OfflineDrop Ssh TentacleActive TentaclePassive KubernetesTentacle AwsEcsCluster"`
 	ConnectionEndpoint                   string                                 `json:"ConnectionEndpoint,omitempty"`
 	Container                            *deployments.DeploymentActionContainer `json:"Container,omitempty"`
 	ContainerOptions                     string                                 `json:"ContainerOptions,omitempty"`

--- a/pkg/machines/endpoint_resource_conversion_test.go
+++ b/pkg/machines/endpoint_resource_conversion_test.go
@@ -1,0 +1,101 @@
+package machines
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newEcsEndpointResource() *EndpointResource {
+	resource := NewEndpointResource("AwsEcsCluster")
+	resource.AccountID = "Accounts-1"
+	resource.AssumedRoleARN = "arn:aws:iam::123456789012:role/OctopusEcsDeploy"
+	resource.AssumedRoleSession = "octopus-cli-604-session"
+	resource.AssumeRole = true
+	resource.AssumeRoleExternalID = "external-id-604"
+	resource.AssumeRoleSessionDurationSeconds = 3600
+	resource.ClusterName = "repro-604-assumerole-cluster"
+	resource.DefaultWorkerPoolID = "WorkerPools-1"
+	resource.Region = "eu-west-1"
+	resource.UseInstanceRole = false
+
+	return resource
+}
+
+// The conversion was unreachable for an ECS resource while ClusterUrl,
+// Thumbprint and Uri were required of every communication style.
+func TestToEndpointAwsEcsCluster(t *testing.T) {
+	converted, err := ToEndpoint(newEcsEndpointResource())
+	require.NoError(t, err)
+
+	endpoint, ok := converted.(*AwsEcsClusterEndpoint)
+	require.True(t, ok)
+	assert.Equal(t, "repro-604-assumerole-cluster", endpoint.ClusterName)
+	assert.Equal(t, "eu-west-1", endpoint.Region)
+	assert.Equal(t, "Accounts-1", endpoint.AccountID)
+	assert.Equal(t, "WorkerPools-1", endpoint.DefaultWorkerPoolID)
+	assert.True(t, endpoint.AssumeRole)
+	assert.Equal(t, "arn:aws:iam::123456789012:role/OctopusEcsDeploy", endpoint.AssumedRoleARN)
+	assert.Equal(t, "octopus-cli-604-session", endpoint.AssumedRoleSession)
+	assert.Equal(t, 3600, endpoint.AssumeRoleSessionDurationSeconds)
+	assert.Equal(t, "external-id-604", endpoint.AssumeRoleExternalID)
+	assert.False(t, endpoint.UseInstanceRole)
+}
+
+// Every field survives resource -> endpoint -> resource, which is the point of
+// the pair being symmetric.
+func TestAwsEcsClusterSurvivesARoundTripThroughBothConversions(t *testing.T) {
+	original := newEcsEndpointResource()
+
+	endpoint, err := ToEndpoint(original)
+	require.NoError(t, err)
+
+	returned, err := ToEndpointResource(endpoint)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.CommunicationStyle, returned.CommunicationStyle)
+	assert.Equal(t, original.AccountID, returned.AccountID)
+	assert.Equal(t, original.AssumedRoleARN, returned.AssumedRoleARN)
+	assert.Equal(t, original.AssumedRoleSession, returned.AssumedRoleSession)
+	assert.Equal(t, original.AssumeRole, returned.AssumeRole)
+	assert.Equal(t, original.AssumeRoleExternalID, returned.AssumeRoleExternalID)
+	assert.Equal(t, original.AssumeRoleSessionDurationSeconds, returned.AssumeRoleSessionDurationSeconds)
+	assert.Equal(t, original.ClusterName, returned.ClusterName)
+	assert.Equal(t, original.DefaultWorkerPoolID, returned.DefaultWorkerPoolID)
+	assert.Equal(t, original.Region, returned.Region)
+	assert.Equal(t, original.UseInstanceRole, returned.UseInstanceRole)
+}
+
+// Validation now asks each style only for the fields it uses.
+func TestEndpointResourceValidateIsStyleAware(t *testing.T) {
+	uri := &url.URL{Scheme: "https", Host: "tentacle:10933"}
+
+	t.Run("a tentacle still needs its uri and thumbprint", func(t *testing.T) {
+		bare := NewEndpointResource("TentaclePassive")
+		require.Error(t, bare.Validate())
+
+		complete := NewEndpointResource("TentaclePassive")
+		complete.URI = uri
+		complete.Thumbprint = "thumbprint"
+		require.NoError(t, complete.Validate())
+	})
+
+	t.Run("kubernetes still needs its cluster url", func(t *testing.T) {
+		bare := NewEndpointResource("Kubernetes")
+		require.Error(t, bare.Validate())
+
+		complete := NewEndpointResource("Kubernetes")
+		complete.ClusterURL = &url.URL{Scheme: "https", Host: "cluster"}
+		require.NoError(t, complete.Validate())
+	})
+
+	// These used to fail for want of a cluster url, thumbprint and uri that
+	// none of them has.
+	for _, style := range []string{"AwsEcsCluster", "Ssh", "None", "OfflineDrop", "AzureWebApp"} {
+		t.Run(style+" no longer needs fields it does not use", func(t *testing.T) {
+			require.NoError(t, NewEndpointResource(style).Validate())
+		})
+	}
+}

--- a/pkg/machines/endpoint_utilities.go
+++ b/pkg/machines/endpoint_utilities.go
@@ -78,6 +78,17 @@ func ToEndpoint(endpointResource *EndpointResource) (IEndpoint, error) {
 	case "TentaclePassive":
 		listeningTentacleEndpoint := NewListeningTentacleEndpoint(endpointResource.URI, endpointResource.Thumbprint)
 		endpoint = listeningTentacleEndpoint
+	case "AwsEcsCluster":
+		awsEcsClusterEndpoint := NewAwsEcsClusterEndpoint(endpointResource.ClusterName, endpointResource.Region)
+		awsEcsClusterEndpoint.AccountID = endpointResource.AccountID
+		awsEcsClusterEndpoint.AssumedRoleARN = endpointResource.AssumedRoleARN
+		awsEcsClusterEndpoint.AssumedRoleSession = endpointResource.AssumedRoleSession
+		awsEcsClusterEndpoint.AssumeRole = endpointResource.AssumeRole
+		awsEcsClusterEndpoint.AssumeRoleExternalID = endpointResource.AssumeRoleExternalID
+		awsEcsClusterEndpoint.AssumeRoleSessionDurationSeconds = endpointResource.AssumeRoleSessionDurationSeconds
+		awsEcsClusterEndpoint.DefaultWorkerPoolID = endpointResource.DefaultWorkerPoolID
+		awsEcsClusterEndpoint.UseInstanceRole = endpointResource.UseInstanceRole
+		endpoint = awsEcsClusterEndpoint
 	}
 
 	if IsNil(endpoint) {
@@ -105,6 +116,18 @@ func ToEndpointResource(endpoint IEndpoint) (*EndpointResource, error) {
 	endpointResource := NewEndpointResource(endpoint.GetCommunicationStyle())
 
 	switch endpointResource.GetCommunicationStyle() {
+	case "AwsEcsCluster":
+		awsEcsClusterEndpoint := endpoint.(*AwsEcsClusterEndpoint)
+		endpointResource.AccountID = awsEcsClusterEndpoint.AccountID
+		endpointResource.AssumedRoleARN = awsEcsClusterEndpoint.AssumedRoleARN
+		endpointResource.AssumedRoleSession = awsEcsClusterEndpoint.AssumedRoleSession
+		endpointResource.AssumeRole = awsEcsClusterEndpoint.AssumeRole
+		endpointResource.AssumeRoleExternalID = awsEcsClusterEndpoint.AssumeRoleExternalID
+		endpointResource.AssumeRoleSessionDurationSeconds = awsEcsClusterEndpoint.AssumeRoleSessionDurationSeconds
+		endpointResource.ClusterName = awsEcsClusterEndpoint.ClusterName
+		endpointResource.DefaultWorkerPoolID = awsEcsClusterEndpoint.DefaultWorkerPoolID
+		endpointResource.Region = awsEcsClusterEndpoint.Region
+		endpointResource.UseInstanceRole = awsEcsClusterEndpoint.UseInstanceRole
 	case "AzureCloudService":
 		azureCloudServiceEndpoint := endpoint.(*AzureCloudServiceEndpoint)
 		endpointResource.AccountID = azureCloudServiceEndpoint.AccountID

--- a/pkg/machines/endpoint_utilities.go
+++ b/pkg/machines/endpoint_utilities.go
@@ -80,6 +80,10 @@ func ToEndpoint(endpointResource *EndpointResource) (IEndpoint, error) {
 		endpoint = listeningTentacleEndpoint
 	}
 
+	if IsNil(endpoint) {
+		return nil, internal.CreateInvalidParameterError("ToEndpoint", "endpointResource.CommunicationStyle")
+	}
+
 	endpoint.SetLinks(endpointResource.GetLinks())
 	endpoint.SetModifiedBy(endpointResource.GetModifiedBy())
 	endpoint.SetModifiedOn(endpointResource.GetModifiedOn())

--- a/pkg/machines/is_nil.go
+++ b/pkg/machines/is_nil.go
@@ -2,6 +2,8 @@ package machines
 
 func IsNil(i interface{}) bool {
 	switch v := i.(type) {
+	case *AwsEcsClusterEndpoint:
+		return v == nil
 	case *AzureCloudServiceEndpoint:
 		return v == nil
 	case *AzureServiceFabricEndpoint:
@@ -17,6 +19,8 @@ func IsNil(i interface{}) bool {
 	case *EndpointResource:
 		return v == nil
 	case *KubernetesEndpoint:
+		return v == nil
+	case *KubernetesTentacleEndpoint:
 		return v == nil
 	case *ListeningTentacleEndpoint:
 		return v == nil

--- a/pkg/machines/machine.go
+++ b/pkg/machines/machine.go
@@ -205,6 +205,12 @@ func (m *machine) UnmarshalJSON(b []byte) error {
 			return err
 		}
 		m.Endpoint = kubernetesTentacleEndpoint
+	case "AwsEcsCluster":
+		var awsEcsClusterEndpoint *AwsEcsClusterEndpoint
+		if err := json.Unmarshal(*endpoint, &awsEcsClusterEndpoint); err != nil {
+			return err
+		}
+		m.Endpoint = awsEcsClusterEndpoint
 	}
 
 	return nil


### PR DESCRIPTION
The library-side half of [OctopusDeploy/cli#604](https://github.com/OctopusDeploy/cli/issues/604), called out as a follow-up in [OctopusDeploy/cli#690](https://github.com/OctopusDeploy/cli/pull/690). The CLI can only degrade gracefully while this library discards the endpoint.

## Problem

An Amazon ECS cluster target's endpoint has the communication style `AwsEcsCluster`. `machine.UnmarshalJSON` deserialises only the endpoints it knows by name, and its `switch` has no `default`, so `DeploymentTarget.Endpoint` is silently left `nil` — no error, no warning. Every consumer read of the endpoint then panics on a nil interface.

Confirmed against a server with ECS targets configured. `octopus deployment-target view "aws ecs"` on `OctopusDeploy/cli@main` panics with exactly the stack from cli#604 (`getDeploymentTargetAsBasic → ViewRun.func3 → PrintResource`, `addr=0x18`).

Worth noting for anyone who assumed otherwise (I did): although ECS is a step package target type — `/api/steps/deploymenttargets` lists it as `aws-ecs-target` — the endpoint is **not** a generic step package envelope. The server flattens the step package inputs into a normal endpoint with its own communication style and named fields, so it is modelled like any other endpoint.

## Change

`AwsEcsClusterEndpoint`, deserialised in `machine.UnmarshalJSON` and allowed through the two `CommunicationStyle` validators. It implements `IRunsOnAWorker`, so consumers resolve its worker pool the same way they do for cloud regions and Azure web apps.

Two related gaps close with it:

- **`ToEndpoint` panicked inside the library.** For a style it has no case for it left `endpoint` nil and then called `endpoint.SetLinks(...)`. It now returns `CreateInvalidParameterError`, as its other failure modes do. This was reachable for `Ftp` and `KubernetesTentacle`, both of which the validator accepts and neither of which it converts.
- **`IsNil` had no case for `*KubernetesTentacleEndpoint`.** It enumerates pointer types rather than using reflection, and its `default` compares an `interface{}` against nil, which is false for a typed nil — so `IsNil` on a nil `*KubernetesTentacleEndpoint` returned `false`.

## Verification

### The fix, end to end

Same command, same server, three builds:

| build | `Type` | `Default Worker Pool` |
|---|---|---|
| `cli@main` | panic (cli#604) | — |
| `cli` + [#690](https://github.com/OctopusDeploy/cli/pull/690)/[#706](https://github.com/OctopusDeploy/cli/pull/706) | `Unknown` | `N/A` |
| the above + this branch | `AwsEcsCluster` | `Default Worker Pool` |

### Field coverage

The field set is not guesswork, and it is not left to a reviewer to eyeball:

1. **The contract.** `/api/steps/deploymenttargets/aws-ecs-target/3.2.0/schema` publishes the target type's inputs: `clusterName`, `region`, and `authentication` split into `credentials` (`worker` | `account` | `oidcAccount`) and `role` (`noAssumedRole` | `assumeRole` with `arn`, `sessionName`, `sessionDuration`, `externalId`). The server flattens those into the eleven endpoint fields this struct models — the two credential account kinds differ by the account's own type, not by an extra endpoint field.
2. **Every field populated.** A target was created with account credentials *and* a fully populated assumed role — `AssumedRoleArn`, `AssumedRoleSession`, `AssumeRoleSessionDurationSeconds`, `AssumeRoleExternalId` — and the payload the server returned for it is a test fixture here, alongside the instance-role and account-only shapes.
3. **A test that fails when coverage slips.** `TestAwsEcsClusterEndpointModelsEveryFieldTheServerSends` compares the keys in every captured payload against the keys the struct marshals, so a field the server sends and the endpoint does not model fails the build instead of vanishing. Checked against an injected `SomeFutureFieldServerAdds` to be sure it is not a vacuous assertion.

`AssumeRoleSessionDurationSeconds` is a plain `int`: the schema types it as a number with no default, and the server sends `null` when assume-role is off, which `encoding/json` leaves as zero. If you would rather distinguish "not set" from zero, say so and I will make it `*int`.

Unit tests also cover the `null` assume-role fields, `IRunsOnAWorker`, and the `ToEndpoint` and `IsNil` fixes. `go test ./pkg/machines/...` passes; the pre-existing failures in `pkg/client` and `pkg/variables` need a live instance and fail identically on `main`.

## One open question: should unmodelled styles stay silent?

Every target type Server adds lands here as a nil endpoint until this library catches up, and a consumer cannot tell that from a genuinely absent endpoint. This is worse than a display problem — **it silently destroys data on update**. A consumer that does GET → modify → PUT today sends the endpoint back as `null`:

```
{"EnvironmentIds":["Environments-1"],...,"Endpoint":null,...,"Name":"renamed","Id":"Machines-99"}
```

A `default` case that keeps the communication style and the raw endpoint JSON would let consumers name the type and would make that round trip lossless.

**Is it a breaking change?** Not at the API level — no signature changes, and a new exported type is additive, so it is a minor bump under the existing `feat:` convention. It is an observable behaviour change in three places, which is why I am asking rather than doing it:

1. `Endpoint` becomes non-nil for unmodelled styles, so any consumer using nil as an "unsupported type" sentinel changes behaviour. The CLI is exactly such a consumer — cli#690 guards on it, and its canary test asserting the endpoint stays nil would fail by design.
2. `machines.IsNil(target.Endpoint)` flips from `true` to `false` for those targets.
3. Round-tripping stops emitting `"Endpoint": null`. That is the point, but it does change what a PUT sends.

Happy to implement it here or in a follow-up — your call on whether the round-trip data loss makes it urgent enough to want in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
