### PR TITLE
feat: add Platform Hub Version Control Settings and GitHub Connections

### DIFF
--- a/examples/platform_hub/configure_version_control_settings.go
+++ b/examples/platform_hub/configure_version_control_settings.go
@@ -1,0 +1,53 @@
+package examples
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/credentials"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/platformhubversioncontrolsettings"
+)
+
+// ConfigurePlatformHubVersionControlSettingsExample provides an example of how to point
+// Platform Hub at a Git repository using username/password credentials.
+//
+// If the repository is already configured, changing the URL will repoint Platform Hub at the new repository.
+func ConfigurePlatformHubVersionControlSettingsExample() {
+	var (
+		apiKey     string = "API-YOUR_API_KEY"
+		octopusURL string = "https://your_octopus_url"
+
+		// version control values
+		gitURL        string = "https://github.com/your-org/your-repo.git"
+		gitUsername   string = "your-username"
+		gitPassword   string = "your-personal-access-token"
+		defaultBranch string = "main"
+		basePath      string = ".octopus/"
+	)
+
+	apiURL, err := url.Parse(octopusURL)
+	if err != nil {
+		_ = fmt.Errorf("error parsing URL for Octopus API: %v", err)
+		return
+	}
+
+	// Platform Hub is system-scoped, so no space ID is required
+	octopusClient, err := client.NewClient(nil, apiURL, apiKey, "")
+	if err != nil {
+		_ = fmt.Errorf("error creating API client: %v", err)
+		return
+	}
+
+	gitCredentials := credentials.NewUsernamePassword(gitUsername, core.NewSensitiveValue(gitPassword))
+	settings := platformhubversioncontrolsettings.NewResource(gitURL, gitCredentials, defaultBranch, basePath)
+
+	updatedSettings, err := platformhubversioncontrolsettings.Update(octopusClient, settings)
+	if err != nil {
+		_ = fmt.Errorf("error updating Platform Hub version control settings: %v", err)
+		return
+	}
+
+	fmt.Printf("Platform Hub configured against: (%s)\n", updatedSettings.URL)
+}

--- a/examples/platform_hub/configure_version_control_settings_with_github_connection.go
+++ b/examples/platform_hub/configure_version_control_settings_with_github_connection.go
@@ -1,0 +1,71 @@
+package examples
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/credentials"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/githubconnections"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/platformhubgithubconnections"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/platformhubversioncontrolsettings"
+)
+
+// ConfigurePlatformHubVersionControlSettingsWithGitHubConnectionExample provides an example
+// of how to point Platform Hub at a repository reachable through a GitHub App connection.
+//
+// The repository listing supplies both the Git URL and the repository's own default branch,
+// so neither needs to be provided.
+func ConfigurePlatformHubVersionControlSettingsWithGitHubConnectionExample() {
+	var (
+		apiKey     string = "API-YOUR_API_KEY"
+		octopusURL string = "https://your_octopus_url"
+
+		// version control values
+		connectionID   string = "GitHubAppConnections-1"
+		repositoryName string = "your-org/your-repo"
+		basePath       string = ".octopus/"
+	)
+
+	apiURL, err := url.Parse(octopusURL)
+	if err != nil {
+		_ = fmt.Errorf("error parsing URL for Octopus API: %v", err)
+		return
+	}
+
+	// Platform Hub is system-scoped, so no space ID is required
+	octopusClient, err := client.NewClient(nil, apiURL, apiKey, "")
+	if err != nil {
+		_ = fmt.Errorf("error creating API client: %v", err)
+		return
+	}
+
+	repositories, err := platformhubgithubconnections.GetRepositories(octopusClient, connectionID)
+	if err != nil {
+		_ = fmt.Errorf("error getting repositories for connection: %v", err)
+		return
+	}
+
+	var repository *githubconnections.Repository
+	for _, r := range repositories {
+		if r.RepositoryName == repositoryName {
+			repository = r
+			break
+		}
+	}
+	if repository == nil {
+		_ = fmt.Errorf("repository (%s) is not accessible through connection (%s)", repositoryName, connectionID)
+		return
+	}
+
+	gitCredentials := credentials.NewGitHubApp(connectionID)
+	settings := platformhubversioncontrolsettings.NewResource(repository.GitURL, gitCredentials, repository.DefaultBranch, basePath)
+
+	updatedSettings, err := platformhubversioncontrolsettings.Update(octopusClient, settings)
+	if err != nil {
+		_ = fmt.Errorf("error updating Platform Hub version control settings: %v", err)
+		return
+	}
+
+	fmt.Printf("Platform Hub configured against: (%s)\n", updatedSettings.URL)
+}

