### PR TITLE
feat: add concurrency token support for partial variable snapshot updates

### DIFF
--- a/pkg/core/variable_identifier.go
+++ b/pkg/core/variable_identifier.go
@@ -12,5 +12,5 @@ type SnapshotVariablesByNameCommand struct {
 
 	// VariableSnapshotConcurrencyToken is the token read from the release or runbook snapshot. When supplied,
 	// the update fails if the snapshot has changed since. Omit to skip the check.
-	VariableSnapshotConcurrencyToken string `json:"VariableSnapshotConcurrencyToken,omitempty"`
+	VariableSnapshotConcurrencyToken *string `json:"VariableSnapshotConcurrencyToken,omitempty"`
 }

--- a/pkg/core/variable_identifier.go
+++ b/pkg/core/variable_identifier.go
@@ -9,4 +9,8 @@ type VariableIdentifier struct {
 // SnapshotVariablesByNameCommand is the request body for refreshing named variables within a variable snapshot.
 type SnapshotVariablesByNameCommand struct {
 	Variables []VariableIdentifier `json:"Variables"`
+
+	// VariableSnapshotConcurrencyToken is the token read from the release or runbook snapshot. When supplied,
+	// the update fails if the snapshot has changed since. Omit to skip the check.
+	VariableSnapshotConcurrencyToken string `json:"VariableSnapshotConcurrencyToken,omitempty"`
 }

--- a/pkg/releases/release.go
+++ b/pkg/releases/release.go
@@ -24,6 +24,7 @@ type Release struct {
 	SpaceID                            string                                   `json:"SpaceId,omitempty"`
 	Version                            string                                   `json:"Version"`
 	CustomFields                       map[string]string                        `json:"CustomFields,omitempty"`
+	VariableSnapshotConcurrencyToken   string                                   `json:"VariableSnapshotConcurrencyToken,omitempty"`
 
 	resources.Resource
 }

--- a/pkg/releases/release_service.go
+++ b/pkg/releases/release_service.go
@@ -238,7 +238,7 @@ func GetReleaseInProject(client newclient.Client, spaceID string, projectID stri
 }
 
 // SnapshotVariablesByName requires octopus feature toggle partial-updates-on-variables = true
-func SnapshotVariablesByName(client newclient.Client, release *Release, variables []core.VariableIdentifier) (*Release, error) {
+func SnapshotVariablesByName(client newclient.Client, release *Release, variables []core.VariableIdentifier, concurrencyToken ...string) (*Release, error) {
 	if client == nil {
 		return nil, internal.CreateInvalidParameterError("SnapshotVariablesByName", "client")
 	}
@@ -271,7 +271,11 @@ func SnapshotVariablesByName(client newclient.Client, release *Release, variable
 		return nil, err
 	}
 
-	command := core.SnapshotVariablesByNameCommand{Variables: variables}
-	return newclient.Post[Release](client.HttpSession(), expandedUri, command)
+	token := release.VariableSnapshotConcurrencyToken
+	if len(concurrencyToken) > 0 {
+		token = concurrencyToken[0]
+	}
 
+	command := core.SnapshotVariablesByNameCommand{Variables: variables, VariableSnapshotConcurrencyToken: token}
+	return newclient.Post[Release](client.HttpSession(), expandedUri, command)
 }

--- a/pkg/releases/release_service.go
+++ b/pkg/releases/release_service.go
@@ -238,7 +238,7 @@ func GetReleaseInProject(client newclient.Client, spaceID string, projectID stri
 }
 
 // SnapshotVariablesByName requires octopus feature toggle partial-updates-on-variables = true
-func SnapshotVariablesByName(client newclient.Client, release *Release, variables []core.VariableIdentifier, concurrencyToken ...string) (*Release, error) {
+func SnapshotVariablesByName(client newclient.Client, release *Release, variables []core.VariableIdentifier, concurrencyToken *string) (*Release, error) {
 	if client == nil {
 		return nil, internal.CreateInvalidParameterError("SnapshotVariablesByName", "client")
 	}
@@ -271,11 +271,6 @@ func SnapshotVariablesByName(client newclient.Client, release *Release, variable
 		return nil, err
 	}
 
-	token := release.VariableSnapshotConcurrencyToken
-	if len(concurrencyToken) > 0 {
-		token = concurrencyToken[0]
-	}
-
-	command := core.SnapshotVariablesByNameCommand{Variables: variables, VariableSnapshotConcurrencyToken: token}
+	command := core.SnapshotVariablesByNameCommand{Variables: variables, VariableSnapshotConcurrencyToken: concurrencyToken}
 	return newclient.Post[Release](client.HttpSession(), expandedUri, command)
 }

--- a/pkg/runbooks/runbook_snapshot.go
+++ b/pkg/runbooks/runbook_snapshot.go
@@ -12,18 +12,19 @@ import (
 
 // RunbookSnapshot represents a runbook snapshot.
 type RunbookSnapshot struct {
-	Assembled                     *time.Time                              `json:"Assembled,omitempty"`
-	FrozenProjectVariableSetID    string                                  `json:"FrozenProjectVariableSetId,omitempty"`
-	FrozenRunbookProcessID        string                                  `json:"FrozenRunbookProcessId,omitempty"`
-	LibraryVariableSetSnapshotIDs []string                                `json:"LibraryVariableSetSnapshotIds"`
-	Name                          string                                  `json:"Name,omitempty"`
-	Notes                         string                                  `json:"Notes,omitempty"`
-	ProjectID                     string                                  `json:"ProjectId" validate:"required,notblank"`
-	ProjectVariableSetSnapshotID  string                                  `json:"ProjectVariableSetSnapshotId,omitempty"`
-	RunbookID                     string                                  `json:"RunbookId" validate:"required,notblank"`
-	SelectedPackages              []*packages.SelectedPackage             `json:"SelectedPackages"`
-	SelectedGitResources          []*gitdependencies.SelectedGitResources `json:"SelectedGitResources,omitempty"`
-	SpaceID                       string                                  `json:"SpaceId,omitempty"`
+	Assembled                        *time.Time                              `json:"Assembled,omitempty"`
+	FrozenProjectVariableSetID       string                                  `json:"FrozenProjectVariableSetId,omitempty"`
+	FrozenRunbookProcessID           string                                  `json:"FrozenRunbookProcessId,omitempty"`
+	LibraryVariableSetSnapshotIDs    []string                                `json:"LibraryVariableSetSnapshotIds"`
+	Name                             string                                  `json:"Name,omitempty"`
+	Notes                            string                                  `json:"Notes,omitempty"`
+	ProjectID                        string                                  `json:"ProjectId" validate:"required,notblank"`
+	ProjectVariableSetSnapshotID     string                                  `json:"ProjectVariableSetSnapshotId,omitempty"`
+	RunbookID                        string                                  `json:"RunbookId" validate:"required,notblank"`
+	SelectedPackages                 []*packages.SelectedPackage             `json:"SelectedPackages"`
+	SelectedGitResources             []*gitdependencies.SelectedGitResources `json:"SelectedGitResources,omitempty"`
+	SpaceID                          string                                  `json:"SpaceId,omitempty"`
+	VariableSnapshotConcurrencyToken string                                  `json:"VariableSnapshotConcurrencyToken,omitempty"`
 
 	resources.Resource
 }

--- a/pkg/runbooks/runbook_snapshot_service.go
+++ b/pkg/runbooks/runbook_snapshot_service.go
@@ -83,7 +83,7 @@ func (s *RunbookSnapshotService) GetByID(id string) (*RunbookSnapshot, error) {
 
 // ----- Experimental ---------------------------------------------------------
 // SnapshotVariablesByName requires octopus feature toggle partial-updates-on-variables = true
-func SnapshotVariablesByName(client newclient.Client, runbookSnapshot *RunbookSnapshot, variables []core.VariableIdentifier) (*RunbookSnapshot, error) {
+func SnapshotVariablesByName(client newclient.Client, runbookSnapshot *RunbookSnapshot, variables []core.VariableIdentifier, concurrencyToken ...string) (*RunbookSnapshot, error) {
 	if client == nil {
 		return nil, internal.CreateInvalidParameterError("SnapshotVariablesByName", "client")
 	}
@@ -116,6 +116,11 @@ func SnapshotVariablesByName(client newclient.Client, runbookSnapshot *RunbookSn
 		return nil, err
 	}
 
-	command := core.SnapshotVariablesByNameCommand{Variables: variables}
+	token := runbookSnapshot.VariableSnapshotConcurrencyToken
+	if len(concurrencyToken) > 0 {
+		token = concurrencyToken[0]
+	}
+
+	command := core.SnapshotVariablesByNameCommand{Variables: variables, VariableSnapshotConcurrencyToken: token}
 	return newclient.Post[RunbookSnapshot](client.HttpSession(), expandedUri, command)
 }

--- a/pkg/runbooks/runbook_snapshot_service.go
+++ b/pkg/runbooks/runbook_snapshot_service.go
@@ -83,7 +83,7 @@ func (s *RunbookSnapshotService) GetByID(id string) (*RunbookSnapshot, error) {
 
 // ----- Experimental ---------------------------------------------------------
 // SnapshotVariablesByName requires octopus feature toggle partial-updates-on-variables = true
-func SnapshotVariablesByName(client newclient.Client, runbookSnapshot *RunbookSnapshot, variables []core.VariableIdentifier, concurrencyToken ...string) (*RunbookSnapshot, error) {
+func SnapshotVariablesByName(client newclient.Client, runbookSnapshot *RunbookSnapshot, variables []core.VariableIdentifier, concurrencyToken *string) (*RunbookSnapshot, error) {
 	if client == nil {
 		return nil, internal.CreateInvalidParameterError("SnapshotVariablesByName", "client")
 	}
@@ -116,11 +116,6 @@ func SnapshotVariablesByName(client newclient.Client, runbookSnapshot *RunbookSn
 		return nil, err
 	}
 
-	token := runbookSnapshot.VariableSnapshotConcurrencyToken
-	if len(concurrencyToken) > 0 {
-		token = concurrencyToken[0]
-	}
-
-	command := core.SnapshotVariablesByNameCommand{Variables: variables, VariableSnapshotConcurrencyToken: token}
+	command := core.SnapshotVariablesByNameCommand{Variables: variables, VariableSnapshotConcurrencyToken: concurrencyToken}
 	return newclient.Post[RunbookSnapshot](client.HttpSession(), expandedUri, command)
 }

--- a/test/e2e/release_service_test.go
+++ b/test/e2e/release_service_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
@@ -260,4 +261,83 @@ func TestReleaseServiceSnapshotVariablesByName(t *testing.T) {
 
 	// Assert
 	assert.NotEqual(t, oldProjectSnapshotId, updatedRelease.ProjectVariableSetSnapshotID)
+}
+
+func TestReleaseServiceSnapshotVariablesByNameConcurrency(t *testing.T) {
+
+	//Arrange
+	octopusClient := getOctopusClient()
+	require.NotNil(t, octopusClient)
+
+	toggle, err := configuration.Get(octopusClient, &configuration.FeatureToggleConfigurationQuery{
+		Name: "partial-updates-on-variables",
+	})
+	if err != nil {
+		t.Skip("Could not get feature toggle configuration")
+	} else if len(toggle.FeatureToggles) == 0 {
+		t.Skip("PartialUpdatesOnVariables feature toggle is not present")
+	} else if !toggle.FeatureToggles[0].IsEnabled {
+		t.Skip("PartialUpdatesOnVariables feature toggle is not enabled")
+	}
+
+	space := GetDefaultSpace(t, octopusClient)
+	require.NotNil(t, space)
+
+	lifecycle := CreateTestLifecycle(t, octopusClient)
+	require.NotNil(t, lifecycle)
+	defer DeleteTestLifecycle(t, octopusClient, lifecycle)
+
+	projectGroup := CreateTestProjectGroup(t, octopusClient)
+	require.NotNil(t, projectGroup)
+	defer DeleteTestProjectGroup(t, octopusClient, projectGroup)
+
+	project := CreateTestProject(t, octopusClient, space, lifecycle, projectGroup)
+	require.NotNil(t, project)
+	defer DeleteTestProject(t, octopusClient, project)
+
+	variableA := CreateTestVariable(t, project.ID, internal.GetRandomName())
+	require.NotNil(t, variableA)
+	variableB := CreateTestVariable(t, project.ID, internal.GetRandomName())
+	require.NotNil(t, variableB)
+
+	channel := CreateTestChannel(t, octopusClient, project)
+	require.NotNil(t, channel)
+	defer DeleteTestChannel(t, octopusClient, channel)
+
+	release := CreateTestRelease(t, octopusClient, channel, project)
+	require.NotNil(t, release)
+	defer DeleteTestRelease(t, octopusClient, release)
+
+	staleToken := release.VariableSnapshotConcurrencyToken
+
+	variableA.Value = "updatedA"
+	_, err = variables.UpdateSingle(octopusClient, space.ID, project.ID, variableA)
+	require.NoError(t, err)
+
+	// Act: refresh using the token captured before the release was fetched again advances the snapshot
+	firstUpdate, err := releases.SnapshotVariablesByName(octopusClient, release, []core.VariableIdentifier{
+		{Name: variableA.Name, OwnerID: project.ID},
+	}, staleToken)
+	require.NoError(t, err)
+	require.NotNil(t, firstUpdate)
+
+	// Assert: reusing the now-stale token is rejected with a conflict
+	variableB.Value = "updatedB"
+	_, err = variables.UpdateSingle(octopusClient, space.ID, project.ID, variableB)
+	require.NoError(t, err)
+
+	_, err = releases.SnapshotVariablesByName(octopusClient, release, []core.VariableIdentifier{
+		{Name: variableB.Name, OwnerID: project.ID},
+	}, staleToken)
+	require.Error(t, err)
+	apiError, ok := err.(*core.APIError)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusConflict, apiError.StatusCode)
+
+	// Assert: supplying the current token succeeds
+	secondUpdate, err := releases.SnapshotVariablesByName(octopusClient, firstUpdate, []core.VariableIdentifier{
+		{Name: variableB.Name, OwnerID: project.ID},
+	}, firstUpdate.VariableSnapshotConcurrencyToken)
+	require.NoError(t, err)
+	require.NotNil(t, secondUpdate)
 }

--- a/test/e2e/release_service_test.go
+++ b/test/e2e/release_service_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 
@@ -295,10 +296,8 @@ func TestReleaseServiceSnapshotVariablesByNameConcurrency(t *testing.T) {
 	require.NotNil(t, project)
 	defer DeleteTestProject(t, octopusClient, project)
 
-	variableA := CreateTestVariable(t, project.ID, internal.GetRandomName())
-	require.NotNil(t, variableA)
-	variableB := CreateTestVariable(t, project.ID, internal.GetRandomName())
-	require.NotNil(t, variableB)
+	variable := CreateTestVariable(t, project.ID, internal.GetRandomName())
+	require.NotNil(t, variable)
 
 	channel := CreateTestChannel(t, octopusClient, project)
 	require.NotNil(t, channel)
@@ -310,33 +309,34 @@ func TestReleaseServiceSnapshotVariablesByNameConcurrency(t *testing.T) {
 
 	staleToken := release.VariableSnapshotConcurrencyToken
 
-	variableA.Value = "updatedA"
-	_, err = variables.UpdateSingle(octopusClient, space.ID, project.ID, variableA)
+	variable.Value = "updatedValue1"
+	_, err = variables.UpdateSingle(octopusClient, space.ID, project.ID, variable)
 	require.NoError(t, err)
 
 	// Act: refresh using the token captured before the release was fetched again advances the snapshot
 	firstUpdate, err := releases.SnapshotVariablesByName(octopusClient, release, []core.VariableIdentifier{
-		{Name: variableA.Name, OwnerID: project.ID},
+		{Name: variable.Name, OwnerID: project.ID},
 	}, staleToken)
 	require.NoError(t, err)
 	require.NotNil(t, firstUpdate)
 
 	// Assert: reusing the now-stale token is rejected with a conflict
-	variableB.Value = "updatedB"
-	_, err = variables.UpdateSingle(octopusClient, space.ID, project.ID, variableB)
+	variable.Value = "updatedValue2"
+	_, err = variables.UpdateSingle(octopusClient, space.ID, project.ID, variable)
 	require.NoError(t, err)
 
 	_, err = releases.SnapshotVariablesByName(octopusClient, release, []core.VariableIdentifier{
-		{Name: variableB.Name, OwnerID: project.ID},
+		{Name: variable.Name, OwnerID: project.ID},
 	}, staleToken)
 	require.Error(t, err)
-	apiError, ok := err.(*core.APIError)
+	var apiError *core.APIError
+	ok := errors.As(err, &apiError)
 	require.True(t, ok)
 	assert.Equal(t, http.StatusConflict, apiError.StatusCode)
 
 	// Assert: supplying the current token succeeds
 	secondUpdate, err := releases.SnapshotVariablesByName(octopusClient, firstUpdate, []core.VariableIdentifier{
-		{Name: variableB.Name, OwnerID: project.ID},
+		{Name: variable.Name, OwnerID: project.ID},
 	}, firstUpdate.VariableSnapshotConcurrencyToken)
 	require.NoError(t, err)
 	require.NotNil(t, secondUpdate)

--- a/test/e2e/release_service_test.go
+++ b/test/e2e/release_service_test.go
@@ -256,7 +256,7 @@ func TestReleaseServiceSnapshotVariablesByName(t *testing.T) {
 	variableIdentifier := core.VariableIdentifier{Name: variable.Name, OwnerID: project.ID}
 	variableIdentifiers := []core.VariableIdentifier{variableIdentifier}
 
-	updatedRelease, err := releases.SnapshotVariablesByName(octopusClient, release, variableIdentifiers)
+	updatedRelease, err := releases.SnapshotVariablesByName(octopusClient, release, variableIdentifiers, nil)
 	require.NoError(t, err)
 	require.NotNil(t, updatedRelease)
 
@@ -316,7 +316,7 @@ func TestReleaseServiceSnapshotVariablesByNameConcurrency(t *testing.T) {
 	// Act: refresh using the token captured before the release was fetched again advances the snapshot
 	firstUpdate, err := releases.SnapshotVariablesByName(octopusClient, release, []core.VariableIdentifier{
 		{Name: variable.Name, OwnerID: project.ID},
-	}, staleToken)
+	}, &staleToken)
 	require.NoError(t, err)
 	require.NotNil(t, firstUpdate)
 
@@ -327,7 +327,7 @@ func TestReleaseServiceSnapshotVariablesByNameConcurrency(t *testing.T) {
 
 	_, err = releases.SnapshotVariablesByName(octopusClient, release, []core.VariableIdentifier{
 		{Name: variable.Name, OwnerID: project.ID},
-	}, staleToken)
+	}, &staleToken)
 	require.Error(t, err)
 	var apiError *core.APIError
 	ok := errors.As(err, &apiError)
@@ -337,7 +337,7 @@ func TestReleaseServiceSnapshotVariablesByNameConcurrency(t *testing.T) {
 	// Assert: supplying the current token succeeds
 	secondUpdate, err := releases.SnapshotVariablesByName(octopusClient, firstUpdate, []core.VariableIdentifier{
 		{Name: variable.Name, OwnerID: project.ID},
-	}, firstUpdate.VariableSnapshotConcurrencyToken)
+	}, &firstUpdate.VariableSnapshotConcurrencyToken)
 	require.NoError(t, err)
 	require.NotNil(t, secondUpdate)
 }

--- a/test/e2e/runbook_snapshot_service_test.go
+++ b/test/e2e/runbook_snapshot_service_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
@@ -190,4 +191,83 @@ func TestRunbookSnapshotServiceSnapshotVariablesByName(t *testing.T) {
 
 	// Assert
 	assert.NotEqual(t, oldProjectSnapshotId, updatedRunbookSnapshot.ProjectVariableSetSnapshotID)
+}
+
+func TestRunbookSnapshotServiceSnapshotVariablesByNameConcurrency(t *testing.T) {
+
+	//Arrange
+	octopusClient := getOctopusClient()
+	require.NotNil(t, octopusClient)
+
+	toggle, err := configuration.Get(octopusClient, &configuration.FeatureToggleConfigurationQuery{
+		Name: "partial-updates-on-variables",
+	})
+	if err != nil {
+		t.Skip("Could not get feature toggle configuration")
+	} else if len(toggle.FeatureToggles) == 0 {
+		t.Skip("PartialUpdatesOnVariables feature toggle is not present")
+	} else if !toggle.FeatureToggles[0].IsEnabled {
+		t.Skip("PartialUpdatesOnVariables feature toggle is not enabled")
+	}
+
+	space := GetDefaultSpace(t, octopusClient)
+	require.NotNil(t, space)
+
+	lifecycle := CreateTestLifecycle(t, octopusClient)
+	require.NotNil(t, lifecycle)
+	defer DeleteTestLifecycle(t, octopusClient, lifecycle)
+
+	projectGroup := CreateTestProjectGroup(t, octopusClient)
+	require.NotNil(t, projectGroup)
+	defer DeleteTestProjectGroup(t, octopusClient, projectGroup)
+
+	project := CreateTestProject(t, octopusClient, space, lifecycle, projectGroup)
+	require.NotNil(t, project)
+	defer DeleteTestProject(t, octopusClient, project)
+
+	variableA := CreateTestVariable(t, project.ID, internal.GetRandomName())
+	require.NotNil(t, variableA)
+	variableB := CreateTestVariable(t, project.ID, internal.GetRandomName())
+	require.NotNil(t, variableB)
+
+	runbook := CreateTestRunbook(t, octopusClient, lifecycle, projectGroup, project)
+	require.NotNil(t, runbook)
+	defer DeleteTestRunbook(t, octopusClient, runbook)
+
+	runbookSnapshot := CreateTestRunbookSnapshot(t, octopusClient, lifecycle, projectGroup, project, runbook)
+	require.NotNil(t, runbookSnapshot)
+	defer DeleteTestRunbookSnapshot(t, octopusClient, runbookSnapshot)
+
+	staleToken := runbookSnapshot.VariableSnapshotConcurrencyToken
+
+	variableA.Value = "updatedA"
+	_, err = variables.UpdateSingle(octopusClient, space.ID, project.ID, variableA)
+	require.NoError(t, err)
+
+	// Act: the token captured right after creation is still valid for the first update
+	firstUpdate, err := runbooks.SnapshotVariablesByName(octopusClient, runbookSnapshot, []core.VariableIdentifier{
+		{Name: variableA.Name, OwnerID: project.ID},
+	}, staleToken)
+	require.NoError(t, err)
+	require.NotNil(t, firstUpdate)
+
+	// Assert: reusing the now-stale token is rejected with a conflict
+	variableB.Value = "updatedB"
+	_, err = variables.UpdateSingle(octopusClient, space.ID, project.ID, variableB)
+	require.NoError(t, err)
+
+	_, err = runbooks.SnapshotVariablesByName(octopusClient, runbookSnapshot, []core.VariableIdentifier{
+		{Name: variableB.Name, OwnerID: project.ID},
+	}, staleToken)
+	require.Error(t, err)
+	apiError, ok := err.(*core.APIError)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusConflict, apiError.StatusCode)
+
+	// Assert: supplying the current token succeeds
+	secondUpdate, err := runbooks.SnapshotVariablesByName(octopusClient, firstUpdate, []core.VariableIdentifier{
+		{Name: variableB.Name, OwnerID: project.ID},
+	}, firstUpdate.VariableSnapshotConcurrencyToken)
+	require.NoError(t, err)
+	require.NotNil(t, secondUpdate)
 }

--- a/test/e2e/runbook_snapshot_service_test.go
+++ b/test/e2e/runbook_snapshot_service_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 
@@ -225,10 +226,8 @@ func TestRunbookSnapshotServiceSnapshotVariablesByNameConcurrency(t *testing.T) 
 	require.NotNil(t, project)
 	defer DeleteTestProject(t, octopusClient, project)
 
-	variableA := CreateTestVariable(t, project.ID, internal.GetRandomName())
-	require.NotNil(t, variableA)
-	variableB := CreateTestVariable(t, project.ID, internal.GetRandomName())
-	require.NotNil(t, variableB)
+	variable := CreateTestVariable(t, project.ID, internal.GetRandomName())
+	require.NotNil(t, variable)
 
 	runbook := CreateTestRunbook(t, octopusClient, lifecycle, projectGroup, project)
 	require.NotNil(t, runbook)
@@ -240,33 +239,34 @@ func TestRunbookSnapshotServiceSnapshotVariablesByNameConcurrency(t *testing.T) 
 
 	staleToken := runbookSnapshot.VariableSnapshotConcurrencyToken
 
-	variableA.Value = "updatedA"
-	_, err = variables.UpdateSingle(octopusClient, space.ID, project.ID, variableA)
+	variable.Value = "updatedValue1"
+	_, err = variables.UpdateSingle(octopusClient, space.ID, project.ID, variable)
 	require.NoError(t, err)
 
 	// Act: the token captured right after creation is still valid for the first update
 	firstUpdate, err := runbooks.SnapshotVariablesByName(octopusClient, runbookSnapshot, []core.VariableIdentifier{
-		{Name: variableA.Name, OwnerID: project.ID},
+		{Name: variable.Name, OwnerID: project.ID},
 	}, staleToken)
 	require.NoError(t, err)
 	require.NotNil(t, firstUpdate)
 
 	// Assert: reusing the now-stale token is rejected with a conflict
-	variableB.Value = "updatedB"
-	_, err = variables.UpdateSingle(octopusClient, space.ID, project.ID, variableB)
+	variable.Value = "updatedValue2"
+	_, err = variables.UpdateSingle(octopusClient, space.ID, project.ID, variable)
 	require.NoError(t, err)
 
 	_, err = runbooks.SnapshotVariablesByName(octopusClient, runbookSnapshot, []core.VariableIdentifier{
-		{Name: variableB.Name, OwnerID: project.ID},
+		{Name: variable.Name, OwnerID: project.ID},
 	}, staleToken)
 	require.Error(t, err)
-	apiError, ok := err.(*core.APIError)
+	var apiError *core.APIError
+	ok := errors.As(err, &apiError)
 	require.True(t, ok)
 	assert.Equal(t, http.StatusConflict, apiError.StatusCode)
 
 	// Assert: supplying the current token succeeds
-	secondUpdate, err := runbooks.SnapshotVariablesByName(octopusClient, firstUpdate, []core.VariableIdentifier{
-		{Name: variableB.Name, OwnerID: project.ID},
+	secondUpdate, err := runbooks.SnapshotVariablesByName(octopusClient, runbookSnapshot, []core.VariableIdentifier{
+		{Name: variable.Name, OwnerID: project.ID},
 	}, firstUpdate.VariableSnapshotConcurrencyToken)
 	require.NoError(t, err)
 	require.NotNil(t, secondUpdate)

--- a/test/e2e/runbook_snapshot_service_test.go
+++ b/test/e2e/runbook_snapshot_service_test.go
@@ -186,7 +186,7 @@ func TestRunbookSnapshotServiceSnapshotVariablesByName(t *testing.T) {
 	variableIdentifier := core.VariableIdentifier{Name: variable.Name, OwnerID: project.ID}
 	variableIdentifiers := []core.VariableIdentifier{variableIdentifier}
 
-	updatedRunbookSnapshot, err := runbooks.SnapshotVariablesByName(octopusClient, runbookSnapshot, variableIdentifiers)
+	updatedRunbookSnapshot, err := runbooks.SnapshotVariablesByName(octopusClient, runbookSnapshot, variableIdentifiers, nil)
 	require.NoError(t, err)
 	require.NotNil(t, updatedRunbookSnapshot)
 
@@ -246,7 +246,7 @@ func TestRunbookSnapshotServiceSnapshotVariablesByNameConcurrency(t *testing.T) 
 	// Act: the token captured right after creation is still valid for the first update
 	firstUpdate, err := runbooks.SnapshotVariablesByName(octopusClient, runbookSnapshot, []core.VariableIdentifier{
 		{Name: variable.Name, OwnerID: project.ID},
-	}, staleToken)
+	}, &staleToken)
 	require.NoError(t, err)
 	require.NotNil(t, firstUpdate)
 
@@ -257,7 +257,7 @@ func TestRunbookSnapshotServiceSnapshotVariablesByNameConcurrency(t *testing.T) 
 
 	_, err = runbooks.SnapshotVariablesByName(octopusClient, runbookSnapshot, []core.VariableIdentifier{
 		{Name: variable.Name, OwnerID: project.ID},
-	}, staleToken)
+	}, &staleToken)
 	require.Error(t, err)
 	var apiError *core.APIError
 	ok := errors.As(err, &apiError)
@@ -267,7 +267,7 @@ func TestRunbookSnapshotServiceSnapshotVariablesByNameConcurrency(t *testing.T) 
 	// Assert: supplying the current token succeeds
 	secondUpdate, err := runbooks.SnapshotVariablesByName(octopusClient, runbookSnapshot, []core.VariableIdentifier{
 		{Name: variable.Name, OwnerID: project.ID},
-	}, firstUpdate.VariableSnapshotConcurrencyToken)
+	}, &firstUpdate.VariableSnapshotConcurrencyToken)
 	require.NoError(t, err)
 	require.NotNil(t, secondUpdate)
 }


### PR DESCRIPTION
# Background

Adds client support for release and runbook variable snapshot concurrency. Relates to the changes in https://github.com/OctopusDeploy/OctopusDeploy/pull/46160 and https://github.com/OctopusDeploy/OctopusDeploy/pull/46136

# Results

The concurrency token can be retrieved from a a release:
```
release, err := client.Releases.Add(releases.NewRelease(channel.GetID(), proj.GetID(), "1.0.0"))
token := release.VariableSnapshotConcurrencyToken
```

A new token is generated by the snapshot by name endpoint:
```
identifiers := []core.VariableIdentifier{{Name: variableName, OwnerID: variableOwnerId}}
afterByName, err := releases.SnapshotVariablesByName(client, release, identifiers, currentToken)
```

An exception occurs when the concurrency token on the request does not equal the token on the release:
```
_, err := releases.SnapshotVariablesByName(client, release, identifiers, staleToken)
apiErr := err.(*core.APIError) // apiErr.StatusCode == http.StatusConflict, apiErr.ErrorMessage == "This variable snapshot was changed by someone else since you last loaded it. Please reload and try again."
```

## Code samples for testing

```
func TestReleaseSnapshotByName(octopusClient *client.Client, project *projects.Project, variable *variables.Variable, release *releases.Release, variableIdentifiers []core.VariableIdentifier) {
	variable.Value = "UpdatedValue1"
	_, err := variables.UpdateSingle(octopusClient, project.SpaceID, project.GetID(), variable)
	if err != nil {
		fmt.Printf("Failed to update the snapshot for release %s. Error: %v\n", release.GetID(), err)
		return
	}

	staleToken := release.VariableSnapshotConcurrencyToken
	updated, err := releases.SnapshotVariablesByName(octopusClient, release, variableIdentifiers, staleToken)
	if err != nil {
		fmt.Printf("Failed to update the snapshot for release %s. Error: %v\n", release.GetID(), err)
		return
	}
	fmt.Printf("Updated the snapshot for release %s\n", updated.GetID())

	variable.Value = "UpdatedValue2"
	_, err = variables.UpdateSingle(octopusClient, project.SpaceID, project.GetID(), variable)
	if err != nil {
		fmt.Printf("Failed to update the snapshot for release %s. Error: %v\n", release.GetID(), err)
		return
	}

	_, err = releases.SnapshotVariablesByName(octopusClient, updated, variableIdentifiers, staleToken)
	if err != nil {
		fmt.Printf("Failed to update the snapshot for release %s. Error: %v\n", release.GetID(), err)
		return
	}
	fmt.Printf("Failed to update the snapshot for release %s. Error: expected an error but none was returned\n", release.GetID())
}
```

```
func TestRunbookSnapshotByName(octopusClient *client.Client, project *projects.Project, variable *variables.Variable, runbookSnapshot *runbooks.RunbookSnapshot, variableIdentifiers []core.VariableIdentifier) {
	variable.Value = "UpdatedValue1"
	_, err := variables.UpdateSingle(octopusClient, project.SpaceID, project.GetID(), variable)
	if err != nil {
		fmt.Printf("Failed to update the snapshot for runbook snapshot %s. Error: %v\n", runbookSnapshot.GetID(), err)
		return
	}

	staleToken := runbookSnapshot.VariableSnapshotConcurrencyToken
	updated, err := runbooks.SnapshotVariablesByName(octopusClient, runbookSnapshot, variableIdentifiers, staleToken)
	if err != nil {
		fmt.Printf("Failed to update the snapshot for runbook snapshot %s. Error: %v\n", runbookSnapshot.GetID(), err)
		return
	}
	fmt.Printf("Updated the snapshot for runbook snapshot %s\n", updated.GetID())

	variable.Value = "UpdatedValue2"
	_, err = variables.UpdateSingle(octopusClient, project.SpaceID, project.GetID(), variable)
	if err != nil {
		fmt.Printf("Failed to update the snapshot for runbook snapshot %s. Error: %v\n", runbookSnapshot.GetID(), err)
		return
	}

	_, err = runbooks.SnapshotVariablesByName(octopusClient, updated, variableIdentifiers, staleToken)
	if err != nil {
		fmt.Printf("Failed to update the snapshot for runbook snapshot %s. Error: %v\n", runbookSnapshot.GetID(), err)
		return
	}
	fmt.Printf("Failed to update the snapshot for runbook snapshot %s. Error: expected an error but none was returned\n", runbookSnapshot.GetID())
}
```