### PR TITLE
Fix: allow a machine policy health check interval to be omitted

### DIFF
--- a/pkg/machinepolicies/duration_formatter.go
+++ b/pkg/machinepolicies/duration_formatter.go
@@ -3,6 +3,7 @@ package machinepolicies
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -30,20 +31,52 @@ func ToTimeSpan(duration time.Duration) string {
 	return fmt.Sprintf("%02d.%02d:%02d:%02d.%05d", days, hours, minutes, seconds, secondsFraction)
 }
 
+// FromTimeSpan parses a .NET TimeSpan ("[-][d.]hh:mm:ss[.fffffff]") into a duration.
 func FromTimeSpan(timeSpan string) time.Duration {
-	if len(timeSpan) == 8 {
-		hours, _ := strconv.ParseInt(timeSpan[0:2], 10, 64)
-		minutes, _ := strconv.ParseInt(timeSpan[3:5], 10, 64)
-		seconds, _ := strconv.ParseInt(timeSpan[6:8], 10, 64)
-		duration, _ := time.ParseDuration(fmt.Sprintf("%dh%dm%ds", hours, minutes, seconds))
-		return duration
+	if timeSpan == "" {
+		return 0
 	}
 
-	days, _ := strconv.ParseInt(timeSpan[0:0], 10, 32)
-	hours, _ := strconv.ParseInt(timeSpan[2:4], 10, 64)
-	hours += (days * 24)
-	minutes, _ := strconv.ParseInt(timeSpan[5:7], 10, 64)
-	seconds, _ := strconv.ParseInt(timeSpan[8:10], 10, 64)
-	duration, _ := time.ParseDuration(fmt.Sprintf("%dh%dm%ds", hours, minutes, seconds))
+	negative := strings.HasPrefix(timeSpan, "-")
+	if negative {
+		timeSpan = timeSpan[1:]
+	}
+
+	var days int64
+	if dot := strings.IndexByte(timeSpan, '.'); dot >= 0 && dot < strings.IndexByte(timeSpan, ':') {
+		days, _ = strconv.ParseInt(timeSpan[:dot], 10, 64)
+		timeSpan = timeSpan[dot+1:]
+	}
+
+	var fraction time.Duration
+	if dot := strings.IndexByte(timeSpan, '.'); dot >= 0 {
+		// .NET fractional seconds are ticks of 100ns, up to 7 digits.
+		ticks := timeSpan[dot+1:]
+		if len(ticks) > 7 {
+			ticks = ticks[:7]
+		}
+		ticks += strings.Repeat("0", 7-len(ticks))
+		parsed, _ := strconv.ParseInt(ticks, 10, 64)
+		fraction = time.Duration(parsed) * 100 * time.Nanosecond
+		timeSpan = timeSpan[:dot]
+	}
+
+	parts := strings.Split(timeSpan, ":")
+	if len(parts) != 3 {
+		return 0
+	}
+	hours, _ := strconv.ParseInt(parts[0], 10, 64)
+	minutes, _ := strconv.ParseInt(parts[1], 10, 64)
+	seconds, _ := strconv.ParseInt(parts[2], 10, 64)
+
+	duration := time.Duration(days)*24*time.Hour +
+		time.Duration(hours)*time.Hour +
+		time.Duration(minutes)*time.Minute +
+		time.Duration(seconds)*time.Second +
+		fraction
+
+	if negative {
+		return -duration
+	}
 	return duration
 }

--- a/pkg/machinepolicies/duration_formatter_test.go
+++ b/pkg/machinepolicies/duration_formatter_test.go
@@ -1,0 +1,54 @@
+package machinepolicies
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromTimeSpanParsesDayComponent(t *testing.T) {
+	assert.Equal(t, 24*time.Hour, FromTimeSpan("1.00:00:00"))
+	assert.Equal(t, 24*time.Hour, FromTimeSpan("01.00:00:00"))
+	assert.Equal(t, 48*time.Hour, FromTimeSpan("2.00:00:00"))
+	assert.Equal(t, 25*time.Hour+30*time.Minute, FromTimeSpan("1.01:30:00"))
+}
+
+func TestFromTimeSpanParsesTimeOnly(t *testing.T) {
+	assert.Equal(t, time.Duration(0), FromTimeSpan("00:00:00"))
+	assert.Equal(t, time.Second, FromTimeSpan("00:00:01"))
+	assert.Equal(t, 12*time.Hour+30*time.Minute+15*time.Second, FromTimeSpan("12:30:15"))
+	assert.Equal(t, 47*time.Hour, FromTimeSpan("47:00:00"))
+}
+
+func TestFromTimeSpanParsesFractionalSeconds(t *testing.T) {
+	assert.Equal(t, 500*time.Millisecond, FromTimeSpan("00:00:00.5000000"))
+	// ToTimeSpan emits a 5-digit fraction rather than .NET's 7, so it must round-trip too.
+	assert.Equal(t, 500*time.Millisecond, FromTimeSpan("00:00:00.50000"))
+	assert.Equal(t, time.Second+500*time.Millisecond, FromTimeSpan("1.00:00:01.50000")-24*time.Hour)
+}
+
+func TestFromTimeSpanHandlesEmptyAndMalformed(t *testing.T) {
+	assert.Equal(t, time.Duration(0), FromTimeSpan(""))
+	assert.Equal(t, time.Duration(0), FromTimeSpan("not-a-timespan"))
+}
+
+func TestFromTimeSpanHandlesNegative(t *testing.T) {
+	assert.Equal(t, -90*time.Minute, FromTimeSpan("-01:30:00"))
+	assert.Equal(t, -25*time.Hour, FromTimeSpan("-1.01:00:00"))
+}
+
+func TestToTimeSpanFromTimeSpanRoundTrip(t *testing.T) {
+	for _, d := range []time.Duration{
+		0,
+		time.Second,
+		time.Minute,
+		time.Hour,
+		24 * time.Hour,
+		47 * time.Hour,
+		48 * time.Hour,
+		25*time.Hour + 30*time.Minute + 15*time.Second,
+	} {
+		assert.Equal(t, d, FromTimeSpan(ToTimeSpan(d)), "round trip failed for %s (rendered %q)", d, ToTimeSpan(d))
+	}
+}

--- a/pkg/machinepolicies/machine_health_check_policy.go
+++ b/pkg/machinepolicies/machine_health_check_policy.go
@@ -28,8 +28,7 @@ func NewMachineHealthCheckPolicy() *MachineHealthCheckPolicy {
 
 // MarshalJSON returns a machine health check policy as its JSON encoding.
 func (m *MachineHealthCheckPolicy) MarshalJSON() ([]byte, error) {
-	// A zero interval is omitted rather than sent as "00:00:00": the server treats an
-	// absent interval as "no scheduled health checks", but "00:00:00" as "check constantly".
+	// The server reads an absent interval as "no health checks" but "00:00:00" as "check constantly".
 	healthCheckInterval := ""
 	if m.HealthCheckInterval > 0 {
 		healthCheckInterval = ToTimeSpan(m.HealthCheckInterval)
@@ -77,9 +76,8 @@ func (m *MachineHealthCheckPolicy) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	if len(fields.HealthCheckInterval) > 0 {
-		m.HealthCheckInterval = FromTimeSpan(fields.HealthCheckInterval)
-	}
+	// An absent interval means no health checks, so it must clear any existing value.
+	m.HealthCheckInterval = FromTimeSpan(fields.HealthCheckInterval)
 
 	m.BashHealthCheckPolicy = fields.BashHealthCheckPolicy
 	m.HealthCheckCron = fields.HealthCheckCron

--- a/pkg/machinepolicies/machine_health_check_policy.go
+++ b/pkg/machinepolicies/machine_health_check_policy.go
@@ -28,6 +28,13 @@ func NewMachineHealthCheckPolicy() *MachineHealthCheckPolicy {
 
 // MarshalJSON returns a machine health check policy as its JSON encoding.
 func (m *MachineHealthCheckPolicy) MarshalJSON() ([]byte, error) {
+	// A zero interval is omitted rather than sent as "00:00:00": the server treats an
+	// absent interval as "no scheduled health checks", but "00:00:00" as "check constantly".
+	healthCheckInterval := ""
+	if m.HealthCheckInterval > 0 {
+		healthCheckInterval = ToTimeSpan(m.HealthCheckInterval)
+	}
+
 	machineHealthCheckPolicy := struct {
 		BashHealthCheckPolicy       *MachineScriptPolicy `json:"BashHealthCheckPolicy,omitempty"`
 		HealthCheckCron             string               `json:"HealthCheckCron,omitempty"`
@@ -39,7 +46,7 @@ func (m *MachineHealthCheckPolicy) MarshalJSON() ([]byte, error) {
 		BashHealthCheckPolicy:       m.BashHealthCheckPolicy,
 		HealthCheckCron:             m.HealthCheckCron,
 		HealthCheckCronTimezone:     m.HealthCheckCronTimezone,
-		HealthCheckInterval:         ToTimeSpan(m.HealthCheckInterval),
+		HealthCheckInterval:         healthCheckInterval,
 		HealthCheckType:             m.HealthCheckType,
 		PowerShellHealthCheckPolicy: m.PowerShellHealthCheckPolicy,
 	}

--- a/pkg/machinepolicies/machine_health_check_policy_test.go
+++ b/pkg/machinepolicies/machine_health_check_policy_test.go
@@ -1,0 +1,81 @@
+package machinepolicies
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalOmitsZeroHealthCheckInterval(t *testing.T) {
+	policy := NewMachineHealthCheckPolicy()
+	policy.HealthCheckInterval = 0
+
+	data, err := json.Marshal(policy)
+	require.NoError(t, err)
+
+	var fields map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &fields))
+
+	_, present := fields["HealthCheckInterval"]
+	assert.False(t, present, "a zero interval must be omitted, not sent as \"00:00:00\"")
+}
+
+func TestMarshalKeepsNonZeroHealthCheckInterval(t *testing.T) {
+	policy := NewMachineHealthCheckPolicy()
+	policy.HealthCheckInterval = 24 * time.Hour
+
+	data, err := json.Marshal(policy)
+	require.NoError(t, err)
+
+	var fields map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &fields))
+
+	assert.Equal(t, "01.00:00:00", fields["HealthCheckInterval"])
+}
+
+func TestMarshalCronOnlyOmitsInterval(t *testing.T) {
+	policy := NewMachineHealthCheckPolicy()
+	policy.HealthCheckInterval = 0
+	policy.HealthCheckCron = "0 0 0 1 1 * 2099"
+
+	data, err := json.Marshal(policy)
+	require.NoError(t, err)
+
+	var fields map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &fields))
+
+	assert.Equal(t, "0 0 0 1 1 * 2099", fields["HealthCheckCron"])
+	_, present := fields["HealthCheckInterval"]
+	assert.False(t, present, "cron-only policy must not also carry an interval")
+}
+
+func TestHealthCheckIntervalSurvivesRoundTrip(t *testing.T) {
+	policy := NewMachineHealthCheckPolicy()
+	policy.HealthCheckInterval = 24 * time.Hour
+
+	data, err := json.Marshal(policy)
+	require.NoError(t, err)
+
+	var decoded MachineHealthCheckPolicy
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	assert.Equal(t, 24*time.Hour, decoded.HealthCheckInterval)
+}
+
+func TestAbsentHealthCheckIntervalDecodesAsZero(t *testing.T) {
+	body := `{
+		"BashHealthCheckPolicy": {"RunType": "InheritFromDefault"},
+		"PowerShellHealthCheckPolicy": {"RunType": "InheritFromDefault"},
+		"HealthCheckCronTimezone": "UTC",
+		"HealthCheckType": "RunScript"
+	}`
+
+	var decoded MachineHealthCheckPolicy
+	require.NoError(t, json.Unmarshal([]byte(body), &decoded))
+
+	assert.Equal(t, time.Duration(0), decoded.HealthCheckInterval)
+	assert.Empty(t, decoded.HealthCheckCron)
+}

--- a/pkg/machines/duration_formatter.go
+++ b/pkg/machines/duration_formatter.go
@@ -3,6 +3,7 @@ package machines
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -30,20 +31,52 @@ func ToTimeSpan(duration time.Duration) string {
 	return fmt.Sprintf("%02d.%02d:%02d:%02d.%05d", days, hours, minutes, seconds, secondsFraction)
 }
 
+// FromTimeSpan parses a .NET TimeSpan ("[-][d.]hh:mm:ss[.fffffff]") into a duration.
 func FromTimeSpan(timeSpan string) time.Duration {
-	if len(timeSpan) == 8 {
-		hours, _ := strconv.ParseInt(timeSpan[0:2], 10, 64)
-		minutes, _ := strconv.ParseInt(timeSpan[3:5], 10, 64)
-		seconds, _ := strconv.ParseInt(timeSpan[6:8], 10, 64)
-		duration, _ := time.ParseDuration(fmt.Sprintf("%dh%dm%ds", hours, minutes, seconds))
-		return duration
+	if timeSpan == "" {
+		return 0
 	}
 
-	days, _ := strconv.ParseInt(timeSpan[0:0], 10, 32)
-	hours, _ := strconv.ParseInt(timeSpan[2:4], 10, 64)
-	hours += (days * 24)
-	minutes, _ := strconv.ParseInt(timeSpan[5:7], 10, 64)
-	seconds, _ := strconv.ParseInt(timeSpan[8:10], 10, 64)
-	duration, _ := time.ParseDuration(fmt.Sprintf("%dh%dm%ds", hours, minutes, seconds))
+	negative := strings.HasPrefix(timeSpan, "-")
+	if negative {
+		timeSpan = timeSpan[1:]
+	}
+
+	var days int64
+	if dot := strings.IndexByte(timeSpan, '.'); dot >= 0 && dot < strings.IndexByte(timeSpan, ':') {
+		days, _ = strconv.ParseInt(timeSpan[:dot], 10, 64)
+		timeSpan = timeSpan[dot+1:]
+	}
+
+	var fraction time.Duration
+	if dot := strings.IndexByte(timeSpan, '.'); dot >= 0 {
+		// .NET fractional seconds are ticks of 100ns, up to 7 digits.
+		ticks := timeSpan[dot+1:]
+		if len(ticks) > 7 {
+			ticks = ticks[:7]
+		}
+		ticks += strings.Repeat("0", 7-len(ticks))
+		parsed, _ := strconv.ParseInt(ticks, 10, 64)
+		fraction = time.Duration(parsed) * 100 * time.Nanosecond
+		timeSpan = timeSpan[:dot]
+	}
+
+	parts := strings.Split(timeSpan, ":")
+	if len(parts) != 3 {
+		return 0
+	}
+	hours, _ := strconv.ParseInt(parts[0], 10, 64)
+	minutes, _ := strconv.ParseInt(parts[1], 10, 64)
+	seconds, _ := strconv.ParseInt(parts[2], 10, 64)
+
+	duration := time.Duration(days)*24*time.Hour +
+		time.Duration(hours)*time.Hour +
+		time.Duration(minutes)*time.Minute +
+		time.Duration(seconds)*time.Second +
+		fraction
+
+	if negative {
+		return -duration
+	}
 	return duration
 }

--- a/pkg/machines/duration_formatter_test.go
+++ b/pkg/machines/duration_formatter_test.go
@@ -3,30 +3,52 @@ package machines
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestToTimeSpan(t *testing.T) {
-	halfSecond, _ := time.ParseDuration("0.5s")
-	second, _ := time.ParseDuration("1111ms")
-	twoHours, _ := time.ParseDuration("120m")
-	fourtySevenHours, _ := time.ParseDuration("47h")
-	twoDays, _ := time.ParseDuration("48h")
-	t.Logf("500ms: %s", ToTimeSpan(halfSecond))
-	t.Logf("1000ms: %s", ToTimeSpan(second))
-	t.Logf("1s: %s", ToTimeSpan(time.Second))
-	t.Logf("1m: %s", ToTimeSpan(time.Minute))
-	t.Logf("1h: %s", ToTimeSpan(time.Hour))
-	t.Logf("120m: %s", ToTimeSpan(twoHours))
-	t.Logf("47h: %s", ToTimeSpan(fourtySevenHours))
-	t.Logf("48h: %s", ToTimeSpan(twoDays))
+func TestFromTimeSpanParsesDayComponent(t *testing.T) {
+	assert.Equal(t, 24*time.Hour, FromTimeSpan("1.00:00:00"))
+	assert.Equal(t, 24*time.Hour, FromTimeSpan("01.00:00:00"))
+	assert.Equal(t, 48*time.Hour, FromTimeSpan("2.00:00:00"))
+	assert.Equal(t, 25*time.Hour+30*time.Minute, FromTimeSpan("1.01:30:00"))
 }
 
-func TestFromTimeSpan(t *testing.T) {
-	t.Logf("1s: %s", FromTimeSpan("00.00:00:01"))
-	t.Logf("1m: %s", FromTimeSpan("00.00:01:00"))
-	t.Logf("1h: %s", FromTimeSpan("00.01:00:00"))
-	t.Logf("120m: %s", FromTimeSpan("00.02:00:00"))
-	t.Logf("47h: %s", FromTimeSpan("00.47:00:00"))
-	t.Logf("48h: %s", FromTimeSpan("00.48:00:00"))
-	t.Logf("2d: %s", FromTimeSpan("02.00:00:00"))
+func TestFromTimeSpanParsesTimeOnly(t *testing.T) {
+	assert.Equal(t, time.Duration(0), FromTimeSpan("00:00:00"))
+	assert.Equal(t, time.Second, FromTimeSpan("00:00:01"))
+	assert.Equal(t, 12*time.Hour+30*time.Minute+15*time.Second, FromTimeSpan("12:30:15"))
+	assert.Equal(t, 47*time.Hour, FromTimeSpan("47:00:00"))
+}
+
+func TestFromTimeSpanParsesFractionalSeconds(t *testing.T) {
+	assert.Equal(t, 500*time.Millisecond, FromTimeSpan("00:00:00.5000000"))
+	// ToTimeSpan emits a 5-digit fraction rather than .NET's 7, so it must round-trip too.
+	assert.Equal(t, 500*time.Millisecond, FromTimeSpan("00:00:00.50000"))
+	assert.Equal(t, time.Second+500*time.Millisecond, FromTimeSpan("1.00:00:01.50000")-24*time.Hour)
+}
+
+func TestFromTimeSpanHandlesEmptyAndMalformed(t *testing.T) {
+	assert.Equal(t, time.Duration(0), FromTimeSpan(""))
+	assert.Equal(t, time.Duration(0), FromTimeSpan("not-a-timespan"))
+}
+
+func TestFromTimeSpanHandlesNegative(t *testing.T) {
+	assert.Equal(t, -90*time.Minute, FromTimeSpan("-01:30:00"))
+	assert.Equal(t, -25*time.Hour, FromTimeSpan("-1.01:00:00"))
+}
+
+func TestToTimeSpanFromTimeSpanRoundTrip(t *testing.T) {
+	for _, d := range []time.Duration{
+		0,
+		time.Second,
+		time.Minute,
+		time.Hour,
+		24 * time.Hour,
+		47 * time.Hour,
+		48 * time.Hour,
+		25*time.Hour + 30*time.Minute + 15*time.Second,
+	} {
+		assert.Equal(t, d, FromTimeSpan(ToTimeSpan(d)), "round trip failed for %s (rendered %q)", d, ToTimeSpan(d))
+	}
 }

--- a/pkg/machines/machine_health_check_policy.go
+++ b/pkg/machines/machine_health_check_policy.go
@@ -28,6 +28,12 @@ func NewMachineHealthCheckPolicy() *MachineHealthCheckPolicy {
 
 // MarshalJSON returns a machine health check policy as its JSON encoding.
 func (m *MachineHealthCheckPolicy) MarshalJSON() ([]byte, error) {
+	// The server reads an absent interval as "no health checks" but "00:00:00" as "check constantly".
+	healthCheckInterval := ""
+	if m.HealthCheckInterval > 0 {
+		healthCheckInterval = ToTimeSpan(m.HealthCheckInterval)
+	}
+
 	machineHealthCheckPolicy := struct {
 		BashHealthCheckPolicy       *MachineScriptPolicy `json:"BashHealthCheckPolicy,omitempty"`
 		HealthCheckCron             string               `json:"HealthCheckCron,omitempty"`
@@ -39,7 +45,7 @@ func (m *MachineHealthCheckPolicy) MarshalJSON() ([]byte, error) {
 		BashHealthCheckPolicy:       m.BashHealthCheckPolicy,
 		HealthCheckCron:             m.HealthCheckCron,
 		HealthCheckCronTimezone:     m.HealthCheckCronTimezone,
-		HealthCheckInterval:         ToTimeSpan(m.HealthCheckInterval),
+		HealthCheckInterval:         healthCheckInterval,
 		HealthCheckType:             m.HealthCheckType,
 		PowerShellHealthCheckPolicy: m.PowerShellHealthCheckPolicy,
 	}
@@ -70,9 +76,8 @@ func (m *MachineHealthCheckPolicy) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	if len(fields.HealthCheckInterval) > 0 {
-		m.HealthCheckInterval = FromTimeSpan(fields.HealthCheckInterval)
-	}
+	// An absent interval means no health checks, so it must clear any existing value.
+	m.HealthCheckInterval = FromTimeSpan(fields.HealthCheckInterval)
 
 	m.BashHealthCheckPolicy = fields.BashHealthCheckPolicy
 	m.HealthCheckCron = fields.HealthCheckCron

--- a/pkg/machines/machine_health_check_policy_test.go
+++ b/pkg/machines/machine_health_check_policy_test.go
@@ -1,4 +1,4 @@
-package machinepolicies
+package machines
 
 import (
 	"encoding/json"


### PR DESCRIPTION
# Background

The client cannot express a machine policy with health checks disabled. `MarshalJSON` runs `HealthCheckInterval` through `ToTimeSpan`, which returns `"00:00:00"` for a zero duration rather than an empty string, so the `omitempty` tag never fires and the field is always sent. The server reads an absent interval as no scheduled health checks, but reads `"00:00:00"` as an interval of zero, which queues a health check against every target in the policy roughly every minute.

`FromTimeSpan` had a separate problem. It returned 0 for any TimeSpan carrying a day component, because it read the day digits from a zero-length slice and the remaining offsets then landed on separator characters. `ToTimeSpan(24h)` produces `"01.00:00:00"`, which parsed back as `0s`, so a one day interval did not survive its own round trip.

These ship together on purpose. Omitting a zero interval on its own would read an existing one day policy back as zero, omit it on the next write, and silently disable that policy's health checks.

# Results

Omit `HealthCheckInterval` when it is zero, and rewrite `FromTimeSpan` to parse the full .NET form including the day component, fractional seconds and negatives. The parsing fix is applied to the identical copy in `pkg/machines`, where the same helper is shared with the connection timeout, retry and cleanup fields.

Fixes HPY-1501

## Before

```go
p.HealthCheckInterval = 0
json.Marshal(p)              // "HealthCheckInterval":"00:00:00"

FromTimeSpan("1.00:00:00")   // 0s
FromTimeSpan(ToTimeSpan(24*time.Hour))  // 0s
```

## After

```go
p.HealthCheckInterval = 0
json.Marshal(p)              // field omitted

FromTimeSpan("1.00:00:00")   // 24h
FromTimeSpan(ToTimeSpan(24*time.Hour))  // 24h
```

# Testing

`pkg/machinepolicies` had no tests. This adds 11 covering the marshalling behaviour and the parser, including a round trip over a range of durations. The existing duration tests in `pkg/machines` only call `t.Logf` and assert nothing, which is why the parsing bug went unnoticed.

The rest of `./pkg/...` fails the same way before and after this change: those are integration tests needing a live server on `:8066`.

# Downstream

`terraform-provider-octopusdeploy` needs this released before it can omit the interval. See the companion PR there.