--- a/examples/platform_hub/get_github_connection_by_id.go
+++ b/examples/platform_hub/get_github_connection_by_id.go
@@ -1,0 +1,53 @@
+package examples
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/platformhubgithubconnections"
+)
+
+// GetPlatformHubGitHubConnectionByIDExample provides an example of how to get a single
+// Platform Hub GitHub App connection and the repositories it grants access to.
+func GetPlatformHubGitHubConnectionByIDExample() {
+	var (
+		apiKey     string = "API-YOUR_API_KEY"
+		octopusURL string = "https://your_octopus_url"
+
+		// GitHub connection values
+		connectionID string = "GitHubAppConnections-1"
+	)
+
+	apiURL, err := url.Parse(octopusURL)
+	if err != nil {
+		_ = fmt.Errorf("error parsing URL for Octopus API: %v", err)
+		return
+	}
+
+	// Platform Hub is system-scoped, so no space ID is required
+	octopusClient, err := client.NewClient(nil, apiURL, apiKey, "")
+	if err != nil {
+		_ = fmt.Errorf("error creating API client: %v", err)
+		return
+	}
+
+	connection, err := platformhubgithubconnections.GetByID(octopusClient, connectionID)
+	if err != nil {
+		_ = fmt.Errorf("error getting GitHub connection: %v", err)
+		return
+	}
+
+	fmt.Printf("connection: (%s) %s\n", connection.ID, connection.Installation.AccountLogin)
+	fmt.Printf("status: %s %s\n", connection.Status, connection.StatusUserMessage)
+
+	for _, repository := range connection.Repositories {
+		fmt.Printf("  repository: %s (%s)\n", repository.RepositoryName, repository.GitURL)
+	}
+
+	// repositories configured on the connection that GitHub no longer returns; they may have
+	// been deleted, renamed, or had access revoked
+	for _, repository := range connection.UnknownRepositories {
+		fmt.Printf("  unknown repository: %s (%s)\n", repository.RepositoryName, repository.RepositoryID)
+	}
+}

--- a/examples/platform_hub/get_version_control_settings.go
+++ b/examples/platform_hub/get_version_control_settings.go
@@ -1,0 +1,53 @@
+package examples
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/credentials"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/platformhubversioncontrolsettings"
+)
+
+// GetPlatformHubVersionControlSettingsExample provides an example of how to read the
+// Platform Hub version control settings from Octopus Deploy through the Go API client.
+func GetPlatformHubVersionControlSettingsExample() {
+	var (
+		apiKey     string = "API-YOUR_API_KEY"
+		octopusURL string = "https://your_octopus_url"
+	)
+
+	apiURL, err := url.Parse(octopusURL)
+	if err != nil {
+		_ = fmt.Errorf("error parsing URL for Octopus API: %v", err)
+		return
+	}
+
+	// Platform Hub is system-scoped, so no space ID is required
+	octopusClient, err := client.NewClient(nil, apiURL, apiKey, "")
+	if err != nil {
+		_ = fmt.Errorf("error creating API client: %v", err)
+		return
+	}
+
+	settings, err := platformhubversioncontrolsettings.Get(octopusClient)
+	if err != nil {
+		_ = fmt.Errorf("error getting Platform Hub version control settings: %v", err)
+		return
+	}
+
+	fmt.Printf("URL: %s\n", settings.URL)
+	fmt.Printf("default branch: %s\n", settings.DefaultBranch)
+	fmt.Printf("base path: %s\n", settings.BasePath)
+
+	switch creds := settings.Credentials.(type) {
+	case *credentials.Anonymous:
+		fmt.Println("credentials: anonymous")
+	case *credentials.UsernamePassword:
+		fmt.Printf("credentials: username/password (%s)\n", creds.Username)
+	case *credentials.GitHubApp:
+		fmt.Printf("credentials: GitHub App connection (%s)\n", creds.ID)
+	case nil:
+		fmt.Println("Platform Hub is not configured for version control")
+	}
+}

--- a/examples/platform_hub/list_github_connections.go
+++ b/examples/platform_hub/list_github_connections.go
@@ -1,0 +1,78 @@
+package examples
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/githubconnections"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/platformhubgithubconnections"
+)
+
+// ListPlatformHubGitHubConnectionsExample provides an example of how to list the GitHub App
+// connections available to Platform Hub, paging through the results.
+func ListPlatformHubGitHubConnectionsExample() {
+	var (
+		apiKey     string = "API-YOUR_API_KEY"
+		octopusURL string = "https://your_octopus_url"
+
+		// paging values; both skip and take are required by the API
+		take int = 30
+	)
+
+	apiURL, err := url.Parse(octopusURL)
+	if err != nil {
+		_ = fmt.Errorf("error parsing URL for Octopus API: %v", err)
+		return
+	}
+
+	// Platform Hub is system-scoped, so no space ID is required
+	octopusClient, err := client.NewClient(nil, apiURL, apiKey, "")
+	if err != nil {
+		_ = fmt.Errorf("error creating API client: %v", err)
+		return
+	}
+
+	settings, err := githubconnections.GetSettings(octopusClient)
+	if err != nil {
+		_ = fmt.Errorf("error getting GitHub App settings: %v", err)
+		return
+	}
+	if !settings.CanUseGitHubApp {
+		fmt.Println("this Octopus instance cannot use GitHub App connections")
+		return
+	}
+
+	var connections []*githubconnections.Connection
+	for {
+		page, err := platformhubgithubconnections.List(octopusClient, len(connections), take)
+		if err != nil {
+			_ = fmt.Errorf("error listing GitHub connections: %v", err)
+			return
+		}
+
+		connections = append(connections, page.Connections...)
+
+		if len(page.Connections) == 0 || len(connections) >= page.TotalResults {
+			break
+		}
+	}
+
+	for _, connection := range connections {
+		fmt.Printf("connection: (%s) %s %s [%s]\n", connection.ID, connection.Installation.AccountType, connection.Installation.AccountLogin, connection.Status)
+
+		if connection.Status != githubconnections.ConnectionStatusConnected {
+			continue
+		}
+
+		repositories, err := platformhubgithubconnections.GetRepositories(octopusClient, connection.ID)
+		if err != nil {
+			_ = fmt.Errorf("error getting repositories for connection: %v", err)
+			return
+		}
+
+		for _, repository := range repositories {
+			fmt.Printf("  repository: %s (%s), default branch: %s\n", repository.RepositoryName, repository.GitURL, repository.DefaultBranch)
+		}
+	}
+}

