### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,12 +16,12 @@ jobs:
         language: [ 'go' ]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -47,10 +47,10 @@ jobs:
       statuses: write
       checks: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v7
         with:
           go-version: '>=1.19.0'
       - name: Build

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,20 +7,20 @@ jobs:
   release-please-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           release-type: simple
           token: ${{ secrets.INTEGRATIONS_MD_BOT_TOKEN }}
-          command: github-release
+          skip-github-pull-request: true
   release-please-pr:
     runs-on: ubuntu-latest
     needs:
       - release-please-release
     steps:
       - id: release-pr
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.INTEGRATIONS_MD_BOT_TOKEN }}
           release-type: simple
-          command: release-pr
+          skip-github-release: true


### PR DESCRIPTION
#### GitHub actions
- switched to node24 (older versions are deprecated)

#### google-github-actions/release-please-action

1. https://github.com/google-github-actions/release-please-action#upgrading-from-v3-to-v4 (this was in v3 to v4 -- even though this action was already running on v4)
2. the action changed to a new repository https://github.com/google-github-actions/release-please-action/commit/edb78cf884d22d5d991d94144d031fce49cadbea
3. there's now a v5 (which uses node24)

---

Note that none of this is easily testable from forks, but that's a separate issue.