### PR TITLE
feat: add Platform Hub Version Control Settings and Process Templates

### DIFF
--- a/examples/platform_hub/configure_version_control_settings.go
+++ b/examples/platform_hub/configure_version_control_settings.go
@@ -1,0 +1,53 @@
+package examples
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/credentials"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/platformhubversioncontrolsettings"
+)
+
+// ConfigurePlatformHubVersionControlSettingsExample provides an example of how to point
+// Platform Hub at a Git repository using username/password credentials.
+//
+// If the repository is already configured, changing the URL will repoint Platform Hub at the new repository.
+func ConfigurePlatformHubVersionControlSettingsExample() {
+	var (
+		apiKey     string = "API-YOUR_API_KEY"
+		octopusURL string = "https://your_octopus_url"
+
+		// version control values
+		gitURL        string = "https://github.com/your-org/your-repo.git"
+		gitUsername   string = "your-username"
+		gitPassword   string = "your-personal-access-token"
+		defaultBranch string = "main"
+		basePath      string = ".octopus/"
+	)
+
+	apiURL, err := url.Parse(octopusURL)
+	if err != nil {
+		_ = fmt.Errorf("error parsing URL for Octopus API: %v", err)
+		return
+	}
+
+	// Platform Hub is system-scoped, so no space ID is required
+	octopusClient, err := client.NewClient(nil, apiURL, apiKey, "")
+	if err != nil {
+		_ = fmt.Errorf("error creating API client: %v", err)
+		return
+	}
+
+	gitCredentials := credentials.NewUsernamePassword(gitUsername, core.NewSensitiveValue(gitPassword))
+	settings := platformhubversioncontrolsettings.NewResource(gitURL, gitCredentials, defaultBranch, basePath)
+
+	updatedSettings, err := platformhubversioncontrolsettings.Update(octopusClient, settings)
+	if err != nil {
+		_ = fmt.Errorf("error updating Platform Hub version control settings: %v", err)
+		return
+	}
+
+	fmt.Printf("Platform Hub configured against: (%s)\n", updatedSettings.URL)
+}

--- a/examples/platform_hub/configure_version_control_settings_with_github_connection.go
+++ b/examples/platform_hub/configure_version_control_settings_with_github_connection.go
@@ -1,0 +1,71 @@
+package examples
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/credentials"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/githubconnections"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/platformhubgithubconnections"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/platformhubversioncontrolsettings"
+)
+
+// ConfigurePlatformHubVersionControlSettingsWithGitHubConnectionExample provides an example
+// of how to point Platform Hub at a repository reachable through a GitHub App connection.
+//
+// The repository listing supplies both the Git URL and the repository's own default branch,
+// so neither needs to be provided.
+func ConfigurePlatformHubVersionControlSettingsWithGitHubConnectionExample() {
+	var (
+		apiKey     string = "API-YOUR_API_KEY"
+		octopusURL string = "https://your_octopus_url"
+
+		// version control values
+		connectionID   string = "GitHubAppConnections-1"
+		repositoryName string = "your-org/your-repo"
+		basePath       string = ".octopus/"
+	)
+
+	apiURL, err := url.Parse(octopusURL)
+	if err != nil {
+		_ = fmt.Errorf("error parsing URL for Octopus API: %v", err)
+		return
+	}
+
+	// Platform Hub is system-scoped, so no space ID is required
+	octopusClient, err := client.NewClient(nil, apiURL, apiKey, "")
+	if err != nil {
+		_ = fmt.Errorf("error creating API client: %v", err)
+		return
+	}
+
+	repositories, err := platformhubgithubconnections.GetRepositories(octopusClient, connectionID)
+	if err != nil {
+		_ = fmt.Errorf("error getting repositories for connection: %v", err)
+		return
+	}
+
+	var repository *githubconnections.Repository
+	for _, r := range repositories {
+		if r.RepositoryName == repositoryName {
+			repository = r
+			break
+		}
+	}
+	if repository == nil {
+		_ = fmt.Errorf("repository (%s) is not accessible through connection (%s)", repositoryName, connectionID)
+		return
+	}
+
+	gitCredentials := credentials.NewGitHubApp(connectionID)
+	settings := platformhubversioncontrolsettings.NewResource(repository.GitURL, gitCredentials, repository.DefaultBranch, basePath)
+
+	updatedSettings, err := platformhubversioncontrolsettings.Update(octopusClient, settings)
+	if err != nil {
+		_ = fmt.Errorf("error updating Platform Hub version control settings: %v", err)
+		return
+	}
+
+	fmt.Printf("Platform Hub configured against: (%s)\n", updatedSettings.URL)
+}

--- a/examples/platform_hub/get_github_connection_by_id.go
+++ b/examples/platform_hub/get_github_connection_by_id.go
@@ -1,0 +1,53 @@
+package examples
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/platformhubgithubconnections"
+)
+
+// GetPlatformHubGitHubConnectionByIDExample provides an example of how to get a single
+// Platform Hub GitHub App connection and the repositories it grants access to.
+func GetPlatformHubGitHubConnectionByIDExample() {
+	var (
+		apiKey     string = "API-YOUR_API_KEY"
+		octopusURL string = "https://your_octopus_url"
+
+		// GitHub connection values
+		connectionID string = "GitHubAppConnections-1"
+	)
+
+	apiURL, err := url.Parse(octopusURL)
+	if err != nil {
+		_ = fmt.Errorf("error parsing URL for Octopus API: %v", err)
+		return
+	}
+
+	// Platform Hub is system-scoped, so no space ID is required
+	octopusClient, err := client.NewClient(nil, apiURL, apiKey, "")
+	if err != nil {
+		_ = fmt.Errorf("error creating API client: %v", err)
+		return
+	}
+
+	connection, err := platformhubgithubconnections.GetByID(octopusClient, connectionID)
+	if err != nil {
+		_ = fmt.Errorf("error getting GitHub connection: %v", err)
+		return
+	}
+
+	fmt.Printf("connection: (%s) %s\n", connection.ID, connection.Installation.AccountLogin)
+	fmt.Printf("status: %s %s\n", connection.Status, connection.StatusUserMessage)
+
+	for _, repository := range connection.Repositories {
+		fmt.Printf("  repository: %s (%s)\n", repository.RepositoryName, repository.GitURL)
+	}
+
+	// repositories configured on the connection that GitHub no longer returns; they may have
+	// been deleted, renamed, or had access revoked
+	for _, repository := range connection.UnknownRepositories {
+		fmt.Printf("  unknown repository: %s (%s)\n", repository.RepositoryName, repository.RepositoryID)
+	}
+}

--- a/examples/platform_hub/get_version_control_settings.go
+++ b/examples/platform_hub/get_version_control_settings.go
@@ -1,0 +1,53 @@
+package examples
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/credentials"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/platformhubversioncontrolsettings"
+)
+
+// GetPlatformHubVersionControlSettingsExample provides an example of how to read the
+// Platform Hub version control settings from Octopus Deploy through the Go API client.
+func GetPlatformHubVersionControlSettingsExample() {
+	var (
+		apiKey     string = "API-YOUR_API_KEY"
+		octopusURL string = "https://your_octopus_url"
+	)
+
+	apiURL, err := url.Parse(octopusURL)
+	if err != nil {
+		_ = fmt.Errorf("error parsing URL for Octopus API: %v", err)
+		return
+	}
+
+	// Platform Hub is system-scoped, so no space ID is required
+	octopusClient, err := client.NewClient(nil, apiURL, apiKey, "")
+	if err != nil {
+		_ = fmt.Errorf("error creating API client: %v", err)
+		return
+	}
+
+	settings, err := platformhubversioncontrolsettings.Get(octopusClient)
+	if err != nil {
+		_ = fmt.Errorf("error getting Platform Hub version control settings: %v", err)
+		return
+	}
+
+	fmt.Printf("URL: %s\n", settings.URL)
+	fmt.Printf("default branch: %s\n", settings.DefaultBranch)
+	fmt.Printf("base path: %s\n", settings.BasePath)
+
+	switch creds := settings.Credentials.(type) {
+	case *credentials.Anonymous:
+		fmt.Println("credentials: anonymous")
+	case *credentials.UsernamePassword:
+		fmt.Printf("credentials: username/password (%s)\n", creds.Username)
+	case *credentials.GitHubApp:
+		fmt.Printf("credentials: GitHub App connection (%s)\n", creds.ID)
+	case nil:
+		fmt.Println("Platform Hub is not configured for version control")
+	}
+}

--- a/examples/platform_hub/list_github_connections.go
+++ b/examples/platform_hub/list_github_connections.go
@@ -1,0 +1,78 @@
+package examples
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/githubconnections"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/platformhubgithubconnections"
+)
+
+// ListPlatformHubGitHubConnectionsExample provides an example of how to list the GitHub App
+// connections available to Platform Hub, paging through the results.
+func ListPlatformHubGitHubConnectionsExample() {
+	var (
+		apiKey     string = "API-YOUR_API_KEY"
+		octopusURL string = "https://your_octopus_url"
+
+		// paging values; both skip and take are required by the API
+		take int = 30
+	)
+
+	apiURL, err := url.Parse(octopusURL)
+	if err != nil {
+		_ = fmt.Errorf("error parsing URL for Octopus API: %v", err)
+		return
+	}
+
+	// Platform Hub is system-scoped, so no space ID is required
+	octopusClient, err := client.NewClient(nil, apiURL, apiKey, "")
+	if err != nil {
+		_ = fmt.Errorf("error creating API client: %v", err)
+		return
+	}
+
+	settings, err := githubconnections.GetSettings(octopusClient)
+	if err != nil {
+		_ = fmt.Errorf("error getting GitHub App settings: %v", err)
+		return
+	}
+	if !settings.CanUseGitHubApp {
+		fmt.Println("this Octopus instance cannot use GitHub App connections")
+		return
+	}
+
+	var connections []*githubconnections.Connection
+	for {
+		page, err := platformhubgithubconnections.List(octopusClient, len(connections), take)
+		if err != nil {
+			_ = fmt.Errorf("error listing GitHub connections: %v", err)
+			return
+		}
+
+		connections = append(connections, page.Connections...)
+
+		if len(page.Connections) == 0 || len(connections) >= page.TotalResults {
+			break
+		}
+	}
+
+	for _, connection := range connections {
+		fmt.Printf("connection: (%s) %s %s [%s]\n", connection.ID, connection.Installation.AccountType, connection.Installation.AccountLogin, connection.Status)
+
+		if connection.Status != githubconnections.ConnectionStatusConnected {
+			continue
+		}
+
+		repositories, err := platformhubgithubconnections.GetRepositories(octopusClient, connection.ID)
+		if err != nil {
+			_ = fmt.Errorf("error getting repositories for connection: %v", err)
+			return
+		}
+
+		for _, repository := range repositories {
+			fmt.Printf("  repository: %s (%s), default branch: %s\n", repository.RepositoryName, repository.GitURL, repository.DefaultBranch)
+		}
+	}
+}