--- a/pkg/githubconnections/connection.go
+++ b/pkg/githubconnections/connection.go
@@ -1,0 +1,31 @@
+package githubconnections
+
+// ConnectionStatus describes the health of a GitHub App connection.
+type ConnectionStatus string
+
+const (
+	ConnectionStatusConnected             = ConnectionStatus("Connected")
+	ConnectionStatusConnectionNotFound    = ConnectionStatus("ConnectionNotFound")
+	ConnectionStatusInstallationNotFound  = ConnectionStatus("InstallationNotFound")
+	ConnectionStatusInstallationSuspended = ConnectionStatus("InstallationSuspended")
+	ConnectionStatusError                 = ConnectionStatus("Error")
+)
+
+// Installation represents the GitHub App installation backing a connection.
+type Installation struct {
+	InstallationID   string `json:"InstallationId"`
+	AccountID        string `json:"AccountId"`
+	AccountLogin     string `json:"AccountLogin"`
+	AccountAvatarURL string `json:"AccountAvatarUrl"`
+	AccountType      string `json:"AccountType"`
+	// AllRepositories is true when the installation can access every repository in the
+	// account, false when it is restricted to a selected set.
+	AllRepositories bool `json:"AllRepositories"`
+}
+
+// Connection represents a GitHub App connection.
+type Connection struct {
+	ID           string           `json:"Id"`
+	Status       ConnectionStatus `json:"Status,omitempty"`
+	Installation *Installation    `json:"Installation,omitempty"`
+}

--- a/pkg/githubconnections/repository.go
+++ b/pkg/githubconnections/repository.go
@@ -1,0 +1,20 @@
+package githubconnections
+
+// Repository represents a GitHub repository reachable through a GitHub App connection.
+type Repository struct {
+	RepositoryID   string `json:"RepositoryId"`
+	RepositoryName string `json:"RepositoryName"`
+	IsAdmin        bool   `json:"IsAdmin"`
+	IsPrivate      bool   `json:"IsPrivate"`
+	Visibility     string `json:"Visibility"`
+	Language       string `json:"Language,omitempty"`
+	GitURL         string `json:"GitUrl"`
+	DefaultBranch  string `json:"DefaultBranch"`
+}
+
+// UnknownRepository represents a repository configured on a connection that has no
+// matching repository returned from GitHub.
+type UnknownRepository struct {
+	RepositoryID   string `json:"RepositoryId"`
+	RepositoryName string `json:"RepositoryName,omitempty"`
+}

--- a/pkg/githubconnections/settings.go
+++ b/pkg/githubconnections/settings.go
@@ -1,0 +1,18 @@
+package githubconnections
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+)
+
+const settingsPath = "/api/githubconnections/app/settings"
+
+// Settings represents the server-wide GitHub App settings.
+type Settings struct {
+	CanUseGitHubApp   bool `json:"CanUseGitHubApp"`
+	CanUseTrustedFlow bool `json:"CanUseTrustedFlow"`
+}
+
+// GetSettings returns the server's GitHub App settings.
+func GetSettings(client newclient.Client) (*Settings, error) {
+	return newclient.Get[Settings](client.HttpSession(), settingsPath)
+}

--- a/pkg/githubconnections/settings.go
+++ b/pkg/githubconnections/settings.go
@@ -4,7 +4,7 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
 )
 
