### PR TITLE
feat: add Priority to the shared create-execution command

### DIFF
--- a/pkg/deployments/deploy_release_v1.go
+++ b/pkg/deployments/deploy_release_v1.go
@@ -16,6 +16,7 @@ type CreateExecutionAbstractCommandV1 struct {
 	ExcludedMachineNames           []string          `json:"excludedMachineNames,omitempty"`
 	SkipStepNames                  []string          `json:"skipStepNames,omitempty"`
 	UseGuidedFailure               *bool             `json:"useGuidedFailure"`     // note: nil is valid, meaning 'use default'
+	Priority                       string            `json:"priority,omitempty"`   // "LifecycleDefault", "On" or "Off"; omitted when empty
 	RunAt                          string            `json:"runAt,omitempty"`      // contains a datetimeOffset-parseable value
 	NoRunAfter                     string            `json:"noRunAfter,omitempty"` // contains a datetimeOffset-parseable value
 	Variables                      map[string]string `json:"variables,omitempty"`


### PR DESCRIPTION
# Background

The server has accepted a `Priority` on both create-execution endpoints for a while now, and the same concept exists on runbook runs. The SDK never carried the field, so nothing built on top of it could ask for a prioritised deployment or runbook run.

This came out of HPY-1553, where a customer wanted to kick off priority deployments from automation they already had and found the CLI could not do it.

# Results

Adds `Priority` to `CreateExecutionAbstractCommandV1`.

Part of HPY-1553. The CLI change that uses this is a separate PR and needs a tagged release of this one first.

## Before

The struct had no priority field, so the request body never contained one and the server always fell back to its own default.

## After

Callers can set `Priority` to `LifecycleDefault`, `On` or `Off`. The struct is embedded by `CreateDeploymentTenantedCommandV1`, `CreateDeploymentUntenantedCommandV1`, `RunbookRunCommandV1` and `GitRunbookRunCommandV1`, so the one field covers deploy and both runbook run paths.

It is `omitempty`, so any caller that leaves it alone sends exactly the same body it sends today.

Checked against a local server. A deployment created with `Priority: "On"` reads back from `GET /api/Spaces-1/deployments` as `On`, `"Off"` reads back as `Off`, and omitting the field gives `LifecycleDefault`.

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered the [appropriate target version for this PR](https://octopushq.atlassian.net/wiki/spaces/RND/pages/1145896982/Which+versions+should+I+patch#Process).
- [ ] I have considered appropriate testing for my change.
  - Automated testing / Exploratory testing / Nothing required?
- [ ] I have considered manually testing my changes on a [branch instance](https://octopushq.atlassian.net/wiki/spaces/RND/pages/1262256152/Use+a+Core+Feature+Branch+Instance) to check correctness, stability and performance on Octopus Cloud.
- [ ] I have considered safety nets to reduce any time-to-recovery for my change.