--- a/examples/process_templates/create_process_template.go
+++ b/examples/process_templates/create_process_template.go
@@ -1,0 +1,48 @@
+package examples
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/processtemplates"
+)
+
+// CreateProcessTemplateExample provides an example of how to create a process template in
+// Platform Hub through the Go API client.
+//
+// Steps and parameters cannot be set at creation time; the new template is empty, and should be
+// configured after in Git or Octopus Deploy.
+func CreateProcessTemplateExample() {
+	var (
+		apiKey     string = "API-YOUR_API_KEY"
+		octopusURL string = "https://your_octopus_url"
+
+		// process template values
+		gitRef            string = "refs/heads/main"
+		name              string = "your-process-template-name"
+		description       string = "your-process-template-description"
+		changeDescription string = "Add a process template"
+	)
+
+	apiURL, err := url.Parse(octopusURL)
+	if err != nil {
+		_ = fmt.Errorf("error parsing URL for Octopus API: %v", err)
+		return
+	}
+
+	// Platform Hub is system-scoped, so no space ID is required
+	octopusClient, err := client.NewClient(nil, apiURL, apiKey, "")
+	if err != nil {
+		_ = fmt.Errorf("error creating API client: %v", err)
+		return
+	}
+
+	processTemplate, err := processtemplates.Add(octopusClient, gitRef, name, description, changeDescription)
+	if err != nil {
+		_ = fmt.Errorf("error creating process template: %v", err)
+		return
+	}
+
+	fmt.Printf("process template created: (%s) %s\n", processTemplate.Slug, processTemplate.Name)
+}

--- a/examples/process_templates/get_process_template_by_slug.go
+++ b/examples/process_templates/get_process_template_by_slug.go
@@ -1,0 +1,62 @@
+package examples
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/processtemplates"
+)
+
+// GetProcessTemplateBySlugExample provides an example of how to get a single process template
+// from Platform Hub through the Go API client.
+func GetProcessTemplateBySlugExample() {
+	var (
+		apiKey     string = "API-YOUR_API_KEY"
+		octopusURL string = "https://your_octopus_url"
+
+		// process template values
+		gitRef string = "refs/heads/main"
+		slug   string = "your-process-template-slug"
+	)
+
+	apiURL, err := url.Parse(octopusURL)
+	if err != nil {
+		_ = fmt.Errorf("error parsing URL for Octopus API: %v", err)
+		return
+	}
+
+	// Platform Hub is system-scoped, so no space ID is required
+	octopusClient, err := client.NewClient(nil, apiURL, apiKey, "")
+	if err != nil {
+		_ = fmt.Errorf("error creating API client: %v", err)
+		return
+	}
+
+	processTemplate, err := processtemplates.GetBySlug(octopusClient, gitRef, slug)
+	if err != nil {
+		_ = fmt.Errorf("error getting process template: %v", err)
+		return
+	}
+
+	fmt.Printf("process template: (%s) %s\n", processTemplate.Slug, processTemplate.Name)
+	fmt.Printf("description: %s\n", processTemplate.Description)
+
+	for _, step := range processTemplate.Steps {
+		fmt.Printf("  step: %s\n", step.Name)
+	}
+
+	for _, parameter := range processTemplate.Parameters {
+		fmt.Printf("  parameter: %s, optional: %t\n", parameter.Name, parameter.IsOptional)
+
+		for _, value := range parameter.Values {
+			// a parameter value is sensitive when it is backed by a sensitive value rather
+			// than a plain string
+			if value.Value.IsSensitive {
+				fmt.Println("    default value: (sensitive)")
+				continue
+			}
+			fmt.Printf("    default value: %s\n", value.Value.Value)
+		}
+	}
+}

--- a/examples/process_templates/list_process_templates.go
+++ b/examples/process_templates/list_process_templates.go
@@ -1,0 +1,51 @@
+package examples
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/processtemplates"
+)
+
+// ListProcessTemplatesExample provides an example of how to list the process templates on a
+// Git reference in Platform Hub through the Go API client.
+func ListProcessTemplatesExample() {
+	var (
+		apiKey     string = "API-YOUR_API_KEY"
+		octopusURL string = "https://your_octopus_url"
+
+		// process template values
+		gitRef string = "refs/heads/main"
+	)
+
+	apiURL, err := url.Parse(octopusURL)
+	if err != nil {
+		_ = fmt.Errorf("error parsing URL for Octopus API: %v", err)
+		return
+	}
+
+	// Platform Hub is system-scoped, so no space ID is required
+	octopusClient, err := client.NewClient(nil, apiURL, apiKey, "")
+	if err != nil {
+		_ = fmt.Errorf("error creating API client: %v", err)
+		return
+	}
+
+	query := processtemplates.ProcessTemplatesQuery{
+		GitRef: gitRef,
+		Take:   30,
+	}
+
+	results, err := processtemplates.List(octopusClient, query)
+	if err != nil {
+		_ = fmt.Errorf("error listing process templates: %v", err)
+		return
+	}
+
+	for _, processTemplate := range results.ProcessTemplates {
+		fmt.Printf("process template: (%s) %s, %d step(s), %d parameter(s)\n", processTemplate.Slug, processTemplate.Name, len(processTemplate.Steps), len(processTemplate.Parameters))
+	}
+
+	fmt.Printf("showing %d of %d process template(s)\n", len(results.ProcessTemplates), results.TotalResults)
+}

--- a/pkg/githubconnections/connection.go
+++ b/pkg/githubconnections/connection.go
@@ -1,0 +1,31 @@
+package githubconnections
+
+// ConnectionStatus describes the health of a GitHub App connection.
+type ConnectionStatus string
+
+const (
+	ConnectionStatusConnected             = ConnectionStatus("Connected")
+	ConnectionStatusConnectionNotFound    = ConnectionStatus("ConnectionNotFound")
+	ConnectionStatusInstallationNotFound  = ConnectionStatus("InstallationNotFound")
+	ConnectionStatusInstallationSuspended = ConnectionStatus("InstallationSuspended")
+	ConnectionStatusError                 = ConnectionStatus("Error")
+)
+
+// Installation represents the GitHub App installation backing a connection.
+type Installation struct {
+	InstallationID   string `json:"InstallationId"`
+	AccountID        string `json:"AccountId"`
+	AccountLogin     string `json:"AccountLogin"`
+	AccountAvatarURL string `json:"AccountAvatarUrl"`
+	AccountType      string `json:"AccountType"`
+	// AllRepositories is true when the installation can access every repository in the
+	// account, false when it is restricted to a selected set.
+	AllRepositories bool `json:"AllRepositories"`
+}
+
+// Connection represents a GitHub App connection.
+type Connection struct {
+	ID           string           `json:"Id"`
+	Status       ConnectionStatus `json:"Status,omitempty"`
+	Installation *Installation    `json:"Installation,omitempty"`
+}

--- a/pkg/githubconnections/repository.go
+++ b/pkg/githubconnections/repository.go
@@ -1,0 +1,20 @@
+package githubconnections
+
+// Repository represents a GitHub repository reachable through a GitHub App connection.
+type Repository struct {
+	RepositoryID   string `json:"RepositoryId"`
+	RepositoryName string `json:"RepositoryName"`
+	IsAdmin        bool   `json:"IsAdmin"`
+	IsPrivate      bool   `json:"IsPrivate"`
+	Visibility     string `json:"Visibility"`
+	Language       string `json:"Language,omitempty"`
+	GitURL         string `json:"GitUrl"`
+	DefaultBranch  string `json:"DefaultBranch"`
+}
+
+// UnknownRepository represents a repository configured on a connection that has no
+// matching repository returned from GitHub.
+type UnknownRepository struct {
+	RepositoryID   string `json:"RepositoryId"`
+	RepositoryName string `json:"RepositoryName,omitempty"`
+}

--- a/pkg/githubconnections/settings.go
+++ b/pkg/githubconnections/settings.go
@@ -1,0 +1,18 @@
+package githubconnections
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+)
+
+const settingsPath = "/api/githubconnections/app/settings"
+
+// Settings represents the server-wide GitHub App settings.
+type Settings struct {
+	CanUseGitHubApp   bool `json:"CanUseGitHubApp"`
+	CanUseTrustedFlow bool `json:"CanUseTrustedFlow"`
+}
+
+// GetSettings returns the server's GitHub App settings.
+func GetSettings(client newclient.Client) (*Settings, error) {
+	return newclient.Get[Settings](client.HttpSession(), settingsPath)
+}

--- a/pkg/githubconnections/settings.go
+++ b/pkg/githubconnections/settings.go
@@ -4,7 +4,7 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
 )
 
