### PR TITLE
feat: convert Amazon ECS cluster endpoints through EndpointResource (WIP)

### DIFF
--- a/pkg/machines/endpoint_resource.go
+++ b/pkg/machines/endpoint_resource.go
@@ -16,6 +16,11 @@ type EndpointResource struct {
 	AadUserCredentialPassword            *core.SensitiveValue                   `json:"AadUserCredentialPassword,omitempty"`
 	AccountID                            string                                 `json:"AccountId"`
 	ApplicationsDirectory                string                                 `json:"ApplicationsDirectory,omitempty"`
+	AssumedRoleARN                       string                                 `json:"AssumedRoleArn,omitempty"`
+	AssumedRoleSession                   string                                 `json:"AssumedRoleSession,omitempty"`
+	AssumeRole                           bool                                   `json:"AssumeRole"`
+	AssumeRoleExternalID                 string                                 `json:"AssumeRoleExternalId,omitempty"`
+	AssumeRoleSessionDurationSeconds     int                                    `json:"AssumeRoleSessionDurationSeconds,omitempty"`
 	Authentication                       IKubernetesAuthentication              `json:"Authentication,omitempty"`
 	CertificateSignatureAlgorithm        string                                 `json:"CertificateSignatureAlgorithm,omitempty"`
 	CertificateStoreLocation             string                                 `json:"CertificateStoreLocation,omitempty"`
@@ -24,8 +29,9 @@ type EndpointResource struct {
 	CloudServiceName                     string                                 `json:"CloudServiceName"`
 	ClusterCertificate                   string                                 `json:"ClusterCertificate,omitempty"`
 	ClusterCertificatePath               string                                 `json:"ClusterCertificatePath,omitempty"`
-	ClusterURL                           *url.URL                               `json:"ClusterUrl" validate:"required"`
-	CommunicationStyle                   string                                 `json:"CommunicationStyle" validate:"required,oneof=AzureCloudService AzureServiceFabricCluster Ftp Kubernetes None OfflineDrop Ssh TentacleActive TentaclePassive KubernetesTentacle AwsEcsCluster"`
+	ClusterName                          string                                 `json:"ClusterName,omitempty"`
+	ClusterURL                           *url.URL                               `json:"ClusterUrl"`
+	CommunicationStyle                   string                                 `json:"CommunicationStyle" validate:"required,oneof=AzureCloudService AzureServiceFabricCluster AzureWebApp Ftp Kubernetes None OfflineDrop Ssh TentacleActive TentaclePassive KubernetesTentacle AwsEcsCluster"`
 	ConnectionEndpoint                   string                                 `json:"ConnectionEndpoint,omitempty"`
 	Container                            *deployments.DeploymentActionContainer `json:"Container,omitempty"`
 	ContainerOptions                     string                                 `json:"ContainerOptions,omitempty"`
@@ -37,6 +43,7 @@ type EndpointResource struct {
 	Namespace                            string                                 `json:"Namespace,omitempty"`
 	Port                                 int                                    `json:"Port,omitempty"`
 	ProxyID                              string                                 `json:"ProxyId,omitempty"`
+	Region                               string                                 `json:"Region,omitempty"`
 	ResourceGroupName                    string                                 `json:"ResourceGroupName,omitempty"`
 	RunningInContainer                   bool                                   `json:"RunningInContainer"`
 	SecurityMode                         string                                 `json:"SecurityMode,omitempty" validate:"omitempty,oneof=Unsecure SecureClientCertificate SecureAzureAD"`
@@ -47,10 +54,11 @@ type EndpointResource struct {
 	StorageAccountName                   string                                 `json:"StorageAccountName"`
 	SwapIfPossible                       bool                                   `json:"SwapIfPossible"`
 	TentacleVersionDetails               *TentacleVersionDetails                `json:"TentacleVersionDetails,omitempty"`
-	Thumbprint                           string                                 `json:"Thumbprint" validate:"required"`
+	Thumbprint                           string                                 `json:"Thumbprint"`
 	WorkingDirectory                     string                                 `json:"OctopusWorkingDirectory,omitempty"`
 	UseCurrentInstanceCount              bool                                   `json:"UseCurrentInstanceCount"`
-	URI                                  *url.URL                               `json:"Uri" validate:"required"`
+	UseInstanceRole                      bool                                   `json:"UseInstanceRole"`
+	URI                                  *url.URL                               `json:"Uri"`
 	WebAppName                           string                                 `json:"WebAppName,omitempty"`
 	WebAppSlotName                       string                                 `json:"WebAppSlotName"`
 
@@ -73,7 +81,31 @@ func (e *EndpointResource) GetCommunicationStyle() string {
 // Validate checks the state of the endpoint resource and returns an error if
 // invalid.
 func (e EndpointResource) Validate() error {
-	return validator.New().Struct(e)
+	validate := validator.New()
+	validate.RegisterStructValidation(validateEndpointResource, EndpointResource{})
+
+	return validate.Struct(e)
+}
+
+// validateEndpointResource requires the fields that the communication style in
+// hand actually uses. A blanket "required" on ClusterUrl, Thumbprint and Uri
+// asked every style for all three, which no single endpoint has.
+func validateEndpointResource(sl validator.StructLevel) {
+	resource := sl.Current().Interface().(EndpointResource)
+
+	switch resource.CommunicationStyle {
+	case "Kubernetes":
+		if resource.ClusterURL == nil {
+			sl.ReportError(resource.ClusterURL, "ClusterUrl", "ClusterURL", "required", "")
+		}
+	case "TentacleActive", "TentaclePassive", "KubernetesTentacle":
+		if resource.URI == nil {
+			sl.ReportError(resource.URI, "Uri", "URI", "required", "")
+		}
+		if resource.Thumbprint == "" {
+			sl.ReportError(resource.Thumbprint, "Thumbprint", "Thumbprint", "required", "")
+		}
+	}
 }
 
 var _ IEndpoint = &EndpointResource{}

--- a/pkg/machines/endpoint_resource_conversion_test.go
+++ b/pkg/machines/endpoint_resource_conversion_test.go
@@ -1,0 +1,101 @@
+package machines
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newEcsEndpointResource() *EndpointResource {
+	resource := NewEndpointResource("AwsEcsCluster")
+	resource.AccountID = "Accounts-1"
+	resource.AssumedRoleARN = "arn:aws:iam::123456789012:role/OctopusEcsDeploy"
+	resource.AssumedRoleSession = "octopus-cli-604-session"
+	resource.AssumeRole = true
+	resource.AssumeRoleExternalID = "external-id-604"
+	resource.AssumeRoleSessionDurationSeconds = 3600
+	resource.ClusterName = "repro-604-assumerole-cluster"
+	resource.DefaultWorkerPoolID = "WorkerPools-1"
+	resource.Region = "eu-west-1"
+	resource.UseInstanceRole = false
+
+	return resource
+}
+
+// The conversion was unreachable for an ECS resource while ClusterUrl,
+// Thumbprint and Uri were required of every communication style.
+func TestToEndpointAwsEcsCluster(t *testing.T) {
+	converted, err := ToEndpoint(newEcsEndpointResource())
+	require.NoError(t, err)
+
+	endpoint, ok := converted.(*AwsEcsClusterEndpoint)
+	require.True(t, ok)
+	assert.Equal(t, "repro-604-assumerole-cluster", endpoint.ClusterName)
+	assert.Equal(t, "eu-west-1", endpoint.Region)
+	assert.Equal(t, "Accounts-1", endpoint.AccountID)
+	assert.Equal(t, "WorkerPools-1", endpoint.DefaultWorkerPoolID)
+	assert.True(t, endpoint.AssumeRole)
+	assert.Equal(t, "arn:aws:iam::123456789012:role/OctopusEcsDeploy", endpoint.AssumedRoleARN)
+	assert.Equal(t, "octopus-cli-604-session", endpoint.AssumedRoleSession)
+	assert.Equal(t, 3600, endpoint.AssumeRoleSessionDurationSeconds)
+	assert.Equal(t, "external-id-604", endpoint.AssumeRoleExternalID)
+	assert.False(t, endpoint.UseInstanceRole)
+}
+
+// Every field survives resource -> endpoint -> resource, which is the point of
+// the pair being symmetric.
+func TestAwsEcsClusterSurvivesARoundTripThroughBothConversions(t *testing.T) {
+	original := newEcsEndpointResource()
+
+	endpoint, err := ToEndpoint(original)
+	require.NoError(t, err)
+
+	returned, err := ToEndpointResource(endpoint)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.CommunicationStyle, returned.CommunicationStyle)
+	assert.Equal(t, original.AccountID, returned.AccountID)
+	assert.Equal(t, original.AssumedRoleARN, returned.AssumedRoleARN)
+	assert.Equal(t, original.AssumedRoleSession, returned.AssumedRoleSession)
+	assert.Equal(t, original.AssumeRole, returned.AssumeRole)
+	assert.Equal(t, original.AssumeRoleExternalID, returned.AssumeRoleExternalID)
+	assert.Equal(t, original.AssumeRoleSessionDurationSeconds, returned.AssumeRoleSessionDurationSeconds)
+	assert.Equal(t, original.ClusterName, returned.ClusterName)
+	assert.Equal(t, original.DefaultWorkerPoolID, returned.DefaultWorkerPoolID)
+	assert.Equal(t, original.Region, returned.Region)
+	assert.Equal(t, original.UseInstanceRole, returned.UseInstanceRole)
+}
+
+// Validation now asks each style only for the fields it uses.
+func TestEndpointResourceValidateIsStyleAware(t *testing.T) {
+	uri := &url.URL{Scheme: "https", Host: "tentacle:10933"}
+
+	t.Run("a tentacle still needs its uri and thumbprint", func(t *testing.T) {
+		bare := NewEndpointResource("TentaclePassive")
+		require.Error(t, bare.Validate())
+
+		complete := NewEndpointResource("TentaclePassive")
+		complete.URI = uri
+		complete.Thumbprint = "thumbprint"
+		require.NoError(t, complete.Validate())
+	})
+
+	t.Run("kubernetes still needs its cluster url", func(t *testing.T) {
+		bare := NewEndpointResource("Kubernetes")
+		require.Error(t, bare.Validate())
+
+		complete := NewEndpointResource("Kubernetes")
+		complete.ClusterURL = &url.URL{Scheme: "https", Host: "cluster"}
+		require.NoError(t, complete.Validate())
+	})
+
+	// These used to fail for want of a cluster url, thumbprint and uri that
+	// none of them has.
+	for _, style := range []string{"AwsEcsCluster", "Ssh", "None", "OfflineDrop", "AzureWebApp"} {
+		t.Run(style+" no longer needs fields it does not use", func(t *testing.T) {
+			require.NoError(t, NewEndpointResource(style).Validate())
+		})
+	}
+}

--- a/pkg/machines/endpoint_utilities.go
+++ b/pkg/machines/endpoint_utilities.go
@@ -78,6 +78,17 @@ func ToEndpoint(endpointResource *EndpointResource) (IEndpoint, error) {
 	case "TentaclePassive":
 		listeningTentacleEndpoint := NewListeningTentacleEndpoint(endpointResource.URI, endpointResource.Thumbprint)
 		endpoint = listeningTentacleEndpoint
+	case "AwsEcsCluster":
+		awsEcsClusterEndpoint := NewAwsEcsClusterEndpoint(endpointResource.ClusterName, endpointResource.Region)
+		awsEcsClusterEndpoint.AccountID = endpointResource.AccountID
+		awsEcsClusterEndpoint.AssumedRoleARN = endpointResource.AssumedRoleARN
+		awsEcsClusterEndpoint.AssumedRoleSession = endpointResource.AssumedRoleSession
+		awsEcsClusterEndpoint.AssumeRole = endpointResource.AssumeRole
+		awsEcsClusterEndpoint.AssumeRoleExternalID = endpointResource.AssumeRoleExternalID
+		awsEcsClusterEndpoint.AssumeRoleSessionDurationSeconds = endpointResource.AssumeRoleSessionDurationSeconds
+		awsEcsClusterEndpoint.DefaultWorkerPoolID = endpointResource.DefaultWorkerPoolID
+		awsEcsClusterEndpoint.UseInstanceRole = endpointResource.UseInstanceRole
+		endpoint = awsEcsClusterEndpoint
 	}
 
 	if IsNil(endpoint) {
@@ -105,6 +116,18 @@ func ToEndpointResource(endpoint IEndpoint) (*EndpointResource, error) {
 	endpointResource := NewEndpointResource(endpoint.GetCommunicationStyle())
 
 	switch endpointResource.GetCommunicationStyle() {
+	case "AwsEcsCluster":
+		awsEcsClusterEndpoint := endpoint.(*AwsEcsClusterEndpoint)
+		endpointResource.AccountID = awsEcsClusterEndpoint.AccountID
+		endpointResource.AssumedRoleARN = awsEcsClusterEndpoint.AssumedRoleARN
+		endpointResource.AssumedRoleSession = awsEcsClusterEndpoint.AssumedRoleSession
+		endpointResource.AssumeRole = awsEcsClusterEndpoint.AssumeRole
+		endpointResource.AssumeRoleExternalID = awsEcsClusterEndpoint.AssumeRoleExternalID
+		endpointResource.AssumeRoleSessionDurationSeconds = awsEcsClusterEndpoint.AssumeRoleSessionDurationSeconds
+		endpointResource.ClusterName = awsEcsClusterEndpoint.ClusterName
+		endpointResource.DefaultWorkerPoolID = awsEcsClusterEndpoint.DefaultWorkerPoolID
+		endpointResource.Region = awsEcsClusterEndpoint.Region
+		endpointResource.UseInstanceRole = awsEcsClusterEndpoint.UseInstanceRole
 	case "AzureCloudService":
 		azureCloudServiceEndpoint := endpoint.(*AzureCloudServiceEndpoint)
 		endpointResource.AccountID = azureCloudServiceEndpoint.AccountID


### PR DESCRIPTION
**WIP.** The symmetry I argued against in [a comment on #457](https://github.com/OctopusDeploy/go-octopusdeploy/pull/457), built so the trade-off is concrete rather than hypothetical. **Stacked on #457** — review that first.

I still think this is a bigger change than #457 should carry, but it is smaller than I expected, and it turned up two real bugs on the way. Merge it, split it, or close it — the point is that the cost is now visible.

## What it does

Gives `ToEndpoint` and `ToEndpointResource` an `AwsEcsCluster` case, and `EndpointResource` the eight fields needed to carry one: `AssumedRoleArn`, `AssumedRoleSession`, `AssumeRole`, `AssumeRoleExternalId`, `AssumeRoleSessionDurationSeconds`, `ClusterName`, `Region`, `UseInstanceRole`.

## The part that isn't mechanical

The case alone would have been dead code. `ToEndpoint` validates the resource before converting, and `EndpointResource` marked `ClusterUrl`, `Thumbprint` and `Uri` as `required` for **every** communication style — three fields no single endpoint has. An ECS resource could never pass, and neither could an SSH, cloud region, offline drop or Azure web app one.

Those three are now required only of the styles that use them, through a struct-level validation:

| style | required |
|---|---|
| `Kubernetes` | `ClusterUrl` |
| `TentacleActive`, `TentaclePassive`, `KubernetesTentacle` | `Uri`, `Thumbprint` |
| everything else | none of the three |

This is the reviewable decision in the PR. It is a **loosening** — resources that used to fail validation now pass — so nothing that validates today stops validating, but `ToEndpoint` does stop rejecting some input it used to refuse. `required_with=` is already used this way in `pkg/accounts`, so conditional validation isn't a new pattern here, though a struct-level function is.

## Two bugs found while proving the conversion runs

- **`AzureWebApp` was missing from `EndpointResource`'s accepted styles.** The base `endpoint` validator lists it, and `ToEndpoint` has a case for it, but the resource validator did not — so that conversion was unreachable for exactly the same reason as ECS. Added.
- **Neither conversion had a test.** `ToEndpoint`, `ToEndpointArray` and `ToEndpointResource` have no callers anywhere in this library, which is how both gaps survived. There is now a round trip asserting all eleven ECS fields survive resource → endpoint → resource, plus a test pinning which style requires which field.

## Verification

`go test ./pkg/machines/...` passes. `TestMachinePolicyServiceDeleteAll` fails identically on the base branch — it wants a live instance.

The ECS resource used in the tests is the one captured from a real server in #457, assumed role and all.

## Worth deciding, not blocking

If you would rather not touch validation, the alternative is to leave `ToEndpoint` unable to convert ECS, SSH, cloud region, offline drop or Azure web app resources — in which case #457 stands as-is and this closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)