### PR TITLE
feat: add teams webhooks to subscriptions

### DIFF
--- a/pkg/subscriptions/subscription.go
+++ b/pkg/subscriptions/subscription.go
@@ -3,9 +3,18 @@ package subscriptions
 import (
 	"time"
 
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 	"github.com/go-playground/validator/v10"
 )
+
+// TeamsWebhookSubscriptionTarget is one Microsoft Teams channel a subscription notifies via an incoming webhook URL.
+// Url is sensitive and write-only: the API accepts a NewValue on write but never returns it; reads show HasValue only.
+type TeamsWebhookSubscriptionTarget struct {
+	Id   string              `json:"Id"`
+	Name string              `json:"Name"`
+	Url  *core.SensitiveValue `json:"Url,omitempty"`
+}
 
 type EventNotificationSubscriptionFilter struct {
 	DocumentTypes   []string `json:"DocumentTypes"`
@@ -31,15 +40,19 @@ type EventNotificationSubscription struct {
 	SlackChannelIds                     []string                             `json:"SlackChannelIds"`
 	SlackChannelNames                   []string                             `json:"SlackChannelNames"`
 	// Deprecated: SlackDigestFormat is no longer used by Octopus Server; Slack digests always send a summary. It will be removed in a future release.
-	SlackDigestFormat               string     `json:"SlackDigestFormat"`
-	SlackFrequencyPeriod            string     `json:"SlackFrequencyPeriod"`
-	WebhookHeaderKey                string     `json:"WebhookHeaderKey"`
-	WebhookHeaderValue              string     `json:"WebhookHeaderValue"`
-	WebhookLastProcessed            *time.Time `json:"WebhookLastProcessed,omitempty"`
-	WebhookLastProcessedEventAutoId *int64     `json:"WebhookLastProcessedEventAutoId,omitempty"`
-	WebhookTeams                    []string   `json:"WebhookTeams"`
-	WebhookTimeout                  string     `json:"WebhookTimeout"`
-	WebhookURI                      string     `json:"WebhookURI"`
+	SlackDigestFormat                   string                           `json:"SlackDigestFormat"`
+	SlackFrequencyPeriod                string                           `json:"SlackFrequencyPeriod"`
+	TeamsDigestLastProcessed            *time.Time                       `json:"TeamsDigestLastProcessed,omitempty"`
+	TeamsDigestLastProcessedEventAutoId *int64                           `json:"TeamsDigestLastProcessedEventAutoId,omitempty"`
+	TeamsFrequencyPeriod                string                           `json:"TeamsFrequencyPeriod"`
+	TeamsWebhooks                       []TeamsWebhookSubscriptionTarget `json:"TeamsWebhooks"`
+	WebhookHeaderKey                    string                           `json:"WebhookHeaderKey"`
+	WebhookHeaderValue                  string                           `json:"WebhookHeaderValue"`
+	WebhookLastProcessed                *time.Time                       `json:"WebhookLastProcessed,omitempty"`
+	WebhookLastProcessedEventAutoId     *int64                           `json:"WebhookLastProcessedEventAutoId,omitempty"`
+	WebhookTeams                        []string                         `json:"WebhookTeams"`
+	WebhookTimeout                      string                           `json:"WebhookTimeout"`
+	WebhookURI                          string                           `json:"WebhookURI"`
 }
 
 type Subscription struct {
@@ -65,6 +78,8 @@ func NewSubscription(name string) *Subscription {
 			SlackChannelNames:          []string{},
 			SlackDigestFormat:          "Summary",
 			SlackFrequencyPeriod:       "01:00:00",
+			TeamsWebhooks:              []TeamsWebhookSubscriptionTarget{},
+			TeamsFrequencyPeriod:       "01:00:00",
 			WebhookTeams:               []string{},
 			WebhookTimeout:             "00:00:10",
 			Filter: &EventNotificationSubscriptionFilter{

--- a/pkg/subscriptions/subscription_test.go
+++ b/pkg/subscriptions/subscription_test.go
@@ -31,6 +31,8 @@ func TestEventNotificationSubscriptionSlackFieldsJSON(t *testing.T) {
 		"SlackChannelNames": ["general", "releases"],
 		"SlackFrequencyPeriod": "01:00:00",
 		"SlackDigestFormat": "Detailed",
+		"TeamsFrequencyPeriod": "",
+		"TeamsWebhooks": null,
 		"WebhookHeaderKey": "",
 		"WebhookHeaderValue": "",
 		"WebhookTeams": [],

--- a/pkg/subscriptions/subscription_test.go
+++ b/pkg/subscriptions/subscription_test.go
@@ -51,3 +51,34 @@ func TestEventNotificationSubscriptionSlackFieldsJSON(t *testing.T) {
 
 	jsonassert.New(t).Assertf(inputJSON, "%s", string(outputJSON))
 }
+
+func TestNewSubscriptionTeamsDefaults(t *testing.T) {
+	s := subscriptions.NewSubscription("my-subscription")
+
+	require.NotNil(t, s.EventNotificationSubscription.TeamsWebhooks)
+	require.Empty(t, s.EventNotificationSubscription.TeamsWebhooks)
+	require.Equal(t, "01:00:00", s.EventNotificationSubscription.TeamsFrequencyPeriod)
+}
+
+func TestEventNotificationSubscriptionTeamsFieldsJSON(t *testing.T) {
+	// The server never returns the URL value, Url is HasValue: true with no NewValue.
+	inputJSON := `{
+		"TeamsWebhooks": [
+			{"Id": "id-1", "Name": "general", "Url": {"HasValue": true}},
+			{"Id": "id-2", "Name": "releases", "Url": {"HasValue": true}}
+		],
+		"TeamsFrequencyPeriod": "01:00:00"
+	}`
+
+	var sub subscriptions.EventNotificationSubscription
+	err := json.Unmarshal([]byte(inputJSON), &sub)
+	require.NoError(t, err)
+
+	require.Len(t, sub.TeamsWebhooks, 2)
+	require.Equal(t, "id-1", sub.TeamsWebhooks[0].Id)
+	require.Equal(t, "general", sub.TeamsWebhooks[0].Name)
+	require.NotNil(t, sub.TeamsWebhooks[0].Url)
+	require.True(t, sub.TeamsWebhooks[0].Url.HasValue)
+	require.Nil(t, sub.TeamsWebhooks[0].Url.NewValue)
+	require.Equal(t, "01:00:00", sub.TeamsFrequencyPeriod)
+}


### PR DESCRIPTION
Adds support for Teams webhook subscriptions
- Added `TeamsChannels`, `TeamsFrequencyPeriod`, `TeamsDigestLastProcessed` and `TeamsDigestLastProcessedEventAutoId` to E`ventNotificationSubscription`, and the `TeamsChannelSubscriptionTarget` type (`Id`, `Name`, `WebhookUrl)`
- Set defaults for these fields in `NewSubscription()`
- Added tests covering the new defaults and JSON round-trip

Fixes SI-378