-const settingsPath = "/api/githubconnections/app/settings"
+const settingsPath = "/api/github/app/settings"
 
 // Settings represents the server-wide GitHub App settings.
 type Settings struct {

--- a/pkg/githubconnections/settings_test.go
+++ b/pkg/githubconnections/settings_test.go
@@ -1,0 +1,33 @@
+package githubconnections
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSettings(t *testing.T) {
+	var requested string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = r.URL.RequestURI()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"CanUseGitHubApp":true,"CanUseTrustedFlow":false}`))
+	}))
+	defer server.Close()
+
+	baseURL, err := url.Parse(server.URL + "/")
+	require.NoError(t, err)
+	client := newclient.NewClient(&newclient.HttpSession{HttpClient: server.Client(), BaseURL: baseURL})
+
+	settings, err := GetSettings(client)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/githubconnections/app/settings", requested)
+	assert.True(t, settings.CanUseGitHubApp)
+	assert.False(t, settings.CanUseTrustedFlow)
+}

--- a/pkg/platformhubgithubconnections/service.go
+++ b/pkg/platformhubgithubconnections/service.go
@@ -23,8 +23,7 @@ type ConnectionDetails struct {
 	UnknownRepositories []*githubconnections.UnknownRepository `json:"UnknownRepositories"`
 }
 
-// ConnectionsQuery represents the query parameters for listing connections. Both
-// skip and take are required by the server contract, so neither is omitted when empty.
+// ConnectionsQuery represents the query parameters for listing connections. Both skip and take are required.
 type ConnectionsQuery struct {
 	Skip int `uri:"skip" json:"skip"`
 	Take int `uri:"take" json:"take"`

--- a/pkg/platformhubgithubconnections/service.go
+++ b/pkg/platformhubgithubconnections/service.go
@@ -1,0 +1,108 @@
+package platformhubgithubconnections
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/githubconnections"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+)
+
+const (
+	connectionsTemplate  = "/api/platformhub/githubconnections/connections{?skip,take}"
+	connectionTemplate   = "/api/platformhub/githubconnections/connections/{id}"
+	repositoriesTemplate = "/api/platformhub/githubconnections/connections/{connectionId}/repositories"
+
+	// defaultPageSize matches the server's default 'take'.
+	defaultPageSize = 30
+)
+
+// ConnectionDetails represents a single Platform Hub GitHub App connection, including the
+// repositories it grants access to which githubconnections.Connection doesn't include.
+type ConnectionDetails struct {
+	ID                  string                                 `json:"Id"`
+	Status              githubconnections.ConnectionStatus     `json:"Status"`
+	StatusUserMessage   string                                 `json:"StatusUserMessage,omitempty"`
+	Installation        *githubconnections.Installation        `json:"Installation,omitempty"`
+	Repositories        []*githubconnections.Repository        `json:"Repositories"`
+	UnknownRepositories []*githubconnections.UnknownRepository `json:"UnknownRepositories"`
+}
+
+// ConnectionsQuery represents the query parameters for listing connections. Both
+// skip and take are required by the server contract, so neither is omitted when empty.
+type ConnectionsQuery struct {
+	Skip int `uri:"skip" json:"skip"`
+	Take int `uri:"take" json:"take"`
+}
+
+// ConnectionsQueryResult is a paginated collection of Platform Hub GitHub App connections.
+type ConnectionsQueryResult struct {
+	Connections   []*githubconnections.Connection `json:"Connections"`
+	ItemsPerPage  int                             `json:"ItemsPerPage"`
+	NumberOfPages int                             `json:"NumberOfPages"`
+	TotalResults  int                             `json:"TotalResults"`
+}
+
+// List returns a single page of Platform Hub GitHub App connections.
+func List(client newclient.Client, skip int, take int) (*ConnectionsQueryResult, error) {
+	path, err := client.URITemplateCache().Expand(connectionsTemplate, ConnectionsQuery{Skip: skip, Take: take})
+	if err != nil {
+		return nil, err
+	}
+
+	return newclient.Get[ConnectionsQueryResult](client.HttpSession(), path)
+}
+
+// ListAll returns every Platform Hub GitHub App connection, paging until TotalResults is reached.
+func ListAll(client newclient.Client) ([]*githubconnections.Connection, error) {
+	connections := make([]*githubconnections.Connection, 0)
+
+	for {
+		page, err := List(client, len(connections), defaultPageSize)
+		if err != nil {
+			return nil, err
+		}
+
+		connections = append(connections, page.Connections...)
+
+		if len(page.Connections) == 0 || len(connections) >= page.TotalResults {
+			return connections, nil
+		}
+	}
+}
+
+// GetByID returns the Platform Hub GitHub App connection with the given ID, along with the
+// repositories it grants access to.
+func GetByID(client newclient.Client, id string) (*ConnectionDetails, error) {
+	if internal.IsEmpty(id) {
+		return nil, internal.CreateInvalidParameterError("GetByID", "id")
+	}
+
+	path, err := client.URITemplateCache().Expand(connectionTemplate, map[string]any{"id": id})
+	if err != nil {
+		return nil, err
+	}
+
+	return newclient.Get[ConnectionDetails](client.HttpSession(), path)
+}
+
+type repositoriesResponse struct {
+	Repositories []*githubconnections.Repository `json:"Repositories"`
+}
+
+// GetRepositories returns the GitHub repositories reachable through the given connection.
+func GetRepositories(client newclient.Client, connectionID string) ([]*githubconnections.Repository, error) {
+	if internal.IsEmpty(connectionID) {
+		return nil, internal.CreateInvalidParameterError("GetRepositories", "connectionID")
+	}
+
+	path, err := client.URITemplateCache().Expand(repositoriesTemplate, map[string]any{"connectionId": connectionID})
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := newclient.Get[repositoriesResponse](client.HttpSession(), path)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Repositories, nil
+}

--- a/pkg/platformhubgithubconnections/service.go
+++ b/pkg/platformhubgithubconnections/service.go
@@ -10,9 +10,6 @@ const (
 	connectionsTemplate  = "/api/platformhub/githubconnections/connections{?skip,take}"
 	connectionTemplate   = "/api/platformhub/githubconnections/connections/{id}"
 	repositoriesTemplate = "/api/platformhub/githubconnections/connections/{connectionId}/repositories"
-
-	// defaultPageSize matches the server's default 'take'.
-	defaultPageSize = 30
 )
 
 // ConnectionDetails represents a single Platform Hub GitHub App connection, including the
@@ -49,24 +46,6 @@ func List(client newclient.Client, skip int, take int) (*ConnectionsQueryResult,
 	}
 
 	return newclient.Get[ConnectionsQueryResult](client.HttpSession(), path)
-}
-
-// ListAll returns every Platform Hub GitHub App connection, paging until TotalResults is reached.
-func ListAll(client newclient.Client) ([]*githubconnections.Connection, error) {
-	connections := make([]*githubconnections.Connection, 0)
-
-	for {
-		page, err := List(client, len(connections), defaultPageSize)
-		if err != nil {
-			return nil, err
-		}
-
-		connections = append(connections, page.Connections...)
-
-		if len(page.Connections) == 0 || len(connections) >= page.TotalResults {
-			return connections, nil
-		}
-	}
 }
 
 // GetByID returns the Platform Hub GitHub App connection with the given ID, along with the

--- a/pkg/platformhubgithubconnections/service.go
+++ b/pkg/platformhubgithubconnections/service.go
@@ -7,9 +7,9 @@ import (
 )
 
 const (
-	connectionsTemplate  = "/api/platformhub/githubconnections/connections{?skip,take}"
-	connectionTemplate   = "/api/platformhub/githubconnections/connections/{id}"
-	repositoriesTemplate = "/api/platformhub/githubconnections/connections/{connectionId}/repositories"
+	connectionsTemplate  = "/api/platformhub/github/connections{?skip,take}"
+	connectionTemplate   = "/api/platformhub/github/connections/{id}"
+	repositoriesTemplate = "/api/platformhub/github/connections/{connectionId}/repositories"
 )
 
 // ConnectionDetails represents a single Platform Hub GitHub App connection, including the

--- a/pkg/platformhubgithubconnections/service_test.go
+++ b/pkg/platformhubgithubconnections/service_test.go
@@ -1,0 +1,190 @@
+package platformhubgithubconnections
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/githubconnections"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestClient returns a client pointed at a server that records the requested URI and
+// replies with the given payloads, one per request in order.
+func newTestClient(t *testing.T, requested *[]string, payloads ...string) newclient.Client {
+	t.Helper()
+
+	call := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*requested = append(*requested, r.URL.RequestURI())
+		payload := payloads[len(payloads)-1]
+		if call < len(payloads) {
+			payload = payloads[call]
+		}
+		call++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(payload))
+	}))
+	t.Cleanup(server.Close)
+
+	baseURL, err := url.Parse(server.URL + "/")
+	require.NoError(t, err)
+
+	return newclient.NewClient(&newclient.HttpSession{HttpClient: server.Client(), BaseURL: baseURL})
+}
+
+func TestList(t *testing.T) {
+	const payload = `{
+	  "Connections": [
+	    {
+	      "Id": "GitHubAppConnections-1",
+	      "Status": "Connected",
+	      "Installation": {
+	        "InstallationId": "12345",
+	        "AccountId": "678",
+	        "AccountLogin": "OctopusDeploy",
+	        "AccountAvatarUrl": "https://avatars.githubusercontent.com/u/678",
+	        "AccountType": "Organization",
+	        "AllRepositories": false
+	      }
+	    },
+	    { "Id": "GitHubAppConnections-2", "Status": "InstallationSuspended" }
+	  ],
+	  "ItemsPerPage": 30,
+	  "NumberOfPages": 1,
+	  "TotalResults": 2
+	}`
+
+	var requested []string
+	client := newTestClient(t, &requested, payload)
+
+	result, err := List(client, 0, 30)
+	require.NoError(t, err)
+
+	// skip and take are [Required] on the server contract, so a zero skip must still be sent.
+	require.Len(t, requested, 1)
+	assert.Equal(t, "/api/platformhub/githubconnections/connections?skip=0&take=30", requested[0])
+
+	require.Len(t, result.Connections, 2)
+	assert.Equal(t, 2, result.TotalResults)
+	assert.Equal(t, "GitHubAppConnections-1", result.Connections[0].ID)
+	assert.Equal(t, githubconnections.ConnectionStatusConnected, result.Connections[0].Status)
+	require.NotNil(t, result.Connections[0].Installation)
+	assert.Equal(t, "OctopusDeploy", result.Connections[0].Installation.AccountLogin)
+	assert.Equal(t, "Organization", result.Connections[0].Installation.AccountType)
+	assert.False(t, result.Connections[0].Installation.AllRepositories)
+	assert.Equal(t, githubconnections.ConnectionStatusInstallationSuspended, result.Connections[1].Status)
+	assert.Nil(t, result.Connections[1].Installation)
+}
+
+func TestListAllPagesUntilTotalResults(t *testing.T) {
+	const firstPage = `{"Connections":[{"Id":"GitHubAppConnections-1"}],"ItemsPerPage":1,"NumberOfPages":2,"TotalResults":2}`
+	const secondPage = `{"Connections":[{"Id":"GitHubAppConnections-2"}],"ItemsPerPage":1,"NumberOfPages":2,"TotalResults":2}`
+
+	var requested []string
+	client := newTestClient(t, &requested, firstPage, secondPage)
+
+	connections, err := ListAll(client)
+	require.NoError(t, err)
+
+	require.Len(t, requested, 2)
+	assert.Equal(t, "/api/platformhub/githubconnections/connections?skip=0&take=30", requested[0])
+	assert.Equal(t, "/api/platformhub/githubconnections/connections?skip=1&take=30", requested[1])
+
+	require.Len(t, connections, 2)
+	assert.Equal(t, "GitHubAppConnections-1", connections[0].ID)
+	assert.Equal(t, "GitHubAppConnections-2", connections[1].ID)
+}
+
+func TestListAllStopsOnEmptyPage(t *testing.T) {
+	// A TotalResults larger than the server actually returns must not loop forever.
+	const page = `{"Connections":[],"ItemsPerPage":30,"NumberOfPages":1,"TotalResults":5}`
+
+	var requested []string
+	client := newTestClient(t, &requested, page)
+
+	connections, err := ListAll(client)
+	require.NoError(t, err)
+
+	assert.Len(t, requested, 1)
+	assert.Empty(t, connections)
+}
+
+func TestGetByID(t *testing.T) {
+	const payload = `{
+	  "Id": "GitHubAppConnections-1",
+	  "Status": "Connected",
+	  "StatusUserMessage": "All good",
+	  "Installation": { "InstallationId": "12345", "AccountLogin": "OctopusDeploy", "AccountType": "Organization" },
+	  "Repositories": [
+	    {
+	      "RepositoryId": "R_1",
+	      "RepositoryName": "hub",
+	      "IsAdmin": true,
+	      "IsPrivate": true,
+	      "Visibility": "private",
+	      "Language": "Go",
+	      "GitUrl": "https://githubconnections.com/OctopusDeploy/hub.git",
+	      "DefaultBranch": "main"
+	    }
+	  ],
+	  "UnknownRepositories": [{ "RepositoryId": "R_2" }]
+	}`
+
+	var requested []string
+	client := newTestClient(t, &requested, payload)
+
+	connection, err := GetByID(client, "GitHubAppConnections-1")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/platformhub/githubconnections/connections/GitHubAppConnections-1", requested[0])
+	assert.Equal(t, githubconnections.ConnectionStatusConnected, connection.Status)
+	assert.Equal(t, "All good", connection.StatusUserMessage)
+	require.Len(t, connection.Repositories, 1)
+	assert.Equal(t, "https://github.com/OctopusDeploy/hub.git", connection.Repositories[0].GitURL)
+	assert.Equal(t, "main", connection.Repositories[0].DefaultBranch)
+	require.Len(t, connection.UnknownRepositories, 1)
+	assert.Equal(t, "R_2", connection.UnknownRepositories[0].RepositoryID)
+}
+
+func TestGetByIDWithEmptyID(t *testing.T) {
+	var requested []string
+	client := newTestClient(t, &requested, `{}`)
+
+	connection, err := GetByID(client, "")
+	require.Error(t, err)
+	require.Nil(t, connection)
+	assert.Empty(t, requested)
+}
+
+func TestGetRepositories(t *testing.T) {
+	const payload = `{
+	  "Repositories": [
+	    { "RepositoryId": "R_1", "RepositoryName": "hub", "GitUrl": "https://githubconnections.com/OctopusDeploy/hub.git", "DefaultBranch": "main" },
+	    { "RepositoryId": "R_2", "RepositoryName": "other", "GitUrl": "https://githubconnections.com/OctopusDeploy/other.git", "DefaultBranch": "trunk" }
+	  ]
+	}`
+
+	var requested []string
+	client := newTestClient(t, &requested, payload)
+
+	repositories, err := GetRepositories(client, "GitHubAppConnections-1")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/platformhub/githubconnections/connections/GitHubAppConnections-1/repositories", requested[0])
+	require.Len(t, repositories, 2)
+	assert.Equal(t, "trunk", repositories[1].DefaultBranch)
+}
+
+func TestGetRepositoriesWithEmptyConnectionID(t *testing.T) {
+	var requested []string
+	client := newTestClient(t, &requested, `{}`)
+
+	repositories, err := GetRepositories(client, "")
+	require.Error(t, err)
+	require.Nil(t, repositories)
+	assert.Empty(t, requested)
+}

--- a/pkg/platformhubgithubconnections/service_test.go
+++ b/pkg/platformhubgithubconnections/service_test.go
@@ -94,7 +94,7 @@ func TestGetByID(t *testing.T) {
 	      "IsPrivate": true,
 	      "Visibility": "private",
 	      "Language": "Go",
-	      "GitUrl": "https://githubconnections.com/OctopusDeploy/hub.git",
+	      "GitUrl": "https://github.com/OctopusDeploy/hub.git",
 	      "DefaultBranch": "main"
 	    }
 	  ],
@@ -130,8 +130,8 @@ func TestGetByIDWithEmptyID(t *testing.T) {
 func TestGetRepositories(t *testing.T) {
 	const payload = `{
 	  "Repositories": [
-	    { "RepositoryId": "R_1", "RepositoryName": "hub", "GitUrl": "https://githubconnections.com/OctopusDeploy/hub.git", "DefaultBranch": "main" },
-	    { "RepositoryId": "R_2", "RepositoryName": "other", "GitUrl": "https://githubconnections.com/OctopusDeploy/other.git", "DefaultBranch": "trunk" }
+	    { "RepositoryId": "R_1", "RepositoryName": "hub", "GitUrl": "https://github.com/OctopusDeploy/hub.git", "DefaultBranch": "main" },
+	    { "RepositoryId": "R_2", "RepositoryName": "other", "GitUrl": "https://github.com/OctopusDeploy/other.git", "DefaultBranch": "trunk" }
 	  ]
 	}`
 

--- a/pkg/platformhubgithubconnections/service_test.go
+++ b/pkg/platformhubgithubconnections/service_test.go
@@ -80,39 +80,6 @@ func TestList(t *testing.T) {
 	assert.Nil(t, result.Connections[1].Installation)
 }
 
-func TestListAllPagesUntilTotalResults(t *testing.T) {
-	const firstPage = `{"Connections":[{"Id":"GitHubAppConnections-1"}],"ItemsPerPage":1,"NumberOfPages":2,"TotalResults":2}`
-	const secondPage = `{"Connections":[{"Id":"GitHubAppConnections-2"}],"ItemsPerPage":1,"NumberOfPages":2,"TotalResults":2}`
-
-	var requested []string
-	client := newTestClient(t, &requested, firstPage, secondPage)
-
-	connections, err := ListAll(client)
-	require.NoError(t, err)
-
-	require.Len(t, requested, 2)
-	assert.Equal(t, "/api/platformhub/githubconnections/connections?skip=0&take=30", requested[0])
-	assert.Equal(t, "/api/platformhub/githubconnections/connections?skip=1&take=30", requested[1])
-
-	require.Len(t, connections, 2)
-	assert.Equal(t, "GitHubAppConnections-1", connections[0].ID)
-	assert.Equal(t, "GitHubAppConnections-2", connections[1].ID)
-}
-
-func TestListAllStopsOnEmptyPage(t *testing.T) {
-	// A TotalResults larger than the server actually returns must not loop forever.
-	const page = `{"Connections":[],"ItemsPerPage":30,"NumberOfPages":1,"TotalResults":5}`
-
-	var requested []string
-	client := newTestClient(t, &requested, page)
-
-	connections, err := ListAll(client)
-	require.NoError(t, err)
-
-	assert.Len(t, requested, 1)
-	assert.Empty(t, connections)
-}
-
 func TestGetByID(t *testing.T) {
 	const payload = `{
 	  "Id": "GitHubAppConnections-1",

--- a/pkg/platformhubversioncontrolsettings/resource.go
+++ b/pkg/platformhubversioncontrolsettings/resource.go
@@ -78,7 +78,16 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 			return err
 		}
 		r.Credentials = usernamePasswordCredential
+	case credentials.GitCredentialTypeGitHubApp:
+		var gitHubAppCredential *credentials.GitHubApp
+		if err := json.Unmarshal(*credentialsRaw, &gitHubAppCredential); err != nil {
+			return err
+		}
+		r.Credentials = gitHubAppCredential
 	}