-const settingsPath = "/api/githubconnections/app/settings"
+const settingsPath = "/api/github/app/settings"
 
 // Settings represents the server-wide GitHub App settings.
 type Settings struct {

--- a/pkg/githubconnections/settings_test.go
+++ b/pkg/githubconnections/settings_test.go
@@ -27,7 +27,7 @@ func TestGetSettings(t *testing.T) {
 	settings, err := GetSettings(client)
 	require.NoError(t, err)
 
-	assert.Equal(t, "/api/githubconnections/app/settings", requested)
+	assert.Equal(t, "/api/github/app/settings", requested)
 	assert.True(t, settings.CanUseGitHubApp)
 	assert.False(t, settings.CanUseTrustedFlow)
 }

--- a/pkg/githubconnections/settings_test.go
+++ b/pkg/githubconnections/settings_test.go
@@ -1,0 +1,33 @@
+package githubconnections
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSettings(t *testing.T) {
+	var requested string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = r.URL.RequestURI()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"CanUseGitHubApp":true,"CanUseTrustedFlow":false}`))
+	}))
+	defer server.Close()
+
+	baseURL, err := url.Parse(server.URL + "/")
+	require.NoError(t, err)
+	client := newclient.NewClient(&newclient.HttpSession{HttpClient: server.Client(), BaseURL: baseURL})
+
+	settings, err := GetSettings(client)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/githubconnections/app/settings", requested)
+	assert.True(t, settings.CanUseGitHubApp)
+	assert.False(t, settings.CanUseTrustedFlow)
+}

--- a/pkg/platformhubgithubconnections/service.go
+++ b/pkg/platformhubgithubconnections/service.go
@@ -23,8 +23,7 @@ type ConnectionDetails struct {
 	UnknownRepositories []*githubconnections.UnknownRepository `json:"UnknownRepositories"`
 }
 
-// ConnectionsQuery represents the query parameters for listing connections. Both
-// skip and take are required by the server contract, so neither is omitted when empty.
+// ConnectionsQuery represents the query parameters for listing connections. Both skip and take are required.
 type ConnectionsQuery struct {
 	Skip int `uri:"skip" json:"skip"`
 	Take int `uri:"take" json:"take"`

--- a/pkg/platformhubgithubconnections/service.go
+++ b/pkg/platformhubgithubconnections/service.go
@@ -1,0 +1,108 @@
+package platformhubgithubconnections
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/internal"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/githubconnections"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+)
+
+const (
+	connectionsTemplate  = "/api/platformhub/githubconnections/connections{?skip,take}"
+	connectionTemplate   = "/api/platformhub/githubconnections/connections/{id}"
+	repositoriesTemplate = "/api/platformhub/githubconnections/connections/{connectionId}/repositories"
+
+	// defaultPageSize matches the server's default 'take'.
+	defaultPageSize = 30
+)
+
+// ConnectionDetails represents a single Platform Hub GitHub App connection, including the
+// repositories it grants access to which githubconnections.Connection doesn't include.
+type ConnectionDetails struct {
+	ID                  string                                 `json:"Id"`
+	Status              githubconnections.ConnectionStatus     `json:"Status"`
+	StatusUserMessage   string                                 `json:"StatusUserMessage,omitempty"`
+	Installation        *githubconnections.Installation        `json:"Installation,omitempty"`
+	Repositories        []*githubconnections.Repository        `json:"Repositories"`
+	UnknownRepositories []*githubconnections.UnknownRepository `json:"UnknownRepositories"`
+}
+
+// ConnectionsQuery represents the query parameters for listing connections. Both
+// skip and take are required by the server contract, so neither is omitted when empty.
+type ConnectionsQuery struct {
+	Skip int `uri:"skip" json:"skip"`
+	Take int `uri:"take" json:"take"`
+}
+
+// ConnectionsQueryResult is a paginated collection of Platform Hub GitHub App connections.
+type ConnectionsQueryResult struct {
+	Connections   []*githubconnections.Connection `json:"Connections"`
+	ItemsPerPage  int                             `json:"ItemsPerPage"`
+	NumberOfPages int                             `json:"NumberOfPages"`
+	TotalResults  int                             `json:"TotalResults"`
+}
+
+// List returns a single page of Platform Hub GitHub App connections.
+func List(client newclient.Client, skip int, take int) (*ConnectionsQueryResult, error) {
+	path, err := client.URITemplateCache().Expand(connectionsTemplate, ConnectionsQuery{Skip: skip, Take: take})
+	if err != nil {
+		return nil, err
+	}
+
+	return newclient.Get[ConnectionsQueryResult](client.HttpSession(), path)
+}
+
+// ListAll returns every Platform Hub GitHub App connection, paging until TotalResults is reached.
+func ListAll(client newclient.Client) ([]*githubconnections.Connection, error) {
+	connections := make([]*githubconnections.Connection, 0)
+
+	for {
+		page, err := List(client, len(connections), defaultPageSize)
+		if err != nil {
+			return nil, err
+		}
+
+		connections = append(connections, page.Connections...)
+
+		if len(page.Connections) == 0 || len(connections) >= page.TotalResults {
+			return connections, nil
+		}
+	}
+}
+
+// GetByID returns the Platform Hub GitHub App connection with the given ID, along with the
+// repositories it grants access to.
+func GetByID(client newclient.Client, id string) (*ConnectionDetails, error) {
+	if internal.IsEmpty(id) {
+		return nil, internal.CreateInvalidParameterError("GetByID", "id")
+	}
+
+	path, err := client.URITemplateCache().Expand(connectionTemplate, map[string]any{"id": id})
+	if err != nil {
+		return nil, err
+	}
+
+	return newclient.Get[ConnectionDetails](client.HttpSession(), path)
+}
+
+type repositoriesResponse struct {
+	Repositories []*githubconnections.Repository `json:"Repositories"`
+}
+
+// GetRepositories returns the GitHub repositories reachable through the given connection.
+func GetRepositories(client newclient.Client, connectionID string) ([]*githubconnections.Repository, error) {
+	if internal.IsEmpty(connectionID) {
+		return nil, internal.CreateInvalidParameterError("GetRepositories", "connectionID")
+	}
+
+	path, err := client.URITemplateCache().Expand(repositoriesTemplate, map[string]any{"connectionId": connectionID})
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := newclient.Get[repositoriesResponse](client.HttpSession(), path)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Repositories, nil
+}

--- a/pkg/platformhubgithubconnections/service.go
+++ b/pkg/platformhubgithubconnections/service.go
@@ -10,9 +10,6 @@ const (
 	connectionsTemplate  = "/api/platformhub/githubconnections/connections{?skip,take}"
 	connectionTemplate   = "/api/platformhub/githubconnections/connections/{id}"
 	repositoriesTemplate = "/api/platformhub/githubconnections/connections/{connectionId}/repositories"
-
-	// defaultPageSize matches the server's default 'take'.
-	defaultPageSize = 30
 )
 
 // ConnectionDetails represents a single Platform Hub GitHub App connection, including the
@@ -49,24 +46,6 @@ func List(client newclient.Client, skip int, take int) (*ConnectionsQueryResult,
 	}
 
 	return newclient.Get[ConnectionsQueryResult](client.HttpSession(), path)
-}
-
-// ListAll returns every Platform Hub GitHub App connection, paging until TotalResults is reached.
-func ListAll(client newclient.Client) ([]*githubconnections.Connection, error) {
-	connections := make([]*githubconnections.Connection, 0)
-
-	for {
-		page, err := List(client, len(connections), defaultPageSize)
-		if err != nil {
-			return nil, err
-		}
-
-		connections = append(connections, page.Connections...)
-
-		if len(page.Connections) == 0 || len(connections) >= page.TotalResults {
-			return connections, nil
-		}
-	}
 }
 
 // GetByID returns the Platform Hub GitHub App connection with the given ID, along with the

--- a/pkg/platformhubgithubconnections/service.go
+++ b/pkg/platformhubgithubconnections/service.go
@@ -7,9 +7,9 @@ import (
 )
 
 const (
-	connectionsTemplate  = "/api/platformhub/githubconnections/connections{?skip,take}"
-	connectionTemplate   = "/api/platformhub/githubconnections/connections/{id}"
-	repositoriesTemplate = "/api/platformhub/githubconnections/connections/{connectionId}/repositories"
+	connectionsTemplate  = "/api/platformhub/github/connections{?skip,take}"
+	connectionTemplate   = "/api/platformhub/github/connections/{id}"
+	repositoriesTemplate = "/api/platformhub/github/connections/{connectionId}/repositories"
 )
 
 // ConnectionDetails represents a single Platform Hub GitHub App connection, including the

--- a/pkg/platformhubgithubconnections/service_test.go
+++ b/pkg/platformhubgithubconnections/service_test.go
@@ -1,0 +1,190 @@
+package platformhubgithubconnections
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/githubconnections"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestClient returns a client pointed at a server that records the requested URI and
+// replies with the given payloads, one per request in order.
+func newTestClient(t *testing.T, requested *[]string, payloads ...string) newclient.Client {
+	t.Helper()
+
+	call := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*requested = append(*requested, r.URL.RequestURI())
+		payload := payloads[len(payloads)-1]
+		if call < len(payloads) {
+			payload = payloads[call]
+		}
+		call++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(payload))
+	}))
+	t.Cleanup(server.Close)
+
+	baseURL, err := url.Parse(server.URL + "/")
+	require.NoError(t, err)
+
+	return newclient.NewClient(&newclient.HttpSession{HttpClient: server.Client(), BaseURL: baseURL})
+}
+
+func TestList(t *testing.T) {
+	const payload = `{
+	  "Connections": [
+	    {
+	      "Id": "GitHubAppConnections-1",
+	      "Status": "Connected",
+	      "Installation": {
+	        "InstallationId": "12345",
+	        "AccountId": "678",
+	        "AccountLogin": "OctopusDeploy",
+	        "AccountAvatarUrl": "https://avatars.githubusercontent.com/u/678",
+	        "AccountType": "Organization",
+	        "AllRepositories": false
+	      }
+	    },
+	    { "Id": "GitHubAppConnections-2", "Status": "InstallationSuspended" }
+	  ],
+	  "ItemsPerPage": 30,
+	  "NumberOfPages": 1,
+	  "TotalResults": 2
+	}`
+
+	var requested []string
+	client := newTestClient(t, &requested, payload)
+
+	result, err := List(client, 0, 30)
+	require.NoError(t, err)
+
+	// skip and take are [Required] on the server contract, so a zero skip must still be sent.
+	require.Len(t, requested, 1)
+	assert.Equal(t, "/api/platformhub/githubconnections/connections?skip=0&take=30", requested[0])
+
+	require.Len(t, result.Connections, 2)
+	assert.Equal(t, 2, result.TotalResults)
+	assert.Equal(t, "GitHubAppConnections-1", result.Connections[0].ID)
+	assert.Equal(t, githubconnections.ConnectionStatusConnected, result.Connections[0].Status)
+	require.NotNil(t, result.Connections[0].Installation)
+	assert.Equal(t, "OctopusDeploy", result.Connections[0].Installation.AccountLogin)
+	assert.Equal(t, "Organization", result.Connections[0].Installation.AccountType)
+	assert.False(t, result.Connections[0].Installation.AllRepositories)
+	assert.Equal(t, githubconnections.ConnectionStatusInstallationSuspended, result.Connections[1].Status)
+	assert.Nil(t, result.Connections[1].Installation)
+}
+
+func TestListAllPagesUntilTotalResults(t *testing.T) {
+	const firstPage = `{"Connections":[{"Id":"GitHubAppConnections-1"}],"ItemsPerPage":1,"NumberOfPages":2,"TotalResults":2}`
+	const secondPage = `{"Connections":[{"Id":"GitHubAppConnections-2"}],"ItemsPerPage":1,"NumberOfPages":2,"TotalResults":2}`
+
+	var requested []string
+	client := newTestClient(t, &requested, firstPage, secondPage)
+
+	connections, err := ListAll(client)
+	require.NoError(t, err)
+
+	require.Len(t, requested, 2)
+	assert.Equal(t, "/api/platformhub/githubconnections/connections?skip=0&take=30", requested[0])
+	assert.Equal(t, "/api/platformhub/githubconnections/connections?skip=1&take=30", requested[1])
+
+	require.Len(t, connections, 2)
+	assert.Equal(t, "GitHubAppConnections-1", connections[0].ID)
+	assert.Equal(t, "GitHubAppConnections-2", connections[1].ID)
+}
+
+func TestListAllStopsOnEmptyPage(t *testing.T) {
+	// A TotalResults larger than the server actually returns must not loop forever.
+	const page = `{"Connections":[],"ItemsPerPage":30,"NumberOfPages":1,"TotalResults":5}`
+
+	var requested []string
+	client := newTestClient(t, &requested, page)
+
+	connections, err := ListAll(client)
+	require.NoError(t, err)
+
+	assert.Len(t, requested, 1)
+	assert.Empty(t, connections)
+}
+
+func TestGetByID(t *testing.T) {
+	const payload = `{
+	  "Id": "GitHubAppConnections-1",
+	  "Status": "Connected",
+	  "StatusUserMessage": "All good",
+	  "Installation": { "InstallationId": "12345", "AccountLogin": "OctopusDeploy", "AccountType": "Organization" },
+	  "Repositories": [
+	    {
+	      "RepositoryId": "R_1",
+	      "RepositoryName": "hub",
+	      "IsAdmin": true,
+	      "IsPrivate": true,
+	      "Visibility": "private",
+	      "Language": "Go",
+	      "GitUrl": "https://githubconnections.com/OctopusDeploy/hub.git",
+	      "DefaultBranch": "main"
+	    }
+	  ],
+	  "UnknownRepositories": [{ "RepositoryId": "R_2" }]
+	}`
+
+	var requested []string
+	client := newTestClient(t, &requested, payload)
+
+	connection, err := GetByID(client, "GitHubAppConnections-1")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/platformhub/githubconnections/connections/GitHubAppConnections-1", requested[0])
+	assert.Equal(t, githubconnections.ConnectionStatusConnected, connection.Status)
+	assert.Equal(t, "All good", connection.StatusUserMessage)
+	require.Len(t, connection.Repositories, 1)
+	assert.Equal(t, "https://github.com/OctopusDeploy/hub.git", connection.Repositories[0].GitURL)
+	assert.Equal(t, "main", connection.Repositories[0].DefaultBranch)
+	require.Len(t, connection.UnknownRepositories, 1)
+	assert.Equal(t, "R_2", connection.UnknownRepositories[0].RepositoryID)
+}
+
+func TestGetByIDWithEmptyID(t *testing.T) {
+	var requested []string
+	client := newTestClient(t, &requested, `{}`)
+
+	connection, err := GetByID(client, "")
+	require.Error(t, err)
+	require.Nil(t, connection)
+	assert.Empty(t, requested)
+}
+
+func TestGetRepositories(t *testing.T) {
+	const payload = `{
+	  "Repositories": [
+	    { "RepositoryId": "R_1", "RepositoryName": "hub", "GitUrl": "https://githubconnections.com/OctopusDeploy/hub.git", "DefaultBranch": "main" },
+	    { "RepositoryId": "R_2", "RepositoryName": "other", "GitUrl": "https://githubconnections.com/OctopusDeploy/other.git", "DefaultBranch": "trunk" }
+	  ]
+	}`
+
+	var requested []string
+	client := newTestClient(t, &requested, payload)
+
+	repositories, err := GetRepositories(client, "GitHubAppConnections-1")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/platformhub/githubconnections/connections/GitHubAppConnections-1/repositories", requested[0])
+	require.Len(t, repositories, 2)
+	assert.Equal(t, "trunk", repositories[1].DefaultBranch)
+}
+
+func TestGetRepositoriesWithEmptyConnectionID(t *testing.T) {
+	var requested []string
+	client := newTestClient(t, &requested, `{}`)
+
+	repositories, err := GetRepositories(client, "")
+	require.Error(t, err)
+	require.Nil(t, repositories)
+	assert.Empty(t, requested)
+}

--- a/pkg/platformhubgithubconnections/service_test.go
+++ b/pkg/platformhubgithubconnections/service_test.go
@@ -94,7 +94,7 @@ func TestGetByID(t *testing.T) {
 	      "IsPrivate": true,
 	      "Visibility": "private",
 	      "Language": "Go",
-	      "GitUrl": "https://githubconnections.com/OctopusDeploy/hub.git",
+	      "GitUrl": "https://github.com/OctopusDeploy/hub.git",
 	      "DefaultBranch": "main"
 	    }
 	  ],
@@ -130,8 +130,8 @@ func TestGetByIDWithEmptyID(t *testing.T) {
 func TestGetRepositories(t *testing.T) {
 	const payload = `{
 	  "Repositories": [
-	    { "RepositoryId": "R_1", "RepositoryName": "hub", "GitUrl": "https://githubconnections.com/OctopusDeploy/hub.git", "DefaultBranch": "main" },
-	    { "RepositoryId": "R_2", "RepositoryName": "other", "GitUrl": "https://githubconnections.com/OctopusDeploy/other.git", "DefaultBranch": "trunk" }
+	    { "RepositoryId": "R_1", "RepositoryName": "hub", "GitUrl": "https://github.com/OctopusDeploy/hub.git", "DefaultBranch": "main" },
+	    { "RepositoryId": "R_2", "RepositoryName": "other", "GitUrl": "https://github.com/OctopusDeploy/other.git", "DefaultBranch": "trunk" }
 	  ]
 	}`
 

--- a/pkg/platformhubgithubconnections/service_test.go
+++ b/pkg/platformhubgithubconnections/service_test.go
@@ -66,7 +66,7 @@ func TestList(t *testing.T) {
 
 	// skip and take are [Required] on the server contract, so a zero skip must still be sent.
 	require.Len(t, requested, 1)
-	assert.Equal(t, "/api/platformhub/githubconnections/connections?skip=0&take=30", requested[0])
+	assert.Equal(t, "/api/platformhub/github/connections?skip=0&take=30", requested[0])
 
 	require.Len(t, result.Connections, 2)
 	assert.Equal(t, 2, result.TotalResults)
@@ -107,7 +107,7 @@ func TestGetByID(t *testing.T) {
 	connection, err := GetByID(client, "GitHubAppConnections-1")
 	require.NoError(t, err)
 
-	assert.Equal(t, "/api/platformhub/githubconnections/connections/GitHubAppConnections-1", requested[0])
+	assert.Equal(t, "/api/platformhub/github/connections/GitHubAppConnections-1", requested[0])
 	assert.Equal(t, githubconnections.ConnectionStatusConnected, connection.Status)
 	assert.Equal(t, "All good", connection.StatusUserMessage)
 	require.Len(t, connection.Repositories, 1)
@@ -141,7 +141,7 @@ func TestGetRepositories(t *testing.T) {
 	repositories, err := GetRepositories(client, "GitHubAppConnections-1")
 	require.NoError(t, err)
 
-	assert.Equal(t, "/api/platformhub/githubconnections/connections/GitHubAppConnections-1/repositories", requested[0])
+	assert.Equal(t, "/api/platformhub/github/connections/GitHubAppConnections-1/repositories", requested[0])
 	require.Len(t, repositories, 2)
 	assert.Equal(t, "trunk", repositories[1].DefaultBranch)
 }

--- a/pkg/platformhubgithubconnections/service_test.go
+++ b/pkg/platformhubgithubconnections/service_test.go
@@ -80,39 +80,6 @@ func TestList(t *testing.T) {
 	assert.Nil(t, result.Connections[1].Installation)
 }
 
-func TestListAllPagesUntilTotalResults(t *testing.T) {
-	const firstPage = `{"Connections":[{"Id":"GitHubAppConnections-1"}],"ItemsPerPage":1,"NumberOfPages":2,"TotalResults":2}`
-	const secondPage = `{"Connections":[{"Id":"GitHubAppConnections-2"}],"ItemsPerPage":1,"NumberOfPages":2,"TotalResults":2}`
-
-	var requested []string
-	client := newTestClient(t, &requested, firstPage, secondPage)
-
-	connections, err := ListAll(client)
-	require.NoError(t, err)
-
-	require.Len(t, requested, 2)
-	assert.Equal(t, "/api/platformhub/githubconnections/connections?skip=0&take=30", requested[0])
-	assert.Equal(t, "/api/platformhub/githubconnections/connections?skip=1&take=30", requested[1])
-
-	require.Len(t, connections, 2)
-	assert.Equal(t, "GitHubAppConnections-1", connections[0].ID)
-	assert.Equal(t, "GitHubAppConnections-2", connections[1].ID)
-}
-
-func TestListAllStopsOnEmptyPage(t *testing.T) {
-	// A TotalResults larger than the server actually returns must not loop forever.
-	const page = `{"Connections":[],"ItemsPerPage":30,"NumberOfPages":1,"TotalResults":5}`
-
-	var requested []string
-	client := newTestClient(t, &requested, page)
-
-	connections, err := ListAll(client)
-	require.NoError(t, err)
-
-	assert.Len(t, requested, 1)
-	assert.Empty(t, connections)
-}
-
 func TestGetByID(t *testing.T) {
 	const payload = `{
 	  "Id": "GitHubAppConnections-1",

--- a/pkg/platformhubversioncontrolsettings/resource.go
+++ b/pkg/platformhubversioncontrolsettings/resource.go
@@ -78,7 +78,16 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 			return err
 		}
 		r.Credentials = usernamePasswordCredential
+	case credentials.GitCredentialTypeGitHubApp:
+		var gitHubAppCredential *credentials.GitHubApp
+		if err := json.Unmarshal(*credentialsRaw, &gitHubAppCredential); err != nil {
+			return err
+		}
+		r.Credentials = gitHubAppCredential
 	}
