### PR TITLE
bump Go to 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/OctopusDeploy/go-octopusdeploy/v2
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/MakeNowJust/heredoc/v2 v2.0.1


### PR DESCRIPTION
Go 1.25 is one release out of support; 1.27 and 1.26 are the supported versions. Moving one step to 1.26.