+	// GitCredentialTypeReference is deliberately not handled: Platform Hub's reference
+	// credential (ReferencePlatformHubGitCredentialUsageResource) is not believed to be
+	// fully validated on save, so it is not exposed here.
 
 	return nil
 }

--- a/pkg/platformhubversioncontrolsettings/resource.go
+++ b/pkg/platformhubversioncontrolsettings/resource.go
@@ -85,9 +85,8 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 		}
 		r.Credentials = gitHubAppCredential
 	}
-	// GitCredentialTypeReference is deliberately not handled: Platform Hub's reference
-	// credential (ReferencePlatformHubGitCredentialUsageResource) is not believed to be
-	// fully validated on save, so it is not exposed here.
+	// GitCredentialTypeReference isn't handled as using a reference credential
+	// (ReferencePlatformHubGitCredentialUsageResource) isn't fully supported yet
 
 	return nil
 }

--- a/pkg/platformhubversioncontrolsettings/resource_test.go
+++ b/pkg/platformhubversioncontrolsettings/resource_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestResource_UnmarshalJSON_Anonymous(t *testing.T) {
 	const payload = `{
-		"Url": "https://githubconnections.com/OctopusDeploy/hub.git",
+		"Url": "https://github.com/OctopusDeploy/hub.git",
 		"DefaultBranch": "main",
 		"BasePath": ".octopus/",
 		"Credentials": { "Type": "Anonymous" }
@@ -31,7 +31,7 @@ func TestResource_UnmarshalJSON_Anonymous(t *testing.T) {
 
 func TestResource_UnmarshalJSON_UsernamePassword(t *testing.T) {
 	const payload = `{
-		"Url": "https://githubconnections.com/OctopusDeploy/hub.git",
+		"Url": "https://github.com/OctopusDeploy/hub.git",
 		"DefaultBranch": "main",
 		"BasePath": ".octopus/",
 		"Credentials": { "Type": "UsernamePassword", "Username": "octobob", "Password": { "HasValue": true } }
@@ -50,7 +50,7 @@ func TestResource_UnmarshalJSON_UsernamePassword(t *testing.T) {
 
 func TestResource_UnmarshalJSON_GitHubApp(t *testing.T) {
 	const payload = `{
-		"Url": "https://githubconnections.com/OctopusDeploy/hub.git",
+		"Url": "https://github.com/OctopusDeploy/hub.git",
 		"DefaultBranch": "main",
 		"BasePath": ".octopus/",
 		"Credentials": { "Type": "GitHub", "Id": "GitHubAppConnections-1" }

--- a/pkg/platformhubversioncontrolsettings/resource_test.go
+++ b/pkg/platformhubversioncontrolsettings/resource_test.go
@@ -1,0 +1,96 @@
+package platformhubversioncontrolsettings
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/credentials"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResource_UnmarshalJSON_Anonymous(t *testing.T) {
+	const payload = `{
+		"Url": "https://githubconnections.com/OctopusDeploy/hub.git",
+		"DefaultBranch": "main",
+		"BasePath": ".octopus/",
+		"Credentials": { "Type": "Anonymous" }
+	}`
+
+	var resource Resource
+	require.NoError(t, json.Unmarshal([]byte(payload), &resource))
+
+	require.Equal(t, "https://github.com/OctopusDeploy/hub.git", resource.URL)
+	require.Equal(t, "main", resource.DefaultBranch)
+	require.Equal(t, ".octopus/", resource.BasePath)
+
+	anonymous, ok := resource.Credentials.(*credentials.Anonymous)
+	require.True(t, ok)
+	require.Equal(t, credentials.GitCredentialTypeAnonymous, anonymous.Type())
+}
+
+func TestResource_UnmarshalJSON_UsernamePassword(t *testing.T) {
+	const payload = `{
+		"Url": "https://githubconnections.com/OctopusDeploy/hub.git",
+		"DefaultBranch": "main",
+		"BasePath": ".octopus/",
+		"Credentials": { "Type": "UsernamePassword", "Username": "octobob", "Password": { "HasValue": true } }
+	}`
+
+	var resource Resource
+	require.NoError(t, json.Unmarshal([]byte(payload), &resource))
+
+	usernamePassword, ok := resource.Credentials.(*credentials.UsernamePassword)
+	require.True(t, ok)
+	require.Equal(t, credentials.GitCredentialTypeUsernamePassword, usernamePassword.Type())
+	require.Equal(t, "octobob", usernamePassword.Username)
+	require.NotNil(t, usernamePassword.Password)
+	require.True(t, usernamePassword.Password.HasValue)
+}
+
+func TestResource_UnmarshalJSON_GitHubApp(t *testing.T) {
+	const payload = `{
+		"Url": "https://githubconnections.com/OctopusDeploy/hub.git",
+		"DefaultBranch": "main",
+		"BasePath": ".octopus/",
+		"Credentials": { "Type": "GitHub", "Id": "GitHubAppConnections-1" }
+	}`
+
+	var resource Resource
+	require.NoError(t, json.Unmarshal([]byte(payload), &resource))
+
+	gitHubApp, ok := resource.Credentials.(*credentials.GitHubApp)
+	require.True(t, ok)
+	require.Equal(t, credentials.GitCredentialTypeGitHubApp, gitHubApp.Type())
+	require.Equal(t, "GitHubAppConnections-1", gitHubApp.ID)
+}
+
+func TestResource_RoundTrip(t *testing.T) {
+	testCases := []struct {
+		name        string
+		credentials credentials.GitCredential
+	}{
+		{"anonymous", credentials.NewAnonymous()},
+		{"username password", credentials.NewUsernamePassword("octobob", core.NewSensitiveValue("secret"))},
+		{"githubconnections app", credentials.NewGitHubApp("GitHubAppConnections-1")},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			original := NewResource("https://github.com/OctopusDeploy/hub.git", testCase.credentials, "main", ".octopus/")
+
+			data, err := json.Marshal(original)
+			require.NoError(t, err)
+
+			var actual Resource
+			require.NoError(t, json.Unmarshal(data, &actual))
+
+			require.Equal(t, original.URL, actual.URL)
+			require.Equal(t, original.DefaultBranch, actual.DefaultBranch)
+			require.Equal(t, original.BasePath, actual.BasePath)
+			require.NotNil(t, actual.Credentials)
+			require.Equal(t, original.Credentials.Type(), actual.Credentials.Type())
+			require.Equal(t, original.Credentials, actual.Credentials)
+		})
+	}
+}

--- a/pkg/processtemplates/process_template.go
+++ b/pkg/processtemplates/process_template.go
@@ -1,8 +1,6 @@
 package processtemplates
 
 import (
-	"time"
-
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
@@ -12,7 +10,7 @@ import (
 type Icon struct {
 	// ID is the Font Awesome icon identifier.
 	ID string `json:"Id"`
-	// Color is the icon background colour, as a hex string.
+	// Color is the icon background color, as a hex string.
 	Color string `json:"Color"`
 }
 
@@ -28,7 +26,7 @@ type ProcessTemplate struct {
 	Parameters  []*Parameter                  `json:"Parameters,omitempty"`
 }
 
-// Parameter represents a parameter declared by a process template.
+// Parameter represents a parameter in a process template.
 type Parameter struct {
 	Name            string            `json:"Name"`
 	Label           string            `json:"Label,omitempty"`
@@ -42,18 +40,4 @@ type Parameter struct {
 type ParameterValue struct {
 	Value core.PropertyValue      `json:"Value"`
 	Scope variables.VariableScope `json:"Scope"`
-}
-
-// Summary represents a process template without its steps or parameters. Listings should
-// prefer this shape: the full template route returns every step body.
-type Summary struct {
-	ID            string     `json:"Id,omitempty"`
-	Name          string     `json:"Name"`
-	GitRef        string     `json:"GitRef"`
-	Slug          string     `json:"Slug"`
-	Description   string     `json:"Description,omitempty"`
-	Icon          *Icon      `json:"Icon,omitempty"`
-	Version       string     `json:"Version,omitempty"`
-	PublishedDate *time.Time `json:"PublishedDate,omitempty"`
-	HasError      bool       `json:"HasError"`
 }

--- a/pkg/processtemplates/process_template.go
+++ b/pkg/processtemplates/process_template.go
@@ -1,0 +1,59 @@
+package processtemplates
+
+import (
+	"time"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
+)
+
+// Icon represents the icon shown against a process template.
+type Icon struct {
+	// ID is the Font Awesome icon identifier.
+	ID string `json:"Id"`
+	// Color is the icon background colour, as a hex string.
+	Color string `json:"Color"`
+}
+
+// ProcessTemplate represents a Platform Hub process template, including its steps and parameters.
+type ProcessTemplate struct {
+	ID          string                        `json:"Id,omitempty"`
+	Name        string                        `json:"Name"`
+	GitRef      string                        `json:"GitRef"`
+	Slug        string                        `json:"Slug"`
+	Description string                        `json:"Description,omitempty"`
+	Icon        *Icon                         `json:"Icon,omitempty"`
+	Steps       []*deployments.DeploymentStep `json:"Steps,omitempty"`
+	Parameters  []*Parameter                  `json:"Parameters,omitempty"`
+}
+
+// Parameter represents a parameter declared by a process template.
+type Parameter struct {
+	Name            string            `json:"Name"`
+	Label           string            `json:"Label,omitempty"`
+	HelpText        string            `json:"HelpText,omitempty"`
+	IsOptional      bool              `json:"IsOptional"`
+	DisplaySettings map[string]string `json:"DisplaySettings,omitempty"`
+	Values          []*ParameterValue `json:"Values,omitempty"`
+}
+
+// ParameterValue represents a scoped default value for a process template parameter.
+type ParameterValue struct {
+	Value core.PropertyValue      `json:"Value"`
+	Scope variables.VariableScope `json:"Scope"`
+}
+
+// Summary represents a process template without its steps or parameters. Listings should
+// prefer this shape: the full template route returns every step body.
+type Summary struct {
+	ID            string     `json:"Id,omitempty"`
+	Name          string     `json:"Name"`
+	GitRef        string     `json:"GitRef"`
+	Slug          string     `json:"Slug"`
+	Description   string     `json:"Description,omitempty"`
+	Icon          *Icon      `json:"Icon,omitempty"`
+	Version       string     `json:"Version,omitempty"`
+	PublishedDate *time.Time `json:"PublishedDate,omitempty"`
+	HasError      bool       `json:"HasError"`
+}

--- a/pkg/processtemplates/service.go
+++ b/pkg/processtemplates/service.go
@@ -6,8 +6,7 @@ import (
 )
 
 const (
-	template          = "/api/platformhub/{gitRef}/processtemplates{/slug}{?skip,take}"
-	summariesTemplate = "/api/platformhub/{gitRef}/processtemplates/summaries{?skip,take,partialName}"
+	template = "/api/platformhub/{gitRef}/processtemplates{/slug}{?skip,take}"
 )
 
 // ProcessTemplatesQuery represents query parameters for listing process templates.
@@ -24,24 +23,7 @@ type ProcessTemplatesQueryResult struct {
 	ItemsPerPage     int                `json:"ItemsPerPage"`
 }
 
-// SummariesQuery represents query parameters for listing process template summaries.
-type SummariesQuery struct {
-	GitRef      string `uri:"gitRef" json:"gitRef"`
-	PartialName string `uri:"partialName,omitempty" json:"partialName,omitempty"`
-	Skip        int    `uri:"skip,omitempty" json:"skip,omitempty"`
-	Take        int    `uri:"take,omitempty" json:"take,omitempty"`
-}
-
-// SummariesQueryResult is a paginated collection of process template summaries.
-type SummariesQueryResult struct {
-	ProcessTemplateSummaries  []*Summary `json:"ProcessTemplateSummaries"`
-	TotalResults              int        `json:"TotalResults"`
-	ItemsPerPage              int        `json:"ItemsPerPage"`
-	TotalNoOfProcessTemplates int        `json:"TotalNoOfProcessTemplates"`
-}
-
-// List returns a paginated collection of process templates, including their steps and
-// parameters. Prefer ListSummaries for listings.
+// List returns a paginated collection of process templates.
 func List(client newclient.Client, query ProcessTemplatesQuery) (*ProcessTemplatesQueryResult, error) {
 	if internal.IsEmpty(query.GitRef) {
 		return nil, internal.CreateInvalidParameterError("List", "GitRef")
@@ -53,20 +35,6 @@ func List(client newclient.Client, query ProcessTemplatesQuery) (*ProcessTemplat
 	}
 
 	return newclient.Get[ProcessTemplatesQueryResult](client.HttpSession(), path)
-}
-
-// ListSummaries returns a paginated collection of process template summaries.
-func ListSummaries(client newclient.Client, query SummariesQuery) (*SummariesQueryResult, error) {
-	if internal.IsEmpty(query.GitRef) {
-		return nil, internal.CreateInvalidParameterError("ListSummaries", "GitRef")
-	}
-
-	path, err := client.URITemplateCache().Expand(summariesTemplate, query)
-	if err != nil {
-		return nil, err
-	}
-
-	return newclient.Get[SummariesQueryResult](client.HttpSession(), path)
 }
 
 // GetBySlug returns the process template that matches the given slug on the given Git reference.
@@ -87,17 +55,16 @@ func GetBySlug(client newclient.Client, gitRef string, slug string) (*ProcessTem
 }
 
 // createProcessTemplateCommand creates an empty process template. Steps and parameters
-// cannot be set at create time - they are authored afterwards in Git or the portal.
+// cannot be set at creation time.
 type createProcessTemplateCommand struct {
-	GitRef string `json:"GitRef"`
-	Name   string `json:"Name"`
-	// Description is the process template's description.
+	GitRef      string `json:"GitRef"`
+	Name        string `json:"Name"`
 	Description string `json:"Description,omitempty"`
-	// ChangeDescription becomes the git commit message for the create.
+	// ChangeDescription becomes the git commit message for the create operation.
 	ChangeDescription string `json:"ChangeDescription,omitempty"`
 }
 
-// Add creates a new, empty process template on the given Git reference. changeDescription
+// Add creates an empty process template on the given Git reference. changeDescription
 // becomes the git commit message.
 func Add(client newclient.Client, gitRef string, name string, description string, changeDescription string) (*ProcessTemplate, error) {
 	if internal.IsEmpty(gitRef) {

--- a/pkg/processtemplates/service.go
+++ b/pkg/processtemplates/service.go
@@ -1,0 +1,123 @@
+package processtemplates
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+)
+
+const (
+	template          = "/api/platformhub/{gitRef}/processtemplates{/slug}{?skip,take}"
+	summariesTemplate = "/api/platformhub/{gitRef}/processtemplates/summaries{?skip,take,partialName}"
+)
+
+// ProcessTemplatesQuery represents query parameters for listing process templates.
+type ProcessTemplatesQuery struct {
+	GitRef string `uri:"gitRef" json:"gitRef"`
+	Skip   int    `uri:"skip,omitempty" json:"skip,omitempty"`
+	Take   int    `uri:"take,omitempty" json:"take,omitempty"`
+}
+
+// ProcessTemplatesQueryResult is a paginated collection of process templates.
+type ProcessTemplatesQueryResult struct {
+	ProcessTemplates []*ProcessTemplate `json:"ProcessTemplates"`
+	TotalResults     int                `json:"TotalResults"`
+	ItemsPerPage     int                `json:"ItemsPerPage"`
+}
+
+// SummariesQuery represents query parameters for listing process template summaries.
+type SummariesQuery struct {
+	GitRef      string `uri:"gitRef" json:"gitRef"`
+	PartialName string `uri:"partialName,omitempty" json:"partialName,omitempty"`
+	Skip        int    `uri:"skip,omitempty" json:"skip,omitempty"`
+	Take        int    `uri:"take,omitempty" json:"take,omitempty"`
+}
+
+// SummariesQueryResult is a paginated collection of process template summaries.
+type SummariesQueryResult struct {
+	ProcessTemplateSummaries  []*Summary `json:"ProcessTemplateSummaries"`
+	TotalResults              int        `json:"TotalResults"`
+	ItemsPerPage              int        `json:"ItemsPerPage"`
+	TotalNoOfProcessTemplates int        `json:"TotalNoOfProcessTemplates"`
+}
+
+// List returns a paginated collection of process templates, including their steps and
+// parameters. Prefer ListSummaries for listings.
+func List(client newclient.Client, query ProcessTemplatesQuery) (*ProcessTemplatesQueryResult, error) {
+	if internal.IsEmpty(query.GitRef) {
+		return nil, internal.CreateInvalidParameterError("List", "GitRef")
+	}
+
+	path, err := client.URITemplateCache().Expand(template, query)
+	if err != nil {
+		return nil, err
+	}
+
+	return newclient.Get[ProcessTemplatesQueryResult](client.HttpSession(), path)
+}
+
+// ListSummaries returns a paginated collection of process template summaries.
+func ListSummaries(client newclient.Client, query SummariesQuery) (*SummariesQueryResult, error) {
+	if internal.IsEmpty(query.GitRef) {
+		return nil, internal.CreateInvalidParameterError("ListSummaries", "GitRef")
+	}
+
+	path, err := client.URITemplateCache().Expand(summariesTemplate, query)
+	if err != nil {
+		return nil, err
+	}
+
+	return newclient.Get[SummariesQueryResult](client.HttpSession(), path)
+}
+
+// GetBySlug returns the process template that matches the given slug on the given Git reference.
+func GetBySlug(client newclient.Client, gitRef string, slug string) (*ProcessTemplate, error) {
+	if internal.IsEmpty(gitRef) {
+		return nil, internal.CreateInvalidParameterError("GetBySlug", "gitRef")
+	}
+	if internal.IsEmpty(slug) {
+		return nil, internal.CreateInvalidParameterError("GetBySlug", "slug")
+	}
+
+	path, err := client.URITemplateCache().Expand(template, map[string]any{"gitRef": gitRef, "slug": slug})
+	if err != nil {
+		return nil, err
+	}
+
+	return newclient.Get[ProcessTemplate](client.HttpSession(), path)
+}
+
+// createProcessTemplateCommand creates an empty process template. Steps and parameters
+// cannot be set at create time - they are authored afterwards in Git or the portal.
+type createProcessTemplateCommand struct {
+	GitRef string `json:"GitRef"`
+	Name   string `json:"Name"`
+	// Description is the process template's description.
+	Description string `json:"Description,omitempty"`
+	// ChangeDescription becomes the git commit message for the create.
+	ChangeDescription string `json:"ChangeDescription,omitempty"`
+}
+
+// Add creates a new, empty process template on the given Git reference. changeDescription
+// becomes the git commit message.
+func Add(client newclient.Client, gitRef string, name string, description string, changeDescription string) (*ProcessTemplate, error) {
+	if internal.IsEmpty(gitRef) {
+		return nil, internal.CreateInvalidParameterError("Add", "gitRef")
+	}
+	if internal.IsEmpty(name) {
+		return nil, internal.CreateInvalidParameterError("Add", "name")
+	}
+
+	path, err := client.URITemplateCache().Expand(template, map[string]any{"gitRef": gitRef})
+	if err != nil {
+		return nil, err
+	}
+
+	command := createProcessTemplateCommand{
+		GitRef:            gitRef,
+		Name:              name,
+		Description:       description,
+		ChangeDescription: changeDescription,
+	}
+
+	return newclient.Post[ProcessTemplate](client.HttpSession(), path, command)
+}

--- a/pkg/processtemplates/service_test.go
+++ b/pkg/processtemplates/service_test.go
@@ -1,0 +1,224 @@
+package processtemplates
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordedRequest struct {
+	uri  string
+	body string
+}
+
+func newTestClient(t *testing.T, recorded *[]recordedRequest, payload string) newclient.Client {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		*recorded = append(*recorded, recordedRequest{uri: r.URL.RequestURI(), body: string(body)})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(payload))
+	}))
+	t.Cleanup(server.Close)
+
+	baseURL, err := url.Parse(server.URL + "/")
+	require.NoError(t, err)
+
+	return newclient.NewClient(&newclient.HttpSession{HttpClient: server.Client(), BaseURL: baseURL})
+}
+
+func TestListSummaries(t *testing.T) {
+	const payload = `{
+	  "ProcessTemplateSummaries": [
+	    {
+	      "Id": "refs/heads/main:my-template",
+	      "Name": "My Template",
+	      "GitRef": "refs/heads/main",
+	      "Slug": "my-template",
+	      "Description": "Does a thing",
+	      "Icon": { "Id": "rocket", "Color": "#25D384" },
+	      "Version": "1.0.0",
+	      "PublishedDate": "2026-08-25T01:02:03.000+00:00",
+	      "HasError": false
+	    },
+	    { "Name": "Unpublished", "GitRef": "refs/heads/main", "Slug": "unpublished", "HasError": true }
+	  ],
+	  "TotalResults": 2,
+	  "ItemsPerPage": 30,
+	  "TotalNoOfProcessTemplates": 2
+	}`
+
+	var recorded []recordedRequest
+	client := newTestClient(t, &recorded, payload)
+
+	result, err := ListSummaries(client, SummariesQuery{GitRef: "refs/heads/main", PartialName: "My", Skip: 0, Take: 30})
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/platformhub/refs%2Fheads%2Fmain/processtemplates/summaries?take=30&partialName=My", recorded[0].uri)
+
+	require.Len(t, result.ProcessTemplateSummaries, 2)
+	assert.Equal(t, 2, result.TotalResults)
+	assert.Equal(t, 2, result.TotalNoOfProcessTemplates)
+
+	first := result.ProcessTemplateSummaries[0]
+	assert.Equal(t, "My Template", first.Name)
+	assert.Equal(t, "my-template", first.Slug)
+	assert.Equal(t, "1.0.0", first.Version)
+	require.NotNil(t, first.PublishedDate)
+	assert.Equal(t, 2026, first.PublishedDate.Year())
+	require.NotNil(t, first.Icon)
+	assert.Equal(t, "rocket", first.Icon.ID)
+
+	second := result.ProcessTemplateSummaries[1]
+	assert.Nil(t, second.PublishedDate)
+	assert.True(t, second.HasError)
+}
+
+func TestListSummariesWithEmptyGitRef(t *testing.T) {
+	var recorded []recordedRequest
+	client := newTestClient(t, &recorded, `{}`)
+
+	result, err := ListSummaries(client, SummariesQuery{})
+	require.Error(t, err)
+	require.Nil(t, result)
+	assert.Empty(t, recorded)
+}
+
+func TestList(t *testing.T) {
+	const payload = `{
+	  "ProcessTemplates": [
+	    {
+	      "Id": "refs/heads/main:my-template",
+	      "Name": "My Template",
+	      "GitRef": "refs/heads/main",
+	      "Slug": "my-template",
+	      "Steps": [{ "Name": "Run a script", "Actions": [] }],
+	      "Parameters": []
+	    }
+	  ],
+	  "TotalResults": 1,
+	  "ItemsPerPage": 30
+	}`
+
+	var recorded []recordedRequest
+	client := newTestClient(t, &recorded, payload)
+
+	result, err := List(client, ProcessTemplatesQuery{GitRef: "refs/heads/main", Take: 10})
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/platformhub/refs%2Fheads%2Fmain/processtemplates?take=10", recorded[0].uri)
+	require.Len(t, result.ProcessTemplates, 1)
+	require.Len(t, result.ProcessTemplates[0].Steps, 1)
+	assert.Equal(t, "Run a script", result.ProcessTemplates[0].Steps[0].Name)
+}
+
+func TestGetBySlug(t *testing.T) {
+	const payload = `{
+	  "Id": "refs/heads/main:my-template",
+	  "Name": "My Template",
+	  "GitRef": "refs/heads/main",
+	  "Slug": "my-template",
+	  "Description": "Does a thing",
+	  "Steps": [{ "Name": "Run a script" }],
+	  "Parameters": [
+	    {
+	      "Name": "Environment",
+	      "Label": "Environment",
+	      "HelpText": "Where to deploy",
+	      "IsOptional": false,
+	      "DisplaySettings": { "Octopus.ControlType": "SingleLineText" },
+	      "Values": [{ "Value": "Production", "Scope": { "Environment": ["Environments-1"] } }]
+	    }
+	  ]
+	}`
+
+	var recorded []recordedRequest
+	client := newTestClient(t, &recorded, payload)
+
+	template, err := GetBySlug(client, "refs/heads/main", "my-template")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/platformhub/refs%2Fheads%2Fmain/processtemplates/my-template", recorded[0].uri)
+	assert.Equal(t, "My Template", template.Name)
+	require.Len(t, template.Steps, 1)
+	require.Len(t, template.Parameters, 1)
+
+	parameter := template.Parameters[0]
+	assert.Equal(t, "Environment", parameter.Name)
+	assert.Equal(t, "SingleLineText", parameter.DisplaySettings["Octopus.ControlType"])
+	require.Len(t, parameter.Values, 1)
+	// PropertyValueResource serialises as a bare string when not sensitive.
+	assert.Equal(t, "Production", parameter.Values[0].Value.Value)
+	assert.False(t, parameter.Values[0].Value.IsSensitive)
+	assert.Equal(t, []string{"Environments-1"}, parameter.Values[0].Scope.Environments)
+}
+
+func TestGetBySlugWithEmptyArguments(t *testing.T) {
+	var recorded []recordedRequest
+	client := newTestClient(t, &recorded, `{}`)
+
+	_, err := GetBySlug(client, "", "my-template")
+	require.Error(t, err)
+
+	_, err = GetBySlug(client, "refs/heads/main", "")
+	require.Error(t, err)
+
+	assert.Empty(t, recorded)
+}
+
+func TestAdd(t *testing.T) {
+	const payload = `{"Id":"refs/heads/main:my-template","Name":"My Template","GitRef":"refs/heads/main","Slug":"my-template"}`
+
+	var recorded []recordedRequest
+	client := newTestClient(t, &recorded, payload)
+
+	created, err := Add(client, "refs/heads/main", "My Template", "Does a thing", "Add My Template")
+	require.NoError(t, err)
+
+	require.Len(t, recorded, 1)
+	assert.Equal(t, "/api/platformhub/refs%2Fheads%2Fmain/processtemplates", recorded[0].uri)
+
+	var command map[string]any
+	require.NoError(t, json.Unmarshal([]byte(recorded[0].body), &command))
+	assert.Equal(t, map[string]any{
+		"GitRef":            "refs/heads/main",
+		"Name":              "My Template",
+		"Description":       "Does a thing",
+		"ChangeDescription": "Add My Template",
+	}, command)
+
+	assert.Equal(t, "my-template", created.Slug)
+}
+
+func TestAddOmitsEmptyOptionalFields(t *testing.T) {
+	var recorded []recordedRequest
+	client := newTestClient(t, &recorded, `{"Name":"My Template","Slug":"my-template"}`)
+
+	_, err := Add(client, "refs/heads/main", "My Template", "", "")
+	require.NoError(t, err)
+
+	var command map[string]any
+	require.NoError(t, json.Unmarshal([]byte(recorded[0].body), &command))
+	assert.Equal(t, map[string]any{"GitRef": "refs/heads/main", "Name": "My Template"}, command)
+}
+
+func TestAddWithEmptyArguments(t *testing.T) {
+	var recorded []recordedRequest
+	client := newTestClient(t, &recorded, `{}`)
+
+	_, err := Add(client, "", "My Template", "", "")
+	require.Error(t, err)
+
+	_, err = Add(client, "refs/heads/main", "", "", "")
+	require.Error(t, err)
+
+	assert.Empty(t, recorded)
+}

--- a/pkg/processtemplates/service_test.go
+++ b/pkg/processtemplates/service_test.go
@@ -35,63 +35,6 @@ func newTestClient(t *testing.T, recorded *[]recordedRequest, payload string) ne
 	return newclient.NewClient(&newclient.HttpSession{HttpClient: server.Client(), BaseURL: baseURL})
 }
 
-func TestListSummaries(t *testing.T) {
-	const payload = `{
-	  "ProcessTemplateSummaries": [
-	    {
-	      "Id": "refs/heads/main:my-template",
-	      "Name": "My Template",
-	      "GitRef": "refs/heads/main",
-	      "Slug": "my-template",
-	      "Description": "Does a thing",
-	      "Icon": { "Id": "rocket", "Color": "#25D384" },
-	      "Version": "1.0.0",
-	      "PublishedDate": "2026-08-25T01:02:03.000+00:00",
-	      "HasError": false
-	    },
-	    { "Name": "Unpublished", "GitRef": "refs/heads/main", "Slug": "unpublished", "HasError": true }
-	  ],
-	  "TotalResults": 2,
-	  "ItemsPerPage": 30,
-	  "TotalNoOfProcessTemplates": 2
-	}`
-
-	var recorded []recordedRequest
-	client := newTestClient(t, &recorded, payload)
-
-	result, err := ListSummaries(client, SummariesQuery{GitRef: "refs/heads/main", PartialName: "My", Skip: 0, Take: 30})
-	require.NoError(t, err)
-
-	assert.Equal(t, "/api/platformhub/refs%2Fheads%2Fmain/processtemplates/summaries?take=30&partialName=My", recorded[0].uri)
-
-	require.Len(t, result.ProcessTemplateSummaries, 2)
-	assert.Equal(t, 2, result.TotalResults)
-	assert.Equal(t, 2, result.TotalNoOfProcessTemplates)
-
-	first := result.ProcessTemplateSummaries[0]
-	assert.Equal(t, "My Template", first.Name)
-	assert.Equal(t, "my-template", first.Slug)
-	assert.Equal(t, "1.0.0", first.Version)
-	require.NotNil(t, first.PublishedDate)
-	assert.Equal(t, 2026, first.PublishedDate.Year())
-	require.NotNil(t, first.Icon)
-	assert.Equal(t, "rocket", first.Icon.ID)
-
-	second := result.ProcessTemplateSummaries[1]
-	assert.Nil(t, second.PublishedDate)
-	assert.True(t, second.HasError)
-}
-
-func TestListSummariesWithEmptyGitRef(t *testing.T) {
-	var recorded []recordedRequest
-	client := newTestClient(t, &recorded, `{}`)
-
-	result, err := ListSummaries(client, SummariesQuery{})
-	require.Error(t, err)
-	require.Nil(t, result)
-	assert.Empty(t, recorded)
-}
-
 func TestList(t *testing.T) {
 	const payload = `{
 	  "ProcessTemplates": [


### PR DESCRIPTION
This PR adds support for:
- Viewing Platform Hub GitHub Connections
- Configuring the Platform Hub Version Control Settings
- Creating and viewing Process Templates

It does not add support for modifying the GitHub Connections or Process Templates.

E2E tests haven't been added as this would require extending the E2E tests to support mocking out a GitHub connection and a local Git repository which doesn't seem worth the effort. There are unit tests.

A basic scenario has been tested using the following Go script:
```
package main

import (
	"bufio"
	"flag"
	"fmt"
	"net/url"
	"os"
	"strings"
	"time"

	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/credentials"
	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/platformhubversioncontrolsettings"
	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/processtemplates"
)

func main() {
	report, err := run()
	if err != nil {
		fmt.Fprintf(os.Stderr, "\nFAILED: %v\n", err)
		os.Exit(1)
	}

	report.print()
	if report.failed() {
		os.Exit(1)
	}
}

func run() (*report, error) {
	loadDotEnv(".env")

	var (
		octopusURL = flag.String("octopus-url", os.Getenv("OCTOPUS_HOST"), "Octopus instance URL (defaults to $OCTOPUS_HOST)")
		apiKey     = flag.String("api-key", os.Getenv("OCTOPUS_API_KEY"), "Octopus API key (defaults to $OCTOPUS_API_KEY)")

		gitURL          = flag.String("git-url", "", "Git repository URL for Platform Hub")
		gitUsername     = flag.String("git-username", "", "Git username (ignored when -git-connection-id is set)")
		gitPassword     = flag.String("git-password", "", "Git password or personal access token (ignored when -git-connection-id is set)")
		gitConnectionID = flag.String("git-connection-id", "", "configure version control with this GitHub App connection instead of username/password")
		gitBranch       = flag.String("git-branch", "main", "default branch")
		gitBasePath     = flag.String("git-base-path", ".octopus/", "base path within the repository")

		connectionID  = flag.String("connection-id", "", "GitHub connection to read back (defaults to the first one returned by the list route)")
		templateName  = flag.String("name", "", "process template name (defaults to a timestamped name)")
		skipConfigure = flag.Bool("skip-configure", false, "skip the version control update and use the settings already on the instance")
		assumeYes     = flag.Bool("y", false, "do not prompt before overwriting the existing version control settings")
	)
	flag.Parse()

	if *octopusURL == "" || *apiKey == "" {
		return nil, fmt.Errorf("octopus URL and API key are required; set OCTOPUS_HOST and OCTOPUS_API_KEY, or pass -octopus-url and -api-key")
	}
	usingGitHubApp := *gitConnectionID != ""
	if !*skipConfigure {
		if *gitURL == "" {
			return nil, fmt.Errorf("-git-url is required unless -skip-configure is set")
		}
		if !usingGitHubApp && (*gitUsername == "" || *gitPassword == "") {
			return nil, fmt.Errorf("-git-username and -git-password are required unless -git-connection-id or -skip-configure is set")
		}
	}

	apiURL, err := url.Parse(*octopusURL)
	if err != nil {
		return nil, fmt.Errorf("parsing Octopus URL: %w", err)
	}

	// Platform Hub is system-scoped, so no space ID is required
	octopusClient, err := client.NewClient(nil, apiURL, *apiKey, "")
	if err != nil {
		return nil, fmt.Errorf("creating API client: %w", err)
	}

	r := &report{}

	// ------------------------------------------------- githubconnections.GetSettings
	r.run("githubconnections.GetSettings", func() error {
		settings, err := githubconnections.GetSettings(octopusClient)
		if err != nil {
			return err
		}
		fmt.Printf("  canUseGitHubApp=%t canUseTrustedFlow=%t\n", settings.CanUseGitHubApp, settings.CanUseTrustedFlow)
		if !settings.CanUseGitHubApp {
			fmt.Println("  note: this instance cannot use GitHub App connections, so the connection routes below may be empty")
		}
		return nil
	})

	// ------------------------------------------------- platformhubgithubconnections.List
	var firstConnectionID string
	r.run("platformhubgithubconnections.List", func() error {
		// both skip and take are required by the API, so a zero skip is still sent
		page, err := platformhubgithubconnections.List(octopusClient, 0, 30)
		if err != nil {
			return err
		}
		fmt.Printf("  returned=%d totalResults=%d itemsPerPage=%d numberOfPages=%d\n", len(page.Connections), page.TotalResults, page.ItemsPerPage, page.NumberOfPages)
		for _, connection := range page.Connections {
			account := "<no installation>"
			if connection.Installation != nil {
				account = fmt.Sprintf("%s %s", connection.Installation.AccountType, connection.Installation.AccountLogin)
			}
			fmt.Printf("  connection: %s %s [%s]\n", connection.ID, account, connection.Status)
		}
		if len(page.Connections) > 0 {
			firstConnectionID = page.Connections[0].ID
		}
		return nil
	})

	// the by-id and repositories routes need a connection to read; prefer the flag, then
	// whatever the list route handed back
	readConnectionID := *connectionID
	if readConnectionID == "" {
		readConnectionID = firstConnectionID
	}
	// configuring through a connection implies that connection exists, so it is a usable
	// fallback when the list route returned nothing
	if readConnectionID == "" {
		readConnectionID = *gitConnectionID
	}

	// ------------------------------------------------- platformhubgithubconnections.GetByID
	if readConnectionID == "" {
		r.skip("platformhubgithubconnections.GetByID", "no connection available; pass -connection-id")
		r.skip("platformhubgithubconnections.GetRepositories", "no connection available; pass -connection-id")
	} else {
		r.run("platformhubgithubconnections.GetByID", func() error {
			connection, err := platformhubgithubconnections.GetByID(octopusClient, readConnectionID)
			if err != nil {
				return err
			}
			account := "<no installation>"
			if connection.Installation != nil {
				account = connection.Installation.AccountLogin
			}
			fmt.Printf("  id=%s account=%s status=%s %s\n", connection.ID, account, connection.Status, connection.StatusUserMessage)
			fmt.Printf("  repositories=%d unknownRepositories=%d\n", len(connection.Repositories), len(connection.UnknownRepositories))
			return nil
		})

		// ---------------------------------------- platformhubgithubconnections.GetRepositories
		r.run("platformhubgithubconnections.GetRepositories", func() error {
			repositories, err := platformhubgithubconnections.GetRepositories(octopusClient, readConnectionID)
			if err != nil {
				return err
			}
			fmt.Printf("  returned=%d\n", len(repositories))
			for _, repository := range repositories {
				fmt.Printf("  repository: %s (%s) defaultBranch=%s\n", repository.RepositoryName, repository.GitURL, repository.DefaultBranch)
			}
			return nil
		})
	}

	// ------------------------------------------------- platformhubversioncontrolsettings.Get
	// read before writing, so the run reports what it is about to overwrite
	var existing *platformhubversioncontrolsettings.Resource
	r.run("platformhubversioncontrolsettings.Get", func() error {
		settings, err := platformhubversioncontrolsettings.Get(octopusClient)
		if err != nil {
			return err
		}
		existing = settings
		printSettings("  current", settings)
		return nil
	})

	branch := *gitBranch

	// ------------------------------------------------- platformhubversioncontrolsettings.Update
	switch {
	case *skipConfigure:
		r.skip("platformhubversioncontrolsettings.Update", "-skip-configure was set")
		if existing == nil || existing.URL == "" {
			return r, fmt.Errorf("-skip-configure was set but Platform Hub is not configured for version control; cannot exercise the process template routes")
		}
		branch = existing.DefaultBranch
	default:
		if existing != nil && existing.URL != "" && existing.URL != *gitURL && !*assumeYes {
			fmt.Printf("\nPlatform Hub is currently pointed at %s.\nThis will repoint it at %s. Continue? [y/N] ", existing.URL, *gitURL)
			if !confirmed() {
				return r, fmt.Errorf("aborted")
			}
		}

		var gitCredentials credentials.GitCredential
		if usingGitHubApp {
			gitCredentials = credentials.NewGitHubApp(*gitConnectionID)
		} else {
			gitCredentials = credentials.NewUsernamePassword(*gitUsername, core.NewSensitiveValue(*gitPassword))
		}

		r.run("platformhubversioncontrolsettings.Update", func() error {
			settings := platformhubversioncontrolsettings.NewResource(*gitURL, gitCredentials, branch, *gitBasePath)
			updated, err := platformhubversioncontrolsettings.Update(octopusClient, settings)
			if err != nil {
				return err
			}
			printSettings("  updated", updated)

			// read back, so deserialisation of what the server actually stored is exercised
			// rather than just the echo from the PUT. This is the path the GitHubApp
			// UnmarshalJSON fix unblocked.
			reread, err := platformhubversioncontrolsettings.Get(octopusClient)
			if err != nil {
				return fmt.Errorf("re-reading settings after update: %w", err)
			}
			printSettings("  re-read", reread)

			if reread.Credentials == nil {
				return fmt.Errorf("settings were saved but read back with nil credentials")
			}
			return nil
		})
	}

	gitRef := branch
	if !strings.HasPrefix(gitRef, "refs/") {
		gitRef = "refs/heads/" + gitRef
	}
	fmt.Printf("\nusing gitRef=%s for the process template routes\n\n", gitRef)

	// ------------------------------------------------- processtemplates.Add
	name := *templateName
	if name == "" {
		// a unique name per run, so repeated runs do not collide on slug
		name = fmt.Sprintf("manual-test-%s", time.Now().Format("20060102-150405"))
	}

	var createdSlug string
	var createdName string
	r.run("processtemplates.Add", func() error {
		created, err := processtemplates.Add(
			octopusClient,
			gitRef,
			name,
			"Created by manualtest/platformhub",
			fmt.Sprintf("Add process template %s", name),
		)
		if err != nil {
			return err
		}
		fmt.Printf("  id=%s slug=%s name=%s gitRef=%s\n", created.ID, created.Slug, created.Name, created.GitRef)
		if created.Slug == "" {
			return fmt.Errorf("the server did not return a slug for the created process template")
		}
		createdSlug = created.Slug
		createdName = created.Name
		return nil
	})

	// ------------------------------------------------- processtemplates.List
	r.run("processtemplates.List", func() error {
		results, err := processtemplates.List(octopusClient, processtemplates.ProcessTemplatesQuery{
			GitRef: gitRef,
			Take:   30,
		})
		if err != nil {
			return err
		}
		fmt.Printf("  returned=%d totalResults=%d itemsPerPage=%d\n", len(results.ProcessTemplates), results.TotalResults, results.ItemsPerPage)
		for _, processTemplate := range results.ProcessTemplates {
			fmt.Printf("  process template: %s (%s) steps=%d parameters=%d\n", processTemplate.Name, processTemplate.Slug, len(processTemplate.Steps), len(processTemplate.Parameters))
		}
		return nil
	})

	// ------------------------------------------------- processtemplates.GetBySlug
	if createdSlug == "" {
		r.skip("processtemplates.GetBySlug", "no slug available because the create failed")
	} else {
		r.run("processtemplates.GetBySlug", func() error {
			fetched, err := processtemplates.GetBySlug(octopusClient, gitRef, createdSlug)
			if err != nil {
				return err
			}
			fmt.Printf("  id=%s slug=%s name=%s\n", fetched.ID, fetched.Slug, fetched.Name)
			fmt.Printf("  description=%s\n", fetched.Description)
			fmt.Printf("  steps=%d parameters=%d\n", len(fetched.Steps), len(fetched.Parameters))

			for _, step := range fetched.Steps {
				fmt.Printf("  step: %s\n", step.Name)
			}
			for _, parameter := range fetched.Parameters {
				fmt.Printf("  parameter: %s optional=%t\n", parameter.Name, parameter.IsOptional)
				for _, value := range parameter.Values {
					if value.Value.IsSensitive {
						fmt.Println("    default value: (sensitive)")
						continue
					}
					fmt.Printf("    default value: %s\n", value.Value.Value)
				}
			}

			if fetched.Name != createdName {
				return fmt.Errorf("round trip mismatch: created %q but fetched %q", createdName, fetched.Name)
			}
			return nil
		})
	}

	return r, nil
}

func printSettings(label string, settings *platformhubversioncontrolsettings.Resource) {
	if settings.URL == "" {
		fmt.Printf("%s: Platform Hub is not configured for version control\n", label)
		return
	}

	fmt.Printf("%s: url=%s branch=%s basePath=%s\n", label, settings.URL, settings.DefaultBranch, settings.BasePath)

	switch creds := settings.Credentials.(type) {
	case *credentials.Anonymous:
		fmt.Printf("%s: credentials=anonymous\n", label)
	case *credentials.UsernamePassword:
		fmt.Printf("%s: credentials=username/password (%s)\n", label, creds.Username)
	case *credentials.GitHubApp:
		fmt.Printf("%s: credentials=GitHub App connection (%s)\n", label, creds.ID)
	case nil:
		// a nil here against a configured instance means the credential type came back as
		// something UnmarshalJSON does not handle - a reference credential, or an SSH key
		fmt.Printf("%s: credentials=<nil> (unhandled credential type?)\n", label)
	default:
		fmt.Printf("%s: credentials=%T\n", label, creds)
	}
}

// report records the outcome of each function under test.
type report struct {
	entries []entry
}

type entry struct {
	name   string
	status string
	detail string
}

const (
	statusPass = "PASS"
	statusFail = "FAIL"
	statusSkip = "SKIP"
)

func (r *report) run(name string, fn func() error) {
	fmt.Printf("== %s ==\n", name)
	if err := fn(); err != nil {
		fmt.Printf("  ERROR: %v\n\n", err)
		r.entries = append(r.entries, entry{name: name, status: statusFail, detail: err.Error()})
		return
	}
	fmt.Println()
	r.entries = append(r.entries, entry{name: name, status: statusPass})
}

func (r *report) skip(name string, reason string) {
	fmt.Printf("== %s ==\n  SKIPPED: %s\n\n", name, reason)
	r.entries = append(r.entries, entry{name: name, status: statusSkip, detail: reason})
}

func (r *report) failed() bool {
	for _, e := range r.entries {
		if e.status == statusFail {
			return true
		}
	}
	return false
}

func (r *report) print() {
	fmt.Println("== summary ==")

	width := 0
	for _, e := range r.entries {
		if len(e.name) > width {
			width = len(e.name)
		}
	}

	skipped := 0
	for _, e := range r.entries {
		fmt.Printf("%-4s %-*s %s\n", e.status, width, e.name, e.detail)
		if e.status == statusSkip {
			skipped++
		}
	}

	if skipped > 0 {
		fmt.Printf("\n%d function(s) were skipped and have NOT been tested by this run\n", skipped)
	}
}

func confirmed() bool {
	scanner := bufio.NewScanner(os.Stdin)
	if !scanner.Scan() {
		return false
	}
	answer := strings.ToLower(strings.TrimSpace(scanner.Text()))
	return answer == "y" || answer == "yes"
}

// loadDotEnv reads KEY=VALUE lines from path into the environment, without overwriting
// variables that are already set. Missing or malformed files are ignored.
func loadDotEnv(path string) {
	file, err := os.Open(path)
	if err != nil {
		return
	}
	defer file.Close()

	scanner := bufio.NewScanner(file)
	for scanner.Scan() {
		line := strings.TrimSpace(scanner.Text())
		if line == "" || strings.HasPrefix(line, "#") {
			continue
		}

		key, value, found := strings.Cut(line, "=")
		if !found {
			continue
		}

		key = strings.TrimSpace(key)
		value = strings.Trim(strings.TrimSpace(value), "\"'")
		if _, alreadySet := os.LookupEnv(key); !alreadySet {
			_ = os.Setenv(key, value)
		}
	}
}
```