+	// GitCredentialTypeReference is deliberately not handled: Platform Hub's reference
+	// credential (ReferencePlatformHubGitCredentialUsageResource) is not believed to be
+	// fully validated on save, so it is not exposed here.
 
 	return nil
 }

--- a/pkg/platformhubversioncontrolsettings/resource.go
+++ b/pkg/platformhubversioncontrolsettings/resource.go
@@ -85,9 +85,8 @@ func (r *Resource) UnmarshalJSON(b []byte) error {
 		}
 		r.Credentials = gitHubAppCredential
 	}
-	// GitCredentialTypeReference is deliberately not handled: Platform Hub's reference
-	// credential (ReferencePlatformHubGitCredentialUsageResource) is not believed to be
-	// fully validated on save, so it is not exposed here.
+	// GitCredentialTypeReference isn't handled as using a reference credential
+	// (ReferencePlatformHubGitCredentialUsageResource) isn't fully supported yet
 
 	return nil
 }

--- a/pkg/platformhubversioncontrolsettings/resource_test.go
+++ b/pkg/platformhubversioncontrolsettings/resource_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestResource_UnmarshalJSON_Anonymous(t *testing.T) {
 	const payload = `{
-		"Url": "https://githubconnections.com/OctopusDeploy/hub.git",
+		"Url": "https://github.com/OctopusDeploy/hub.git",
 		"DefaultBranch": "main",
 		"BasePath": ".octopus/",
 		"Credentials": { "Type": "Anonymous" }
@@ -31,7 +31,7 @@ func TestResource_UnmarshalJSON_Anonymous(t *testing.T) {
 
 func TestResource_UnmarshalJSON_UsernamePassword(t *testing.T) {
 	const payload = `{
-		"Url": "https://githubconnections.com/OctopusDeploy/hub.git",
+		"Url": "https://github.com/OctopusDeploy/hub.git",
 		"DefaultBranch": "main",
 		"BasePath": ".octopus/",
 		"Credentials": { "Type": "UsernamePassword", "Username": "octobob", "Password": { "HasValue": true } }
@@ -50,7 +50,7 @@ func TestResource_UnmarshalJSON_UsernamePassword(t *testing.T) {
 
 func TestResource_UnmarshalJSON_GitHubApp(t *testing.T) {
 	const payload = `{
-		"Url": "https://githubconnections.com/OctopusDeploy/hub.git",
+		"Url": "https://github.com/OctopusDeploy/hub.git",
 		"DefaultBranch": "main",
 		"BasePath": ".octopus/",
 		"Credentials": { "Type": "GitHub", "Id": "GitHubAppConnections-1" }

--- a/pkg/platformhubversioncontrolsettings/resource_test.go
+++ b/pkg/platformhubversioncontrolsettings/resource_test.go
@@ -1,0 +1,96 @@
+package platformhubversioncontrolsettings
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/credentials"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResource_UnmarshalJSON_Anonymous(t *testing.T) {
+	const payload = `{
+		"Url": "https://githubconnections.com/OctopusDeploy/hub.git",
+		"DefaultBranch": "main",
+		"BasePath": ".octopus/",
+		"Credentials": { "Type": "Anonymous" }
+	}`
+
+	var resource Resource
+	require.NoError(t, json.Unmarshal([]byte(payload), &resource))
+
+	require.Equal(t, "https://github.com/OctopusDeploy/hub.git", resource.URL)
+	require.Equal(t, "main", resource.DefaultBranch)
+	require.Equal(t, ".octopus/", resource.BasePath)
+
+	anonymous, ok := resource.Credentials.(*credentials.Anonymous)
+	require.True(t, ok)
+	require.Equal(t, credentials.GitCredentialTypeAnonymous, anonymous.Type())
+}
+
+func TestResource_UnmarshalJSON_UsernamePassword(t *testing.T) {
+	const payload = `{
+		"Url": "https://githubconnections.com/OctopusDeploy/hub.git",
+		"DefaultBranch": "main",
+		"BasePath": ".octopus/",
+		"Credentials": { "Type": "UsernamePassword", "Username": "octobob", "Password": { "HasValue": true } }
+	}`
+
+	var resource Resource
+	require.NoError(t, json.Unmarshal([]byte(payload), &resource))
+
+	usernamePassword, ok := resource.Credentials.(*credentials.UsernamePassword)
+	require.True(t, ok)
+	require.Equal(t, credentials.GitCredentialTypeUsernamePassword, usernamePassword.Type())
+	require.Equal(t, "octobob", usernamePassword.Username)
+	require.NotNil(t, usernamePassword.Password)
+	require.True(t, usernamePassword.Password.HasValue)
+}
+
+func TestResource_UnmarshalJSON_GitHubApp(t *testing.T) {
+	const payload = `{
+		"Url": "https://githubconnections.com/OctopusDeploy/hub.git",
+		"DefaultBranch": "main",
+		"BasePath": ".octopus/",
+		"Credentials": { "Type": "GitHub", "Id": "GitHubAppConnections-1" }
+	}`
+
+	var resource Resource
+	require.NoError(t, json.Unmarshal([]byte(payload), &resource))
+
+	gitHubApp, ok := resource.Credentials.(*credentials.GitHubApp)
+	require.True(t, ok)
+	require.Equal(t, credentials.GitCredentialTypeGitHubApp, gitHubApp.Type())
+	require.Equal(t, "GitHubAppConnections-1", gitHubApp.ID)
+}
+
+func TestResource_RoundTrip(t *testing.T) {
+	testCases := []struct {
+		name        string
+		credentials credentials.GitCredential
+	}{
+		{"anonymous", credentials.NewAnonymous()},
+		{"username password", credentials.NewUsernamePassword("octobob", core.NewSensitiveValue("secret"))},
+		{"githubconnections app", credentials.NewGitHubApp("GitHubAppConnections-1")},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			original := NewResource("https://github.com/OctopusDeploy/hub.git", testCase.credentials, "main", ".octopus/")
+
+			data, err := json.Marshal(original)
+			require.NoError(t, err)
+
+			var actual Resource
+			require.NoError(t, json.Unmarshal(data, &actual))
+
+			require.Equal(t, original.URL, actual.URL)
+			require.Equal(t, original.DefaultBranch, actual.DefaultBranch)
+			require.Equal(t, original.BasePath, actual.BasePath)
+			require.NotNil(t, actual.Credentials)
+			require.Equal(t, original.Credentials.Type(), actual.Credentials.Type())
+			require.Equal(t, original.Credentials, actual.Credentials)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for:
- Viewing Platform Hub GitHub Connections
- Configuring the Platform Hub Version Control Settings

It does not add support for modifying the GitHub Connections.

E2E tests haven't been added as this would require extending the E2E tests to support mocking out a GitHub connection which doesn't seem worth the effort. There are unit tests.

You can find an example Go script in a separate PR https://github.com/OctopusDeploy/go-octopusdeploy/pull/469